### PR TITLE
Preserve emoticons in copy/paste

### DIFF
--- a/src/features/emoticon-text-in-clipboard.js
+++ b/src/features/emoticon-text-in-clipboard.js
@@ -1,0 +1,46 @@
+// Add an event listener to the "copy" event that fires when text is copied to
+// the clipboard to convert any emoticons within the text selection to the
+// corresponding text that will create the emoticon. This allows copy/pasted
+// text to preserve emoticons within the Twitch chat (issue #234).
+module.exports = function() {
+    if (!('oncopy' in document)) {
+        // Copy event is not supported.
+        return;
+    }
+
+    var onCopy = function(e) {
+        if (!e.clipboardData || !e.clipboardData.setData) {
+            // Setting clipboard data is not possible. This is not currently
+            // possible to detect without actually firing a real copy event.
+            document.removeEventListener('copy', onCopy);
+            return;
+        }
+
+        var emoticonSelector = 'img.emoticon';
+
+        // Iterator to replace an element matching an emoticon image with its text.
+        var replaceEmoticon = function(i, el) {
+            var alphaNum = /^[a-z0-9]+$/i;
+            var regex = $(el).data('regex');
+            if (alphaNum.test(regex)) {
+                $(el).after(regex).remove();
+            }
+        };
+
+        var selection = $(window.getSelection().getRangeAt(0).cloneContents());
+
+        // The selection is a html fragment, so some of the jquery functions will
+        // not work, so we work with the children.
+        if (selection.children().is(emoticonSelector) || selection.children().find(emoticonSelector).length) {
+            // The text contains an emoticon, so replace them with text that will
+            // create the emoticon if possible.
+            selection.children().filter(emoticonSelector).each(replaceEmoticon);
+            selection.children().find(emoticonSelector).each(replaceEmoticon);
+            e.clipboardData.setData('text/plain', selection.text());
+            // We want our data, not data from any selection, to be written to the clipboard
+            e.preventDefault();
+        }
+    };
+
+    document.addEventListener('copy', onCopy);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2013,6 +2013,7 @@ var clearClutter = require('./features/clear-clutter'),
     embeddedPolling = require('./features/embedded-polling'),
     handleTwitchChatEmotesScript = require('./features/handle-twitchchat-emotes'),
     loadChatSettings = require('./features/chat-load-settings'),
+    emoticonTextInClipboard = require('./features/emoticon-text-in-clipboard'),
     createSettings = require('./features/create-settings');
     cssLoader = require('./features/css-loader');
 
@@ -2207,6 +2208,7 @@ var main = function () {
         dashboardChannelInfo();
         directoryFunctions();
         handleTwitchChatEmotesScript();
+        emoticonTextInClipboard();
 
         $(window).trigger('resize');
         setTimeout(function() {


### PR DESCRIPTION
Add an event listener to the "copy" event that fires when text is copied
to the clipboard to convert any emoticons within the text selection to
the corresponding text that will create the emoticon. This allows
copy/pasted text to preserve emoticons within the Twitch chat.

fixes #234