### PR TITLE
Added mouseover image preview for chat: Fixes #131

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -3671,13 +3671,13 @@ var debug = require('../helpers/debug');
 
 var enablePreview = exports.enablePreview = function() {
     /* CONFIG */
-    var xOffset = -250,
+    var xOffset = -255,
         yOffset = 0;
 
     /* END CONFIG */
     $(document).on({
         mouseenter: function (e) {
-            $("body").append("<p id='chat_preview'><img width=\"250px\" src='"+ this.href +"' alt='Image preview' /></p>");
+            $("body").append('<iframe id="chat_preview" marginwidth="0" marginheight="0" hspace="0" vspace="0" frameborder="0" width="250px" scrolling="no" src="//api.betterttv.net/2/image_embed/'+ encodeURIComponent(this.href) +'"></iframe>');
             $("#chat_preview")
                 .css("top",(e.pageY - yOffset) + "px")
                 .css("left", (e.pageX - xOffset) + "px")

--- a/betterttv.js
+++ b/betterttv.js
@@ -1195,7 +1195,7 @@ var translate = exports.translate = function(element, sender, text) {
 
 // Add mouseover image preview to image links
 module.exports = function(imgUrl) {
-    return '<a href="' + imgUrl + '" class="preview" target="_blank">' + imgUrl + '</a>';
+    return '<a href="' + imgUrl + '" class="chat-preview" target="_blank">' + imgUrl + '</a>';
 };
 
 },{}],7:[function(require,module,exports){
@@ -2798,8 +2798,7 @@ var debug = require('../helpers/debug'),
     vars = require('../vars'),
     removeElement = require('../helpers/element').remove;
 var darkenPage = require('./darken-page'),
-    splitChat = require('./split-chat'),
-    imagePreview = require('./image-preview');
+    splitChat = require('./split-chat');
 
 module.exports = function() {
     if(!$('.ember-chat .chat-settings').length || $('.ember-chat .chat-settings .bttvChatSettings').length) return;
@@ -2869,19 +2868,6 @@ module.exports = function() {
         }
     });
 
-    $('.toggleChatImagePreview').change(function(e) {
-        e.preventDefault();
-        if (bttv.settings.get("chatImagePreview") === true) {
-            bttv.settings.save("chatImagePreview", false);
-            imagePreview.disablePreview();
-            $(this).prop('checked', false);
-        } else {
-            bttv.settings.save("chatImagePreview", true);
-            imagePreview.enablePreview();
-            $(this).prop('checked', true);
-        }
-    });
-
     $('.flipDashboard').click(function(e) {
         e.preventDefault();
         if (bttv.settings.get("flipDashboard") === true) {
@@ -2922,7 +2908,7 @@ module.exports = function() {
     });
 };
 
-},{"../helpers/debug":42,"../helpers/element":43,"../templates/chat-settings":48,"../vars":55,"./darken-page":25,"./image-preview":36,"./split-chat":40}],19:[function(require,module,exports){
+},{"../helpers/debug":42,"../helpers/element":43,"../templates/chat-settings":48,"../vars":55,"./darken-page":25,"./split-chat":40}],19:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 var checkBroadcastInfo = module.exports = function() {
@@ -3691,25 +3677,25 @@ var enablePreview = exports.enablePreview = function() {
     /* END CONFIG */
     $(document).on({
         mouseenter: function (e) {
-            $("body").append("<p id='preview'><img height=\"200px\" src='"+ this.href +"' alt='Image preview' /></p>");
-            $("#preview")
+            $("body").append("<p id='chat_preview'><img width=\"250px\" src='"+ this.href +"' alt='Image preview' /></p>");
+            $("#chat_preview")
                 .css("top",(e.pageY - yOffset) + "px")
                 .css("left", (e.pageX - xOffset) + "px")
                 .css("position", "absolute")
                 .css("z-index", '100')
                 .fadeIn("fast");
         }, mouseleave: function (e) {
-            $("#preview").remove();
+            $("#chat_preview").remove();
         }, mousemove: function (e) {
-            $("#preview")
+            $("#chat_preview")
             .css("top",(e.pageY - yOffset) + "px")
             .css("left",(e.pageX + xOffset) + "px");
         }
-    }, 'a.preview');
+    }, 'a.chat-preview');
 };
 
 var disablePreview = exports.disablePreview = function() {
-    $(document).off('mouseenter mouseleave mousemove', 'a.preview');
+    $(document).off('mouseenter mouseleave mousemove', 'a.chat-preview');
 };
 
 },{"../helpers/debug":42}],37:[function(require,module,exports){
@@ -4376,7 +4362,8 @@ var betaChat = require('./features/beta-chat'),
     flipDashboard = require('./features/flip-dashboard'),
     cssLoader = require('./features/css-loader');
 var displayElement = require('./helpers/element').display,
-    removeElement = require('./helpers/element').remove;
+    removeElement = require('./helpers/element').remove,
+    imagePreview = require('./features/image-preview');
 
 module.exports = [
     {
@@ -4418,7 +4405,14 @@ module.exports = [
         name: 'Chat Image Preview',
         description: 'Preview chat images on mouse over',
         default: true,
-        storageKey: 'chatImagePreview'
+        storageKey: 'chatImagePreview',
+        toggle: function (value) {
+            if (value === true) {
+                imagePreview.enablePreview();
+            } else {
+                imagePreview.disablePreview();
+            }
+        }
     },
     {
         name: 'Blue Buttons',
@@ -4775,7 +4769,7 @@ module.exports = [
     }
 ];
 
-},{"./features/beta-chat":13,"./features/channel-reformat":16,"./features/css-loader":24,"./features/darken-page":25,"./features/flip-dashboard":30,"./features/handle-background":33,"./features/split-chat":40,"./helpers/element":43}],48:[function(require,module,exports){
+},{"./features/beta-chat":13,"./features/channel-reformat":16,"./features/css-loader":24,"./features/darken-page":25,"./features/flip-dashboard":30,"./features/handle-background":33,"./features/image-preview":36,"./features/split-chat":40,"./helpers/element":43}],48:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -4799,7 +4793,7 @@ buf.push("Flip Dashboard");
 }
 buf.push("</a></p>");
 }
