### PR TITLE
Don't autocomplete when ctrl pressed

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -989,7 +989,7 @@ bttv.chat = {
             }
 
             // Actual tabs must be captured on keydown
-            if(e.which === keyCodes.Tab) {
+            if(e.which === keyCodes.Tab && !e.ctrlKey) {
                 bttv.chat.helpers.tabCompletion(e);
                 e.preventDefault();
             }

--- a/src/main.js
+++ b/src/main.js
@@ -683,7 +683,7 @@ bttv.chat = {
             }
 
             // Actual tabs must be captured on keydown
-            if(e.which === keyCodes.Tab) {
+            if(e.which === keyCodes.Tab && !e.ctrlKey) {
                 bttv.chat.helpers.tabCompletion(e);
                 e.preventDefault();
             }


### PR DESCRIPTION
Autocomplete shouldn't fire when a user is ctrl-tabbing through their
tabs.

This is the change I wanted for #252