### PR TITLE
Fix: Profile->Settings->Connections->Recommended boxes

### DIFF
--- a/style/stylesheets/betterttv-dark.css
+++ b/style/stylesheets/betterttv-dark.css
@@ -1347,7 +1347,7 @@ table.simple_table th {
 table.simple_table td {
 	border-color: transparent transparent #333;
 }
-.connect-item-info {
+.connect-items .connect-item .connect-item-info {
 	background: #343434;
 }
 


### PR DESCRIPTION
Also adds a missing "#" to the .connect_items rile on line 1335.  This adds a new background color rule inside of the "Dark Twitch Settings" from line 1209