-buf.push("<p><input type=\"checkbox\"" + (jade.attr("checked", bttv.settings.get("darkenedMode"), true, false)) + " class=\"toggleDarkenTTV\"/>Dark Mode</p><p><input type=\"checkbox\"" + (jade.attr("checked", bttv.settings.get("chatImagePreview"), true, false)) + " class=\"toggleChatImagePreview\"/>Chat Image Preview</p><p><a href=\"#\" class=\"g18_gear-00000080 setBlacklistKeywords\">Set Blacklist Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setHighlightKeywords\">Set Highlight Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setScrollbackAmount\">Set Scrollback Amount</a></p><p><a href=\"#\" class=\"g18_trash-00000080 clearChat\">Clear My Chat</a></p><p><a href=\"#\" style=\"display: block;margin-top: 8px;text-align: center;\" class=\"button-simple dark openSettings\">BetterTTV Settings</a></p></div>");}.call(this,"$" in locals_for_with?locals_for_with.$:typeof $!=="undefined"?$:undefined,"window" in locals_for_with?locals_for_with.window:typeof window!=="undefined"?window:undefined,"bttv" in locals_for_with?locals_for_with.bttv:typeof bttv!=="undefined"?bttv:undefined));;return buf.join("");
+buf.push("<p><input type=\"checkbox\"" + (jade.attr("checked", bttv.settings.get("darkenedMode"), true, false)) + " class=\"toggleDarkenTTV\"/>Dark Mode</p><p><a href=\"#\" class=\"g18_gear-00000080 setBlacklistKeywords\">Set Blacklist Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setHighlightKeywords\">Set Highlight Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setScrollbackAmount\">Set Scrollback Amount</a></p><p><a href=\"#\" class=\"g18_trash-00000080 clearChat\">Clear My Chat</a></p><p><a href=\"#\" style=\"display: block;margin-top: 8px;text-align: center;\" class=\"button-simple dark openSettings\">BetterTTV Settings</a></p></div>");}.call(this,"$" in locals_for_with?locals_for_with.$:typeof $!=="undefined"?$:undefined,"window" in locals_for_with?locals_for_with.window:typeof window!=="undefined"?window:undefined,"bttv" in locals_for_with?locals_for_with.bttv:typeof bttv!=="undefined"?bttv:undefined));;return buf.join("");
 };module.exports=template;
 },{}],49:[function(require,module,exports){
 function template(locals) {

--- a/betterttv.js
+++ b/betterttv.js
@@ -308,7 +308,9 @@ exports.emotes = require('./chat/emotes');
 exports.helpers = require('./chat/helpers');
 exports.handlers = require('./chat/handlers');
 exports.store = require('./chat/store');
-},{"./chat/emotes":3,"./chat/handlers":4,"./chat/helpers":5,"./chat/store":7,"./chat/takeover":8,"./chat/templates":9,"./chat/tmi":10}],3:[function(require,module,exports){
+exports.imagePreview = require('./chat/image-preview');
+
+},{"./chat/emotes":3,"./chat/handlers":4,"./chat/helpers":5,"./chat/image-preview":6,"./chat/store":8,"./chat/takeover":9,"./chat/templates":10,"./chat/tmi":11}],3:[function(require,module,exports){
 var tmi = require('./tmi'),
     store = require('./store'),
     helpers = require('./helpers');
@@ -346,7 +348,7 @@ module.exports = function() {
 
     return usableEmotes;
 };
-},{"./helpers":5,"./store":7,"./tmi":10}],4:[function(require,module,exports){
+},{"./helpers":5,"./store":8,"./tmi":11}],4:[function(require,module,exports){
 var vars = require('../vars'),
     debug = require('../helpers/debug');
 var store = require('./store'),
@@ -685,7 +687,7 @@ var privmsg = exports.privmsg = function (channel, data) {
     store.__messageQueue.push(message);
 }
 
-},{"../bots":1,"../features/embedded-polling":27,"../features/keywords-lists":35,"../features/make-card":36,"../helpers/colors":39,"../helpers/debug":40,"../helpers/regex":42,"../legacy-tags":44,"../vars":53,"./helpers":5,"./rooms":6,"./store":7,"./templates":9,"./tmi":10}],5:[function(require,module,exports){
+},{"../bots":1,"../features/embedded-polling":28,"../features/keywords-lists":37,"../features/make-card":38,"../helpers/colors":41,"../helpers/debug":42,"../helpers/regex":44,"../legacy-tags":46,"../vars":55,"./helpers":5,"./rooms":7,"./store":8,"./templates":10,"./tmi":11}],5:[function(require,module,exports){
 var vars = require('../vars'),
     keyCodes = require('../keycodes');
 var tmi = require('./tmi'),
@@ -1189,7 +1191,14 @@ var translate = exports.translate = function(element, sender, text) {
         }
     });
 }
-},{"../helpers/colors":39,"../helpers/element":41,"../helpers/regex":42,"../keycodes":43,"../vars":53,"./handlers":4,"./store":7,"./templates":9,"./tmi":10}],6:[function(require,module,exports){
+},{"../helpers/colors":41,"../helpers/element":43,"../helpers/regex":44,"../keycodes":45,"../vars":55,"./handlers":4,"./store":8,"./templates":10,"./tmi":11}],6:[function(require,module,exports){
+
+// Add mouseover image preview to image links
+module.exports = function(imgUrl) {
+    return '<a href="' + imgUrl + '" class="preview" target="_blank">' + imgUrl + '</a>';
+};
+
+},{}],7:[function(require,module,exports){
 var tmi = require('./tmi'),
     store = require('./store');
 
@@ -1257,7 +1266,7 @@ var newRoom = exports.newRoom = function(name) {
         }
     }
 };
-},{"./handlers":4,"./store":7,"./tmi":10}],7:[function(require,module,exports){
+},{"./handlers":4,"./store":8,"./tmi":11}],8:[function(require,module,exports){
 var tmi = require('./tmi');
 
 exports.__rooms = {};
@@ -1281,7 +1290,7 @@ exports.__messageTimer = false;
 exports.__usersBeingLookedUp = 0;
 exports.currentRoom = '';
 exports.activeView = true;
-},{"./tmi":10}],8:[function(require,module,exports){
+},{"./tmi":11}],9:[function(require,module,exports){
 var vars = require('../vars'),
     debug = require('../helpers/debug'),
     keyCodes = require('../keycodes');
@@ -1602,7 +1611,7 @@ var takeover = module.exports = function() {
         }
     });
 }
