### PR TITLE
Tab completion bug fixes

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -951,6 +951,12 @@ bttv.chat = {
                     return e.preventDefault();
                 }
 
+                var $suggestions = $chatInterface.find('.suggestions');
+                if ($suggestions.length){
+                    $suggestions.find('.highlighted').children().click();
+                    return e.preventDefault();
+                }
+
                 if(val.charAt(0) === '/') {
                     bttv.chat.handlers.commands(val);
                 }
@@ -1286,9 +1292,12 @@ bttv.chat = {
             $suggestions.find('.suggestion').on('click', function() {
                 var user = $(this).text();
                 var sentence = $chatInput.val().trim().split(' ');
-                sentence.pop();
+                var lastWord = sentence.pop();
+                if (lastWord.charAt(0) === '@') {
                 sentence.push("@" + bttv.chat.helpers.lookupDisplayName(user));
-
+                } else {
+                    sentence.push(bttv.chat.helpers.lookupDisplayName(user));
+                }
                 if(sentence.length === 1) {
                     $chatInput.val(sentence.join(' ') + ", ");
                 } else {

--- a/betterttv.js
+++ b/betterttv.js
@@ -938,7 +938,7 @@ bttv.chat = {
         // Message input features (tab completion, message history)
         $chatInput.on('keyup', function(e) {
             // '@' completion is captured only on keyup
-            if(e.which === keyCodes.Tab || e.shiftKey) return;
+            if(e.which === keyCodes.Tab || e.which === keyCodes.Shift) return;
 
             bttv.chat.helpers.tabCompletion(e);
         });
@@ -981,7 +981,7 @@ bttv.chat = {
             }
 
             var $suggestions = $chatInterface.find('.suggestions');
-            if($suggestions.length) {
+            if($suggestions.length && e.which !== keyCodes.Shift) {
                 $suggestions.remove();
             }
 
@@ -1160,7 +1160,7 @@ bttv.chat = {
             var sentence = $chatInput.val().trim().split(' ');
             var lastWord = sentence.pop().toLowerCase();
 
-            if(keyCode === keyCodes.Tab || lastWord.charAt(0) === '@') {
+            if(keyCode === keyCodes.Tab || lastWord.charAt(0) === '@' && keyCode !== keyCodes.Enter) {
                 var sugStore = chat.store.suggestions;
 
                 var currentMatch = lastWord.replace(/(^@|,$)/g, '');

--- a/src/main.js
+++ b/src/main.js
@@ -632,7 +632,7 @@ bttv.chat = {
         // Message input features (tab completion, message history)
         $chatInput.on('keyup', function(e) {
             // '@' completion is captured only on keyup
-            if(e.which === keyCodes.Tab || e.shiftKey) return;
+            if(e.which === keyCodes.Tab || e.which === keyCodes.Shift) return;
 
             bttv.chat.helpers.tabCompletion(e);
         });
@@ -675,7 +675,7 @@ bttv.chat = {
             }
 
             var $suggestions = $chatInterface.find('.suggestions');
-            if($suggestions.length) {
+            if($suggestions.length && e.which !== keyCodes.Shift) {
                 $suggestions.remove();
             }
 
@@ -854,7 +854,7 @@ bttv.chat = {
             var sentence = $chatInput.val().trim().split(' ');
             var lastWord = sentence.pop().toLowerCase();
 
-            if(keyCode === keyCodes.Tab || lastWord.charAt(0) === '@') {
+            if(keyCode === keyCodes.Tab || lastWord.charAt(0) === '@' && keyCode !== keyCodes.Enter) {
                 var sugStore = chat.store.suggestions;
 
                 var currentMatch = lastWord.replace(/(^@|,$)/g, '');

--- a/src/main.js
+++ b/src/main.js
@@ -645,6 +645,12 @@ bttv.chat = {
                     return e.preventDefault();
                 }
 
+                var $suggestions = $chatInterface.find('.suggestions');
+                if ($suggestions.length){
+                    $suggestions.find('.highlighted').children().click();
+                    return e.preventDefault();
+                }
+
                 if(val.charAt(0) === '/') {
                     bttv.chat.handlers.commands(val);
                 }
@@ -980,9 +986,12 @@ bttv.chat = {
             $suggestions.find('.suggestion').on('click', function() {
                 var user = $(this).text();
                 var sentence = $chatInput.val().trim().split(' ');
-                sentence.pop();
+                var lastWord = sentence.pop();
+                if (lastWord.charAt(0) === '@') {
                 sentence.push("@" + bttv.chat.helpers.lookupDisplayName(user));
-
+                } else {
+                    sentence.push(bttv.chat.helpers.lookupDisplayName(user));
+                }
                 if(sentence.length === 1) {
                     $chatInput.val(sentence.join(' ') + ", ");
                 } else {


### PR DESCRIPTION
Fixed bug where pressing shift caused the suggestions menu to hide.
Fixed bug where the keyup event, emitted by releasing shift, shifted the highlight marker in the suggestions menu.
Allows the user to press enter to select the highlighted suggestion instead of having to press space.
Fixed but where clicking a suggestion would append a '@' symbol at the start of the name even if '@' wasn't present originally.
Fixed the bug where selecting a suggestion wouldn't hide the suggestions menu if the '@' symbol was in front of the name