### PR TITLE
BetterColorChange

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1540,8 +1540,7 @@ var removeElement = require('element').remove,
         // Modified further to use HSL as an intermediate format, to avoid hue-shifting
         // of colors with exactly one component equal to 00 and exactly one equal to FF
         'use strict';
-        var inputColor = color, rgb, hsl, light = (background === 'light'),
-            factor = (light ? 0.2 : -0.5), c, i, r, g, b, l;
+        var rgb, hsl, light = (background === 'light'), factor = (light ? 0.2 : -0.5), r, g, b, l;
 
         color = String(color).replace(/[^0-9a-f]/gi, '');
         if (color.length < 6) {


### PR DESCRIPTION
Sorry, I misunderstood the meaning of "background === 'light'" as whether DarkenTTV was off; now I know it means that the color would _look best_ on a light background.

I changed the lightening algorithm again, to something closer to what was originally intended; for colors to be lightened, instead of lightening by 20%, I inverted luminosity, darkened by 80%, then inverted again, so even Black, Blue, Red, and Magenta would become light enough without special-case logic.

Below are the results when I ran gulp:

> [07:07:24] Using gulpfile C:\Users\lewisje\Documents\GitHub\BetterTTV\gulpfile.js
> [07:07:24] Starting 'templates'...
> [07:07:24] Finished 'templates' after 473 ms
> [07:07:24] Starting 'scripts'...
> [07:07:24] Finished 'scripts' after 11 ms
> [07:07:24] Starting 'default'...
> [07:07:24] Finished 'default' after 20 µs