-},{"../features/chat-load-settings":17,"../features/css-loader":23,"../features/override-emotes":37,"../helpers/debug":40,"../keycodes":43,"../vars":53,"./handlers":4,"./helpers":5,"./rooms":6,"./store":7,"./tmi":10}],9:[function(require,module,exports){
+},{"../features/chat-load-settings":18,"../features/css-loader":24,"../features/override-emotes":39,"../helpers/debug":42,"../keycodes":45,"../vars":55,"./handlers":4,"./helpers":5,"./rooms":7,"./store":8,"./tmi":11}],10:[function(require,module,exports){
 var tmi = require('./tmi'),
     store = require('./store');
 
@@ -1736,6 +1745,15 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
     for(var i=0; i<tokenizedString.length; i++) {
         var piece = tokenizedString[i];
 
+        if(bttv.settings.get('chatImagePreview') === true) {
+            var imageTest = new RegExp('(https?:\/\/.)([a-z\-_0-9\/\:\.]*\.(jpg|jpeg|png|gif))', 'i');
+            if (imageTest.test(piece)) {
+                piece = bttv.chat.imagePreview(piece);
+                tokenizedString[i] = piece;
+                continue;
+            }
+        }
+
         var test = piece.replace(/(^[~!@#$%\^&\*\(\)]+|[~!@#$%\^&\*\(\)]+$)/g, '');
         var emote = store.bttvEmotes[test] || store.bttvEmotes[piece];
 
@@ -1785,11 +1803,11 @@ var privmsg = exports.privmsg = function(highlight, action, server, isMod, data)
     return '<div class="chat-line'+(highlight?' highlight':'')+(action?' action':'')+(server?' admin':'')+'" data-sender="'+data.sender+'">'+timestamp(data.time)+' '+(isMod?modicons():'')+' '+badges(data.badges)+from(data.nickname, data.color)+message(data.sender, data.message, data.emotes, action?data.color:false)+'</div>';
 }
 
-},{"../templates/chat-suggestions":47,"../templates/moderation-card":49,"./helpers":5,"./store":7,"./tmi":10}],10:[function(require,module,exports){
+},{"../templates/chat-suggestions":49,"../templates/moderation-card":51,"./helpers":5,"./store":8,"./tmi":11}],11:[function(require,module,exports){
 module.exports = function() {
 	return bttv.getChatController() ? bttv.getChatController().currentRoom : false;
 }
-},{}],11:[function(require,module,exports){
+},{}],12:[function(require,module,exports){
 var keyCodes = require('./keycodes');
 var punycode = require('punycode');
 
@@ -1801,7 +1819,7 @@ var debug = require('./helpers/debug'),
 bttv.info = {
     version: "6.8",
     release: 33,
-    versionString: function() { 
+    versionString: function() {
         return bttv.info.version + 'R' + bttv.info.release;
     }
 };
@@ -2120,6 +2138,7 @@ var clearClutter = require('./features/clear-clutter'),
     handleTwitchChatEmotesScript = require('./features/handle-twitchchat-emotes'),
     emoticonTextInClipboard = require('./features/emoticon-text-in-clipboard'),
     createSettings = require('./features/create-settings');
+    enableImagePreview = require('./features/image-preview').enablePreview;
 
 var chatFunctions = function () {
 
@@ -2313,6 +2332,9 @@ var main = function () {
         directoryFunctions();
         handleTwitchChatEmotesScript();
         emoticonTextInClipboard();
+        if (bttv.settings.get('chatImagePreview') === true) {
+            enableImagePreview();
+        }
 
         $(window).trigger('resize');
         setTimeout(function() {
@@ -2377,7 +2399,8 @@ if(window.BTTVLOADED === true) return;
 debug.log("BTTV LOADED " + document.URL);
 BTTVLOADED = true;
 checkJquery();
-},{"./chat":2,"./features/beta-chat":12,"./features/brand":13,"./features/channel-reformat":15,"./features/check-broadcast-info":18,"./features/check-following":19,"./features/check-messages":20,"./features/clear-clutter":21,"./features/create-settings":22,"./features/darken-page":24,"./features/dashboard-channelinfo":25,"./features/directory-functions":26,"./features/emoticon-text-in-clipboard":28,"./features/flip-dashboard":29,"./features/format-dashboard":30,"./features/giveaway-compatibility":31,"./features/handle-background":32,"./features/handle-twitchchat-emotes":33,"./features/split-chat":38,"./helpers/debug":40,"./keycodes":43,"./settings-list":45,"./templates/setting-switch":50,"./twitch-api":52,"./vars":53,"punycode":54}],12:[function(require,module,exports){
+
+},{"./chat":2,"./features/beta-chat":13,"./features/brand":14,"./features/channel-reformat":16,"./features/check-broadcast-info":19,"./features/check-following":20,"./features/check-messages":21,"./features/clear-clutter":22,"./features/create-settings":23,"./features/darken-page":25,"./features/dashboard-channelinfo":26,"./features/directory-functions":27,"./features/emoticon-text-in-clipboard":29,"./features/flip-dashboard":30,"./features/format-dashboard":31,"./features/giveaway-compatibility":32,"./features/handle-background":33,"./features/handle-twitchchat-emotes":34,"./features/image-preview":36,"./features/split-chat":40,"./helpers/debug":42,"./keycodes":45,"./settings-list":47,"./templates/setting-switch":52,"./twitch-api":54,"./vars":55,"punycode":56}],13:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -2425,7 +2448,7 @@ module.exports = function () {
         $('body').append("<style>.ember-chat .chat-interface { height: 140px !important; } .ember-chat .chat-messages { bottom: 140px; } .ember-chat .chat-settings { bottom: 80px; } .ember-chat .emoticon-selector { bottom: 142px !important; }</style>");
     }
 }
-},{"../helpers/debug":40,"../vars":53}],13:[function(require,module,exports){
+},{"../helpers/debug":42,"../vars":55}],14:[function(require,module,exports){
 var debug = require('../helpers/debug');
 var betaChat = require('./beta-chat');
 
@@ -2492,7 +2515,7 @@ module.exports = function () {
     // Run Beta Chat After BTTV CSS
     betaChat();
 };
-},{"../helpers/debug":40,"./beta-chat":12}],14:[function(require,module,exports){
+},{"../helpers/debug":42,"./beta-chat":13}],15:[function(require,module,exports){
 var debug = require('../../helpers/debug'),
     vars = require('../../vars');
 
@@ -2550,7 +2573,7 @@ var handleResize = module.exports = function () {
 
     $("#channel_panels").masonry("reload");
 };
-},{"../../helpers/debug":40,"../../vars":53}],15:[function(require,module,exports){
+},{"../../helpers/debug":42,"../../vars":55}],16:[function(require,module,exports){
 var debug = require('../../helpers/debug'),
     keyCodes = require('../../keycodes'),
     vars = require('../../vars');
@@ -2709,7 +2732,7 @@ module.exports = function () {
         bttv.settings.save("chatWidth", $("#right_col").width());
     }
 }
-},{"../../helpers/debug":40,"../../keycodes":43,"../../vars":53,"./handle-resize":14,"./twitchcast":16}],16:[function(require,module,exports){
+},{"../../helpers/debug":42,"../../keycodes":45,"../../vars":55,"./handle-resize":15,"./twitchcast":17}],17:[function(require,module,exports){
 module.exports = function() {
     if($('.archive_info').length) return;
     
@@ -2770,12 +2793,13 @@ module.exports = function() {
         $('#twitchcast_button').remove();
     }
 }
-},{}],17:[function(require,module,exports){
+},{}],18:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars'),
     removeElement = require('../helpers/element').remove;
 var darkenPage = require('./darken-page'),
-    splitChat = require('./split-chat');
+    splitChat = require('./split-chat'),
+    imagePreview = require('./image-preview');
 
 module.exports = function() {
     if(!$('.ember-chat .chat-settings').length || $('.ember-chat .chat-settings .bttvChatSettings').length) return;
@@ -2845,6 +2869,19 @@ module.exports = function() {
         }
     });
 
+    $('.toggleChatImagePreview').change(function(e) {
+        e.preventDefault();
+        if (bttv.settings.get("chatImagePreview") === true) {
+            bttv.settings.save("chatImagePreview", false);
+            imagePreview.disablePreview();
+            $(this).prop('checked', false);
+        } else {
+            bttv.settings.save("chatImagePreview", true);
+            imagePreview.enablePreview();
+            $(this).prop('checked', true);
+        }
+    });
+
     $('.flipDashboard').click(function(e) {
         e.preventDefault();
         if (bttv.settings.get("flipDashboard") === true) {
@@ -2884,7 +2921,8 @@ module.exports = function() {
         }
     });
 };
-},{"../helpers/debug":40,"../helpers/element":41,"../templates/chat-settings":46,"../vars":53,"./darken-page":24,"./split-chat":38}],18:[function(require,module,exports){
+
+},{"../helpers/debug":42,"../helpers/element":43,"../templates/chat-settings":48,"../vars":55,"./darken-page":25,"./image-preview":36,"./split-chat":40}],19:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 var checkBroadcastInfo = module.exports = function() {
@@ -2919,7 +2957,7 @@ var checkBroadcastInfo = module.exports = function() {
         setTimeout(checkBroadcastInfo, 60000);
     });
 }
-},{"../helpers/debug":40}],19:[function(require,module,exports){
+},{"../helpers/debug":42}],20:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -2986,7 +3024,7 @@ var checkFollowing = module.exports = function () {
         setTimeout(checkFollowing, 60000);
     });
 }
-},{"../helpers/debug":40,"../vars":53}],20:[function(require,module,exports){
+},{"../helpers/debug":42,"../vars":55}],21:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -3077,7 +3115,7 @@ module.exports = function () {
     setInterval(checkOther, 30000);
     checkOther();
 }
-},{"../helpers/debug":40,"../vars":53}],21:[function(require,module,exports){
+},{"../helpers/debug":42,"../vars":55}],22:[function(require,module,exports){
 var debug = require('../helpers/debug'),
 	removeElement = require('../helpers/element').remove;
 
@@ -3094,7 +3132,7 @@ module.exports = function () {
         $('body').append('<style>#nav_games, #nav_streams, #nav_related_streams { display: none; }</style>');
     }
 }
-},{"../helpers/debug":40,"../helpers/element":41}],22:[function(require,module,exports){
+},{"../helpers/debug":42,"../helpers/element":43}],23:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars'),
     removeElement = require('../helpers/element').remove;
@@ -3163,7 +3201,7 @@ module.exports = function () {
         $(this).parent("li").addClass("active");
     });
 };
-},{"../helpers/debug":40,"../helpers/element":41,"../templates/settings-panel":51,"../vars":53,"./darken-page":24,"./split-chat":38}],23:[function(require,module,exports){
+},{"../helpers/debug":42,"../helpers/element":43,"../templates/settings-panel":53,"../vars":55,"./darken-page":25,"./split-chat":40}],24:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 function load(file, key){
@@ -3182,7 +3220,7 @@ function unload(key){
 
 module.exports.load = load;
 module.exports.unload = unload; 
-},{"../helpers/debug":40}],24:[function(require,module,exports){
+},{"../helpers/debug":42}],25:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     handleBackground = require('./handle-background');
 
@@ -3220,7 +3258,7 @@ module.exports = function () {
     }
 
 }
-},{"../helpers/debug":40,"./handle-background":32}],25:[function(require,module,exports){
+},{"../helpers/debug":42,"./handle-background":33}],26:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -3306,7 +3344,7 @@ module.exports = function dashboardChannelInfo() {
         setTimeout(dashboardChannelInfo, 60000);
     }
 };
-},{"../helpers/debug":40,"../vars":53}],26:[function(require,module,exports){
+},{"../helpers/debug":42,"../vars":55}],27:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -3329,7 +3367,7 @@ module.exports = function () {
         }
     });
 }
-},{"../helpers/debug":40,"../vars":53}],27:[function(require,module,exports){
+},{"../helpers/debug":42,"../vars":55}],28:[function(require,module,exports){
 var debug = require('../helpers/debug');
 var pollTemplate = require('../templates/embedded-poll');
 
@@ -3383,7 +3421,7 @@ module.exports = function (pollId) {
     lastPollId = pollId;
 }
 
-},{"../helpers/debug":40,"../templates/embedded-poll":48}],28:[function(require,module,exports){
+},{"../helpers/debug":42,"../templates/embedded-poll":50}],29:[function(require,module,exports){
 // Add an event listener to the "copy" event that fires when text is copied to
 // the clipboard to convert any emoticons within the text selection to the
 // corresponding text that will create the emoticon. This allows copy/pasted
@@ -3431,7 +3469,7 @@ module.exports = function() {
     document.addEventListener('copy', onCopy);
 }
 
-},{}],29:[function(require,module,exports){
+},{}],30:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 module.exports = function () {
@@ -3461,7 +3499,7 @@ module.exports = function () {
     }
 }
 
-},{"../helpers/debug":40}],30:[function(require,module,exports){
+},{"../helpers/debug":42}],31:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 module.exports = function () {
@@ -3481,7 +3519,7 @@ module.exports = function () {
     }
 }
 
-},{"../helpers/debug":40}],31:[function(require,module,exports){
+},{"../helpers/debug":42}],32:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 module.exports = function () {
@@ -3503,7 +3541,7 @@ module.exports = function () {
         });
     }
 };
-},{"../helpers/debug":40}],32:[function(require,module,exports){
+},{"../helpers/debug":42}],33:[function(require,module,exports){
 module.exports = function handleBackground(tiled) {
     var tiled = tiled || false;
     
@@ -3595,7 +3633,7 @@ module.exports = function handleBackground(tiled) {
         }
     }
 }
-},{}],33:[function(require,module,exports){
+},{}],34:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 module.exports = function () {
@@ -3624,7 +3662,7 @@ module.exports = function () {
         }, 1000);
     }
 }
-},{"../helpers/debug":40}],34:[function(require,module,exports){
+},{"../helpers/debug":42}],35:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 var ts_tink;
@@ -3642,7 +3680,39 @@ module.exports = function () {
     };
 };
 
-},{"../helpers/debug":40}],35:[function(require,module,exports){
+},{"../helpers/debug":42}],36:[function(require,module,exports){
+var debug = require('../helpers/debug');
+
+var enablePreview = exports.enablePreview = function() {
+    /* CONFIG */
+    xOffset = -250;
+    yOffset = 0;
+
+    /* END CONFIG */
+    $(document).on({
+        mouseenter: function (e) {
+            $("body").append("<p id='preview'><img height=\"200px\" src='"+ this.href +"' alt='Image preview' /></p>");
+            $("#preview")
+                .css("top",(e.pageY - yOffset) + "px")
+                .css("left", (e.pageX - xOffset) + "px")
+                .css("position", "absolute")
+                .css("z-index", '100')
+                .fadeIn("fast");
+        }, mouseleave: function (e) {
+            $("#preview").remove();
+        }, mousemove: function (e) {
+            $("#preview")
+            .css("top",(e.pageY - yOffset) + "px")
+            .css("left",(e.pageX + xOffset) + "px");
+        }
+    }, 'a.preview');
+};
+
+var disablePreview = exports.disablePreview = function() {
+    $(document).off('mouseenter mouseleave mousemove', 'a.preview');
+};
+
+},{"../helpers/debug":42}],37:[function(require,module,exports){
 var vars = require('../vars');
 var escapeRegExp = require('../helpers/regex').escapeRegExp;
 
@@ -3744,7 +3814,7 @@ exports.highlighting = function (data) {
 
     return false;
 }
-},{"../features/highlight-feedback":34,"../helpers/regex":42,"../vars":53}],36:[function(require,module,exports){
+},{"../features/highlight-feedback":35,"../helpers/regex":44,"../vars":55}],38:[function(require,module,exports){
 module.exports = function(user, $event) {
     var template = bttv.chat.templates.moderationCard(user, $event.offset().top, $('.chat-line:last').offset().left);
     $('.ember-chat .moderation-card').remove();
@@ -3855,7 +3925,7 @@ module.exports = function(user, $event) {
     });
 }
 
-},{}],37:[function(require,module,exports){
+},{}],39:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -3939,7 +4009,7 @@ module.exports = function () {
         generate(data);
     });
 };
-},{"../helpers/debug":40,"../vars":53}],38:[function(require,module,exports){
+},{"../helpers/debug":42,"../vars":55}],40:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 module.exports = function () {
@@ -3954,7 +4024,7 @@ module.exports = function () {
         $('body').append(splitCSS);
     }
 }
-},{"../helpers/debug":40}],39:[function(require,module,exports){
+},{"../helpers/debug":42}],41:[function(require,module,exports){
 var calculateColorBackground = exports.calculateColorBackground = function (color) {
     // Converts HEX to YIQ to judge what color background the color would look best on
     color = String(color).replace(/[^0-9a-f]/gi, '');
@@ -4091,13 +4161,13 @@ var getHex = exports.getHex = function (color) {
     return '#'+convert(color['r'])+convert(color['g'])+convert(color['b']);
 };
 
-},{}],40:[function(require,module,exports){
+},{}],42:[function(require,module,exports){
 module.exports = {
     log: function(string) {
         if(window.console && console.log && bttv.settings.get('consoleLog') === true) console.log("BTTV: " + string);
     }
 };
-},{}],41:[function(require,module,exports){
+},{}],43:[function(require,module,exports){
 exports.remove = function (e) {
     // Removes all of an element
     $(e).each(function () {
@@ -4110,7 +4180,7 @@ exports.display = function (e) {
         $(this).show();
     });
 };
-},{}],42:[function(require,module,exports){
+},{}],44:[function(require,module,exports){
 exports.escapeRegExp = function (text) {
     // Escapes an input to make it usable for regexes
     return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, "\\$&");
@@ -4133,7 +4203,7 @@ exports.getEmoteFromRegEx = function(regex) {
         .replace(/^\\b|\\b$/g, '') // remove boundaries
         .replace(/\\/g, ''); // unescape
 }
-},{}],43:[function(require,module,exports){
+},{}],45:[function(require,module,exports){
 module.exports = {
     'LeftClick': 1,
     'Backspace': 8,
@@ -4224,7 +4294,7 @@ module.exports = {
     'Slash': 191,
     'Backslash': 220
 }
-},{}],44:[function(require,module,exports){
+},{}],46:[function(require,module,exports){
 module.exports = function (data) {
     return {
         //Developers and Supporters
@@ -4291,7 +4361,7 @@ module.exports = function (data) {
         "ackleyman": { mod: true, tagType: "orange", tagName: "Ack" }
     };
 };
-},{}],45:[function(require,module,exports){
+},{}],47:[function(require,module,exports){
 /** BTTV :
  * cssBlueButtons
  * handleTwitchChatEmotesScript
@@ -4345,6 +4415,12 @@ module.exports = [
         }
     },
     {
+        name: 'Chat Image Preview',
+        description: 'Preview chat images on mouse over',
+        default: true,
+        storageKey: 'chatImagePreview'
+    },
+    {
         name: 'Blue Buttons',
         description: 'BetterTTV replaces Twitch\'s purple with blue by default',
         default: false,
@@ -4353,7 +4429,7 @@ module.exports = [
             if(value === true) {
                 cssLoader.load("blue-buttons", "showBlueButtons");
             } else {
-                cssLoader.unload("showBlueButtons");   
+                cssLoader.unload("showBlueButtons");
             }
         },
         load: function() {
@@ -4495,7 +4571,7 @@ module.exports = [
             if(value === true) {
                 cssLoader.load("hide-group-chat", "groupChatRemoval");
             } else {
-                cssLoader.unload("groupChatRemoval");   
+                cssLoader.unload("groupChatRemoval");
             }
         },
         load: function() {
@@ -4591,7 +4667,7 @@ module.exports = [
             }
         }
     },
-    {   
+    {
         default: '',
         storageKey: 'blacklistKeywords',
         toggle: function(keywords) {
@@ -4607,7 +4683,7 @@ module.exports = [
             }
 
             keywords === "" ? keywords = phraseKeywords : keywords = keywords.split(" ").concat(phraseKeywords);
-            
+
             for(var i=0; i<keywords.length; i++) {
                 if(/^\([a-z0-9_\-\*]+\)$/i.test(keywords[i])) {
                     keywords[i] = keywords[i].replace(/(\(|\))/g, '');
@@ -4677,7 +4753,7 @@ module.exports = [
                     keywords[i] = keywords[i].replace(/(\(|\))/g, '');
                 }
             }
-            
+
             var keywordList = keywords.join(", ");
             if(keywordList === "") {
                 chat.helpers.serverMessage("Highlight Keywords list is empty");
@@ -4698,7 +4774,8 @@ module.exports = [
         }
     }
 ];
-},{"./features/beta-chat":12,"./features/channel-reformat":15,"./features/css-loader":23,"./features/darken-page":24,"./features/flip-dashboard":29,"./features/handle-background":32,"./features/split-chat":38,"./helpers/element":41}],46:[function(require,module,exports){
+
+},{"./features/beta-chat":13,"./features/channel-reformat":16,"./features/css-loader":24,"./features/darken-page":25,"./features/flip-dashboard":30,"./features/handle-background":33,"./features/split-chat":40,"./helpers/element":43}],48:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -4722,9 +4799,9 @@ buf.push("Flip Dashboard");
 }
 buf.push("</a></p>");
 }
-buf.push("<p><input type=\"checkbox\"" + (jade.attr("checked", bttv.settings.get("darkenedMode"), true, false)) + " class=\"toggleDarkenTTV\"/>Dark Mode</p><p><a href=\"#\" class=\"g18_gear-00000080 setBlacklistKeywords\">Set Blacklist Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setHighlightKeywords\">Set Highlight Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setScrollbackAmount\">Set Scrollback Amount</a></p><p><a href=\"#\" class=\"g18_trash-00000080 clearChat\">Clear My Chat</a></p><p><a href=\"#\" style=\"display: block;margin-top: 8px;text-align: center;\" class=\"button-simple dark openSettings\">BetterTTV Settings</a></p></div>");}.call(this,"$" in locals_for_with?locals_for_with.$:typeof $!=="undefined"?$:undefined,"window" in locals_for_with?locals_for_with.window:typeof window!=="undefined"?window:undefined,"bttv" in locals_for_with?locals_for_with.bttv:typeof bttv!=="undefined"?bttv:undefined));;return buf.join("");
+buf.push("<p><input type=\"checkbox\"" + (jade.attr("checked", bttv.settings.get("darkenedMode"), true, false)) + " class=\"toggleDarkenTTV\"/>Dark Mode</p><p><input type=\"checkbox\"" + (jade.attr("checked", bttv.settings.get("chatImagePreview"), true, false)) + " class=\"toggleChatImagePreview\"/>Chat Image Preview</p><p><a href=\"#\" class=\"g18_gear-00000080 setBlacklistKeywords\">Set Blacklist Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setHighlightKeywords\">Set Highlight Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setScrollbackAmount\">Set Scrollback Amount</a></p><p><a href=\"#\" class=\"g18_trash-00000080 clearChat\">Clear My Chat</a></p><p><a href=\"#\" style=\"display: block;margin-top: 8px;text-align: center;\" class=\"button-simple dark openSettings\">BetterTTV Settings</a></p></div>");}.call(this,"$" in locals_for_with?locals_for_with.$:typeof $!=="undefined"?$:undefined,"window" in locals_for_with?locals_for_with.window:typeof window!=="undefined"?window:undefined,"bttv" in locals_for_with?locals_for_with.bttv:typeof bttv!=="undefined"?bttv:undefined));;return buf.join("");
 };module.exports=template;
-},{}],47:[function(require,module,exports){
+},{}],49:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -4757,7 +4834,7 @@ buf.push("<div" + (jade.cls([highlighted], [true])) + "><div class=\"suggestion\
 
 buf.push("</div>");}.call(this,"suggestions" in locals_for_with?locals_for_with.suggestions:typeof suggestions!=="undefined"?suggestions:undefined,"index" in locals_for_with?locals_for_with.index:typeof index!=="undefined"?index:undefined));;return buf.join("");
 };module.exports=template;
-},{}],48:[function(require,module,exports){
+},{}],50:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -4765,7 +4842,7 @@ var jade_interp;
 ;var locals_for_with = (locals || {});(function (pollId) {
 buf.push("<div id=\"bttv-poll-contain\"><div class=\"title\">New poll available! <span style=\"text-decoration: underline;\">Vote now!</span></div><div class=\"close\"><svg height=\"16px\" version=\"1.1\" viewbox=\"0 0 16 16\" width=\"16px\" x=\"0px\" y=\"0px\" class=\"svg-close\"><path clip-rule=\"evenodd\" d=\"M13.657,3.757L9.414,8l4.243,4.242l-1.415,1.415L8,9.414l-4.243,4.243l-1.414-1.415L6.586,8L2.343,3.757l1.414-1.414L8,6.586l4.242-4.243L13.657,3.757z\" fill-rule=\"evenodd\"></path></svg></div><iframe" + (jade.attr("src", 'http://strawpoll.me/embed_2/' + (pollId) + '', true, false)) + " class=\"frame\"></iframe></div>");}.call(this,"pollId" in locals_for_with?locals_for_with.pollId:typeof pollId!=="undefined"?pollId:undefined));;return buf.join("");
 };module.exports=template;
-},{}],49:[function(require,module,exports){
+},{}],51:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -4798,7 +4875,7 @@ buf.push("</div>");
 }
 buf.push("</div>");}.call(this,"require" in locals_for_with?locals_for_with.require:typeof require!=="undefined"?require:undefined,"user" in locals_for_with?locals_for_with.user:typeof user!=="undefined"?user:undefined,"top" in locals_for_with?locals_for_with.top:typeof top!=="undefined"?top:undefined,"left" in locals_for_with?locals_for_with.left:typeof left!=="undefined"?left:undefined,"Twitch" in locals_for_with?locals_for_with.Twitch:typeof Twitch!=="undefined"?Twitch:undefined,"bttv" in locals_for_with?locals_for_with.bttv:typeof bttv!=="undefined"?bttv:undefined));;return buf.join("");
 };module.exports=template;
-},{"../vars":53}],50:[function(require,module,exports){
+},{"../vars":55}],52:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -4806,7 +4883,7 @@ var jade_interp;
 ;var locals_for_with = (locals || {});(function (storageKey, name, description) {
 buf.push("<div" + (jade.cls(['option',"bttvOption-" + (storageKey) + ""], [null,true])) + "><span style=\"font-weight:bold;font-size:14px;color:#D3D3D3;\">" + (jade.escape(null == (jade_interp = name) ? "" : jade_interp)) + "</span>&nbsp;&nbsp;&mdash;&nbsp;&nbsp;" + (jade.escape(null == (jade_interp = description) ? "" : jade_interp)) + "<div class=\"bttv-switch\"><input type=\"radio\"" + (jade.attr("name", storageKey, true, false)) + " value=\"false\"" + (jade.attr("id", "" + (storageKey) + "False", true, false)) + " class=\"bttv-switch-input bttv-switch-off\"/><label" + (jade.attr("for", "" + (storageKey) + "False", true, false)) + " class=\"bttv-switch-label bttv-switch-label-off\">Off</label><input type=\"radio\"" + (jade.attr("name", storageKey, true, false)) + " value=\"true\"" + (jade.attr("id", "" + (storageKey) + "True", true, false)) + " class=\"bttv-switch-input\"/><label" + (jade.attr("for", "" + (storageKey) + "True", true, false)) + " class=\"bttv-switch-label bttv-switch-label-on\">On</label><span class=\"bttv-switch-selection\"></span></div></div>");}.call(this,"storageKey" in locals_for_with?locals_for_with.storageKey:typeof storageKey!=="undefined"?storageKey:undefined,"name" in locals_for_with?locals_for_with.name:typeof name!=="undefined"?name:undefined,"description" in locals_for_with?locals_for_with.description:typeof description!=="undefined"?description:undefined));;return buf.join("");
 };module.exports=template;
-},{}],51:[function(require,module,exports){
+},{}],53:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -4814,7 +4891,7 @@ var jade_interp;
 ;var locals_for_with = (locals || {});(function (bttv) {
 buf.push("<div id=\"header\"><span id=\"logo\"><img height=\"45px\" src=\"//cdn.betterttv.net/style/logos/settings_logo.png\"/></span><ul class=\"nav\"><li><a href=\"#bttvAbout\">About</a></li><li class=\"active\"><a href=\"#bttvSettings\">Settings</a></li><li><a href=\"#bttvChannel\" target=\"_blank\">Channel</a></li><li><a href=\"#bttvChangelog\">Changelog</a></li><li><a href=\"#bttvPrivacy\">Privacy Policy</a></li><li><a href=\"#bttvBackup\">Backup/Import</a></li></ul><span id=\"close\">&times;</span></div><div id=\"bttvSettings\" style=\"height:425px;\" class=\"scroll scroll-dark\"><div class=\"tse-content options-list\"><h2 class=\"option\">Here you can manage the various BetterTTV options. Click On or Off to toggle settings.</h2></div></div><div id=\"bttvAbout\" style=\"display:none;\"><div class=\"aboutHalf\"><img src=\"//cdn.betterttv.net/style/logos/mascot.png\" class=\"bttvAboutIcon\"/><h1>BetterTTV v " + (jade.escape((jade_interp = bttv.info.versionString()) == null ? '' : jade_interp)) + "</h1><h2>from your friends at <a href=\"https://www.nightdev.com\" target=\"_blank\">NightDev</a></h2><br/></div><div class=\"aboutHalf\"><h1 style=\"margin-top: 100px;\">Think this addon is awesome?</h1><br/><br/><h2><a target=\"_blank\" href=\"https://chrome.google.com/webstore/detail/ajopnjidmegmdimjlfnijceegpefgped\">Drop a Review on the Chrome Webstore</a></h2><br/><h2>or maybe</h2><br/><h2><a target=\"_blank\" href=\"https://streamtip.com/t/night\">Support the Developer</a></h2><br/></div></div><div id=\"bttvChannel\" style=\"display:none;\"><iframe src=\"https://manage.betterttv.net\" frameborder=\"0\" width=\"100%\" height=\"425\"></iframe></div><div id=\"bttvPrivacy\" style=\"display:none;height:425px;\" class=\"scroll scroll-dark\"><div class=\"tse-content\"></div></div><div id=\"bttvChangelog\" style=\"display:none;height:425px;\" class=\"scroll scroll-dark\"><div class=\"tse-content\"></div></div><div id=\"bttvBackup\" style=\"display:none;height:425px;padding:25px;\"><h1 style=\"padding-bottom:15px;\">Backup Settings</h1><button id=\"bttvBackupButton\" class=\"primary_button\"><span>Download</span></button><h1 style=\"padding-top:25px;padding-bottom:15px;\">Import Settings</h1><input id=\"bttvImportInput\" type=\"file\" style=\"height: 25px;width: 250px;\"/></div><div id=\"footer\"><span>BetterTTV &copy; <a href=\"https://www.nightdev.com\" target=\"_blank\">NightDev, LLC</a> 2015</span><span style=\"float:right;\"><a href=\"https://community.nightdev.com/c/betterttv\" target=\"_blank\">Get Support</a> | <a href=\"https://github.com/night/BetterTTV/issues/new?labels=bug\" target=\"_blank\">Report a Bug</a> | <a href=\"https://streamtip.com/t/night\" target=\"_blank\">Support the Developer</a></span></div>");}.call(this,"bttv" in locals_for_with?locals_for_with.bttv:typeof bttv!=="undefined"?bttv:undefined));;return buf.join("");
 };module.exports=template;
-},{}],52:[function(require,module,exports){
+},{}],54:[function(require,module,exports){
 module.exports = {
     _ref: null,
     _headers: function(e, t) {
@@ -4859,7 +4936,7 @@ module.exports = {
         return this._call('del', url);
     }
 };
-},{}],53:[function(require,module,exports){
+},{}],55:[function(require,module,exports){
 module.exports = {
     userData: {
         isLoggedIn: window.Twitch ? Twitch.user.isLoggedIn() : false,
@@ -4869,7 +4946,7 @@ module.exports = {
     liveChannels: [],
     blackChat: false
 };
-},{}],54:[function(require,module,exports){
+},{}],56:[function(require,module,exports){
 (function (global){
 /*! http://mths.be/punycode v1.2.4 by @mathias */
 ;(function(root) {
@@ -5380,4 +5457,4 @@ module.exports = {
 }(this));
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}]},{},[11])}(window.BetterTTV = window.BetterTTV || {}));
+},{}]},{},[12])}(window.BetterTTV = window.BetterTTV || {}));

--- a/betterttv.js
+++ b/betterttv.js
@@ -1746,7 +1746,7 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
         var piece = tokenizedString[i];
 
         if(bttv.settings.get('chatImagePreview') === true) {
-            var imageTest = new RegExp('(https?:\/\/.)([a-z\-_0-9\/\:\.]*\.(jpg|jpeg|png|gif))', 'i');
+            var imageTest = new RegExp('(https?:\/\/.)([a-z\-_0-9\/\:\.\%]*\.(jpg|jpeg|png|gif))', 'i');
             if (imageTest.test(piece)) {
                 piece = bttv.chat.imagePreview(piece);
                 tokenizedString[i] = piece;

--- a/betterttv.js
+++ b/betterttv.js
@@ -4402,19 +4402,6 @@ module.exports = [
         }
     },
     {
-        name: 'Chat Image Preview',
-        description: 'Preview chat images on mouse over',
-        default: true,
-        storageKey: 'chatImagePreview',
-        toggle: function (value) {
-            if (value === true) {
-                imagePreview.enablePreview();
-            } else {
-                imagePreview.disablePreview();
-            }
-        }
-    },
-    {
         name: 'Blue Buttons',
         description: 'BetterTTV replaces Twitch\'s purple with blue by default',
         default: false,
@@ -4428,6 +4415,19 @@ module.exports = [
         },
         load: function() {
             cssLoader.load("blue-buttons", "showBlueButtons");
+        }
+    },
+    {
+        name: 'Chat Image Preview',
+        description: 'Preview chat images on mouse over',
+        default: true,
+        storageKey: 'chatImagePreview',
+        toggle: function (value) {
+            if (value === true) {
+                imagePreview.enablePreview();
+            } else {
+                imagePreview.disablePreview();
+            }
         }
     },
     {

--- a/betterttv.js
+++ b/betterttv.js
@@ -3685,8 +3685,8 @@ var debug = require('../helpers/debug');
 
 var enablePreview = exports.enablePreview = function() {
     /* CONFIG */
-    xOffset = -250;
-    yOffset = 0;
+    var xOffset = -250,
+        yOffset = 0;
 
     /* END CONFIG */
     $(document).on({

--- a/src/chat.js
+++ b/src/chat.js
@@ -5,3 +5,4 @@ exports.emotes = require('./chat/emotes');
 exports.helpers = require('./chat/helpers');
 exports.handlers = require('./chat/handlers');
 exports.store = require('./chat/store');
+exports.imagePreview = require('./chat/image-preview');

--- a/src/chat/image-preview.js
+++ b/src/chat/image-preview.js
@@ -1,0 +1,5 @@
+
+// Add mouseover image preview to image links
+module.exports = function(imgUrl) {
+    return '<a href="' + imgUrl + '" class="preview" target="_blank">' + imgUrl + '</a>';
+};

--- a/src/chat/image-preview.js
+++ b/src/chat/image-preview.js
@@ -1,5 +1,5 @@
 
 // Add mouseover image preview to image links
 module.exports = function(imgUrl) {
-    return '<a href="' + imgUrl + '" class="preview" target="_blank">' + imgUrl + '</a>';
+    return '<a href="' + imgUrl + '" class="chat-preview" target="_blank">' + imgUrl + '</a>';
 };

--- a/src/chat/templates.js
+++ b/src/chat/templates.js
@@ -132,7 +132,7 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
         var piece = tokenizedString[i];
 
         if(bttv.settings.get('chatImagePreview') === true) {
-            var imageTest = new RegExp('(https?:\/\/.)([a-z\-_0-9\/\:\.]*\.(jpg|jpeg|png|gif))', 'i');
+            var imageTest = new RegExp('(https?:\/\/.)([a-z\-_0-9\/\:\.\%]*\.(jpg|jpeg|png|gif))', 'i');
             if (imageTest.test(piece)) {
                 piece = bttv.chat.imagePreview(piece);
                 tokenizedString[i] = piece;

--- a/src/chat/templates.js
+++ b/src/chat/templates.js
@@ -131,6 +131,15 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
     for(var i=0; i<tokenizedString.length; i++) {
         var piece = tokenizedString[i];
 
+        if(bttv.settings.get('chatImagePreview') === true) {
+            var imageTest = new RegExp('(https?:\/\/.)([a-z\-_0-9\/\:\.]*\.(jpg|jpeg|png|gif))', 'i');
+            if (imageTest.test(piece)) {
+                piece = bttv.chat.imagePreview(piece);
+                tokenizedString[i] = piece;
+                continue;
+            }
+        }
+
         var test = piece.replace(/(^[~!@#$%\^&\*\(\)]+|[~!@#$%\^&\*\(\)]+$)/g, '');
         var emote = store.bttvEmotes[test] || store.bttvEmotes[piece];
 

--- a/src/features/chat-load-settings.js
+++ b/src/features/chat-load-settings.js
@@ -2,7 +2,8 @@ var debug = require('../helpers/debug'),
     vars = require('../vars'),
     removeElement = require('../helpers/element').remove;
 var darkenPage = require('./darken-page'),
-    splitChat = require('./split-chat');
+    splitChat = require('./split-chat'),
+    imagePreview = require('./image-preview');
 
 module.exports = function() {
     if(!$('.ember-chat .chat-settings').length || $('.ember-chat .chat-settings .bttvChatSettings').length) return;
@@ -68,6 +69,19 @@ module.exports = function() {
             $(this).prop('checked', false);
         } else {
             bttv.settings.save("darkenedMode", true);
+            $(this).prop('checked', true);
+        }
+    });
+
+    $('.toggleChatImagePreview').change(function(e) {
+        e.preventDefault();
+        if (bttv.settings.get("chatImagePreview") === true) {
+            bttv.settings.save("chatImagePreview", false);
+            imagePreview.disablePreview();
+            $(this).prop('checked', false);
+        } else {
+            bttv.settings.save("chatImagePreview", true);
+            imagePreview.enablePreview();
             $(this).prop('checked', true);
         }
     });

--- a/src/features/chat-load-settings.js
+++ b/src/features/chat-load-settings.js
@@ -2,8 +2,7 @@ var debug = require('../helpers/debug'),
     vars = require('../vars'),
     removeElement = require('../helpers/element').remove;
 var darkenPage = require('./darken-page'),
-    splitChat = require('./split-chat'),
-    imagePreview = require('./image-preview');
+    splitChat = require('./split-chat');
 
 module.exports = function() {
     if(!$('.ember-chat .chat-settings').length || $('.ember-chat .chat-settings .bttvChatSettings').length) return;
@@ -69,19 +68,6 @@ module.exports = function() {
             $(this).prop('checked', false);
         } else {
             bttv.settings.save("darkenedMode", true);
-            $(this).prop('checked', true);
-        }
-    });
-
-    $('.toggleChatImagePreview').change(function(e) {
-        e.preventDefault();
-        if (bttv.settings.get("chatImagePreview") === true) {
-            bttv.settings.save("chatImagePreview", false);
-            imagePreview.disablePreview();
-            $(this).prop('checked', false);
-        } else {
-            bttv.settings.save("chatImagePreview", true);
-            imagePreview.enablePreview();
             $(this).prop('checked', true);
         }
     });

--- a/src/features/image-preview.js
+++ b/src/features/image-preview.js
@@ -8,23 +8,23 @@ var enablePreview = exports.enablePreview = function() {
     /* END CONFIG */
     $(document).on({
         mouseenter: function (e) {
-            $("body").append("<p id='preview'><img height=\"200px\" src='"+ this.href +"' alt='Image preview' /></p>");
-            $("#preview")
+            $("body").append("<p id='chat_preview'><img width=\"250px\" src='"+ this.href +"' alt='Image preview' /></p>");
+            $("#chat_preview")
                 .css("top",(e.pageY - yOffset) + "px")
                 .css("left", (e.pageX - xOffset) + "px")
                 .css("position", "absolute")
                 .css("z-index", '100')
                 .fadeIn("fast");
         }, mouseleave: function (e) {
-            $("#preview").remove();
+            $("#chat_preview").remove();
         }, mousemove: function (e) {
-            $("#preview")
+            $("#chat_preview")
             .css("top",(e.pageY - yOffset) + "px")
             .css("left",(e.pageX + xOffset) + "px");
         }
-    }, 'a.preview');
+    }, 'a.chat-preview');
 };
 
 var disablePreview = exports.disablePreview = function() {
-    $(document).off('mouseenter mouseleave mousemove', 'a.preview');
+    $(document).off('mouseenter mouseleave mousemove', 'a.chat-preview');
 };

--- a/src/features/image-preview.js
+++ b/src/features/image-preview.js
@@ -2,13 +2,13 @@ var debug = require('../helpers/debug');
 
 var enablePreview = exports.enablePreview = function() {
     /* CONFIG */
-    var xOffset = -250,
+    var xOffset = -255,
         yOffset = 0;
 
     /* END CONFIG */
     $(document).on({
         mouseenter: function (e) {
-            $("body").append("<p id='chat_preview'><img width=\"250px\" src='"+ this.href +"' alt='Image preview' /></p>");
+            $("body").append('<iframe id="chat_preview" marginwidth="0" marginheight="0" hspace="0" vspace="0" frameborder="0" width="250px" scrolling="no" src="//api.betterttv.net/2/image_embed/'+ encodeURIComponent(this.href) +'"></iframe>');
             $("#chat_preview")
                 .css("top",(e.pageY - yOffset) + "px")
                 .css("left", (e.pageX - xOffset) + "px")

--- a/src/features/image-preview.js
+++ b/src/features/image-preview.js
@@ -1,0 +1,30 @@
+var debug = require('../helpers/debug');
+
+var enablePreview = exports.enablePreview = function() {
+    /* CONFIG */
+    xOffset = -250;
+    yOffset = 0;
+
+    /* END CONFIG */
+    $(document).on({
+        mouseenter: function (e) {
+            $("body").append("<p id='preview'><img height=\"200px\" src='"+ this.href +"' alt='Image preview' /></p>");
+            $("#preview")
+                .css("top",(e.pageY - yOffset) + "px")
+                .css("left", (e.pageX - xOffset) + "px")
+                .css("position", "absolute")
+                .css("z-index", '100')
+                .fadeIn("fast");
+        }, mouseleave: function (e) {
+            $("#preview").remove();
+        }, mousemove: function (e) {
+            $("#preview")
+            .css("top",(e.pageY - yOffset) + "px")
+            .css("left",(e.pageX + xOffset) + "px");
+        }
+    }, 'a.preview');
+};
+
+var disablePreview = exports.disablePreview = function() {
+    $(document).off('mouseenter mouseleave mousemove', 'a.preview');
+};

--- a/src/features/image-preview.js
+++ b/src/features/image-preview.js
@@ -2,8 +2,8 @@ var debug = require('../helpers/debug');
 
 var enablePreview = exports.enablePreview = function() {
     /* CONFIG */
-    xOffset = -250;
-    yOffset = 0;
+    var xOffset = -250,
+        yOffset = 0;
 
     /* END CONFIG */
     $(document).on({

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ var debug = require('./helpers/debug'),
 bttv.info = {
     version: "6.8",
     release: 33,
-    versionString: function() { 
+    versionString: function() {
         return bttv.info.version + 'R' + bttv.info.release;
     }
 };
@@ -328,6 +328,7 @@ var clearClutter = require('./features/clear-clutter'),
     handleTwitchChatEmotesScript = require('./features/handle-twitchchat-emotes'),
     emoticonTextInClipboard = require('./features/emoticon-text-in-clipboard'),
     createSettings = require('./features/create-settings');
+    enableImagePreview = require('./features/image-preview').enablePreview;
 
 var chatFunctions = function () {
 
@@ -521,6 +522,9 @@ var main = function () {
         directoryFunctions();
         handleTwitchChatEmotesScript();
         emoticonTextInClipboard();
+        if (bttv.settings.get('chatImagePreview') === true) {
+            enableImagePreview();
+        }
 
         $(window).trigger('resize');
         setTimeout(function() {

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -12,7 +12,8 @@ var betaChat = require('./features/beta-chat'),
     flipDashboard = require('./features/flip-dashboard'),
     cssLoader = require('./features/css-loader');
 var displayElement = require('./helpers/element').display,
-    removeElement = require('./helpers/element').remove;
+    removeElement = require('./helpers/element').remove,
+    imagePreview = require('./features/image-preview');
 
 module.exports = [
     {
@@ -54,7 +55,14 @@ module.exports = [
         name: 'Chat Image Preview',
         description: 'Preview chat images on mouse over',
         default: true,
-        storageKey: 'chatImagePreview'
+        storageKey: 'chatImagePreview',
+        toggle: function (value) {
+            if (value === true) {
+                imagePreview.enablePreview();
+            } else {
+                imagePreview.disablePreview();
+            }
+        }
     },
     {
         name: 'Blue Buttons',

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -52,19 +52,6 @@ module.exports = [
         }
     },
     {
-        name: 'Chat Image Preview',
-        description: 'Preview chat images on mouse over',
-        default: true,
-        storageKey: 'chatImagePreview',
-        toggle: function (value) {
-            if (value === true) {
-                imagePreview.enablePreview();
-            } else {
-                imagePreview.disablePreview();
-            }
-        }
-    },
-    {
         name: 'Blue Buttons',
         description: 'BetterTTV replaces Twitch\'s purple with blue by default',
         default: false,
@@ -78,6 +65,19 @@ module.exports = [
         },
         load: function() {
             cssLoader.load("blue-buttons", "showBlueButtons");
+        }
+    },
+    {
+        name: 'Chat Image Preview',
+        description: 'Preview chat images on mouse over',
+        default: true,
+        storageKey: 'chatImagePreview',
+        toggle: function (value) {
+            if (value === true) {
+                imagePreview.enablePreview();
+            } else {
+                imagePreview.disablePreview();
+            }
         }
     },
     {

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -51,6 +51,12 @@ module.exports = [
         }
     },
     {
+        name: 'Chat Image Preview',
+        description: 'Preview chat images on mouse over',
+        default: true,
+        storageKey: 'chatImagePreview'
+    },
+    {
         name: 'Blue Buttons',
         description: 'BetterTTV replaces Twitch\'s purple with blue by default',
         default: false,
@@ -59,7 +65,7 @@ module.exports = [
             if(value === true) {
                 cssLoader.load("blue-buttons", "showBlueButtons");
             } else {
-                cssLoader.unload("showBlueButtons");   
+                cssLoader.unload("showBlueButtons");
             }
         },
         load: function() {
@@ -201,7 +207,7 @@ module.exports = [
             if(value === true) {
                 cssLoader.load("hide-group-chat", "groupChatRemoval");
             } else {
-                cssLoader.unload("groupChatRemoval");   
+                cssLoader.unload("groupChatRemoval");
             }
         },
         load: function() {
@@ -297,7 +303,7 @@ module.exports = [
             }
         }
     },
-    {   
+    {
         default: '',
         storageKey: 'blacklistKeywords',
         toggle: function(keywords) {
@@ -313,7 +319,7 @@ module.exports = [
             }
 
             keywords === "" ? keywords = phraseKeywords : keywords = keywords.split(" ").concat(phraseKeywords);
-            
+
             for(var i=0; i<keywords.length; i++) {
                 if(/^\([a-z0-9_\-\*]+\)$/i.test(keywords[i])) {
                     keywords[i] = keywords[i].replace(/(\(|\))/g, '');
@@ -383,7 +389,7 @@ module.exports = [
                     keywords[i] = keywords[i].replace(/(\(|\))/g, '');
                 }
             }
-            
+
             var keywordList = keywords.join(", ");
             if(keywordList === "") {
                 chat.helpers.serverMessage("Highlight Keywords list is empty");

--- a/src/templates/chat-settings.jade
+++ b/src/templates/chat-settings.jade
@@ -11,9 +11,6 @@
     p
         input.toggleDarkenTTV(type="checkbox", checked=bttv.settings.get("darkenedMode"))
         | Dark Mode
-     p
-        input.toggleChatImagePreview(type="checkbox", checked=bttv.settings.get("chatImagePreview"))
-        | Chat Image Preview
     p: a.g18_gear-00000080.setBlacklistKeywords(href="#") Set Blacklist Keywords
     p: a.g18_gear-00000080.setHighlightKeywords(href="#") Set Highlight Keywords
     p: a.g18_gear-00000080.setScrollbackAmount(href="#") Set Scrollback Amount

--- a/src/templates/chat-settings.jade
+++ b/src/templates/chat-settings.jade
@@ -11,6 +11,9 @@
     p
         input.toggleDarkenTTV(type="checkbox", checked=bttv.settings.get("darkenedMode"))
         | Dark Mode
+     p
+        input.toggleChatImagePreview(type="checkbox", checked=bttv.settings.get("chatImagePreview"))
+        | Chat Image Preview
     p: a.g18_gear-00000080.setBlacklistKeywords(href="#") Set Blacklist Keywords
     p: a.g18_gear-00000080.setHighlightKeywords(href="#") Set Highlight Keywords
     p: a.g18_gear-00000080.setScrollbackAmount(href="#") Set Scrollback Amount


### PR DESCRIPTION
Added ability to enable and disable chat image preview within the chat. Preview opens next to mouse cursor and closes when moused off. Works for any link which ends in .jpg, .jpeg, .gif, and .png.

Preview:
![preview](http://cl.ly/image/1X27071o1U2s/Image%202015-03-29%20at%203.05.46%20PM.png)

Config screen:
![config](http://cl.ly/image/1r0R3P333b2S/Image%202015-03-29%20at%203.06.07%20PM.png)