### PR TITLE
Added timestamps to notification messages: Fixes #291

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -578,7 +578,7 @@ var privmsg = exports.privmsg = function (channel, data) {
             vars.userData.isLoggedIn ? helpers.isModerator(vars.userData.login) : false,
             {
                 message: data.message,
-                time: data.date.toLocaleTimeString().replace(/^(\d{0,2}):(\d{0,2}):(.*)$/i, '$1:$2'),
+                time: data.date == null ? '' : data.date.toLocaleTimeString().replace(/^(\d{0,2}):(\d{0,2}):(.*)$/i, '$1:$2'),
                 nickname: data.from || 'jtv',
                 sender: data.from,
                 badges: data.badges || (data.from==='twitchnotify'?[{
@@ -908,11 +908,12 @@ var suggestions = exports.suggestions = function(words, index) {
         $(this).remove();
     });
 };
-var serverMessage = exports.serverMessage = function(message) {
-    var handlers = require('./handlers');
+var serverMessage = exports.serverMessage = function(message, timestampOverride) {
+    var handlers = require('./handlers'),
+        disableTimestamp = timestampOverride === true ? true : false;
     handlers.onPrivmsg(store.currentRoom, {
         from: 'jtv',
-        date: new Date(),
+        date:  disableTimestamp ? null : new Date(),
         message: message,
         style: 'admin'
     });
@@ -1041,7 +1042,7 @@ var scrollChat = exports.scrollChat = function() {
 
         $chatScroller[0].scrollTop = $chatScroller[0].scrollHeight;
     });
-    
+
     var linesToDelete = $chatLines.length - bttv.settings.get("scrollbackAmount");
 
     if(linesToDelete <= 0) return;
@@ -1212,6 +1213,7 @@ var translate = exports.translate = function(element, sender, text) {
         }
     });
 }
+
 },{"../helpers/colors":39,"../helpers/element":41,"../helpers/regex":42,"../keycodes":43,"../vars":53,"./handlers":4,"./store":7,"./templates":9,"./tmi":10}],6:[function(require,module,exports){
 var tmi = require('./tmi'),
     store = require('./store');
@@ -1566,7 +1568,7 @@ var takeover = module.exports = function() {
 
     $('.ember-chat .chat-messages .chat-line').remove();
     if(bttv.socketServer) bttv.socketServer.emit('chat history');
-    helpers.serverMessage('<center><small>BetterTTV v' + bttv.info.version + ' Loaded.</small></center>');
+    helpers.serverMessage('<center><small>BetterTTV v' + bttv.info.version + ' Loaded.</small></center>', true);
     helpers.serverMessage('Welcome to '+helpers.lookupDisplayName(bttv.getChannel())+'\'s chat room!');
 
     // Reset chatters list
@@ -1625,6 +1627,7 @@ var takeover = module.exports = function() {
         }
     });
 }
+
 },{"../features/chat-load-settings":17,"../features/css-loader":23,"../features/override-emotes":37,"../helpers/debug":40,"../keycodes":43,"../vars":53,"./handlers":4,"./helpers":5,"./rooms":6,"./store":7,"./tmi":10}],9:[function(require,module,exports){
 var tmi = require('./tmi'),
     store = require('./store');

--- a/betterttv.js
+++ b/betterttv.js
@@ -383,22 +383,22 @@ var commands = exports.commands = function (input) {
     } else if (command === "/suboff") {
         tmi().tmiRoom.stopSubscribersMode();
     } else if (command === "/localsub") {
-        helpers.serverMessage("Local subscribers-only mode enabled.");
+        helpers.serverMessage("Local subscribers-only mode enabled.", true);
         vars.localSubsOnly = true;
     } else if (command === "/localsuboff") {
-        helpers.serverMessage("Local subscribers-only mode disabled.");
+        helpers.serverMessage("Local subscribers-only mode disabled.", true);
         vars.localSubsOnly = false;
     } else if (command === "/viewers") {
         bttv.TwitchAPI.get('streams/' + bttv.getChannel()).done(function(stream) {
-            helpers.serverMessage("Current Viewers: " + Twitch.display.commatize(stream.stream.viewers));
+            helpers.serverMessage("Current Viewers: " + Twitch.display.commatize(stream.stream.viewers), true);
         }).fail(function() {
-            helpers.serverMessage("Could not fetch viewer count.");
+            helpers.serverMessage("Could not fetch viewer count.", true);
         });
     } else if (command === "/followers") {
         bttv.TwitchAPI.get('channels/' + bttv.getChannel() + '/follows').done(function(channel) {
-            helpers.serverMessage("Current Followers: " + Twitch.display.commatize(channel._total));
+            helpers.serverMessage("Current Followers: " + Twitch.display.commatize(channel._total), true);
         }).fail(function() {
-            helpers.serverMessage("Could not fetch follower count.");
+            helpers.serverMessage("Could not fetch follower count.", true);
         });
     } else if (command === "/linehistory") {
         if(sentence[1] === "off") {
@@ -420,13 +420,14 @@ var commands = exports.commands = function (input) {
                     (days > 0 ? days + " days " : "") +
                     (hours > 0 ? hours + " hours " : "") +
                     (minutes > 0 ? minutes + " minutes " : "") +
-                    (seconds > 0 ? seconds + " seconds " : "")
+                    (seconds > 0 ? seconds + " seconds " : ""),
+                    true
                 );
             } else {
-                helpers.serverMessage("Stream offline");
+                helpers.serverMessage("Stream offline", true);
             }
         }).fail(function () {
-            helpers.serverMessage("Could not fetch start time.");
+            helpers.serverMessage("Could not fetch start time.", true);
         });
     }
 };
@@ -459,7 +460,7 @@ var shiftQueue = exports.shiftQueue = function () {
         store.currentRoom = id;
         store.__messageQueue = [];
         rooms.getRoom(id).playQueue();
-        helpers.serverMessage('You switched to: '+tmi().get('name').replace(/</g,"&lt;").replace(/>/g,"&gt;"));
+        helpers.serverMessage('You switched to: '+tmi().get('name').replace(/</g,"&lt;").replace(/>/g,"&gt;"), true);
     } else {
         if(store.__messageQueue.length === 0) return;
         $('.ember-chat .chat-messages .tse-content .chat-lines').append(store.__messageQueue.join(""));
@@ -495,7 +496,7 @@ var clearChat = exports.clearChat = function (user) {
     var trackTimeouts = store.trackTimeouts;
 
     if(!user) {
-        helpers.serverMessage("Chat was cleared by a moderator (Prevented by BetterTTV)");
+        helpers.serverMessage("Chat was cleared by a moderator (Prevented by BetterTTV)", true);
     } else {
         if($('.chat-line[data-sender="' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + '"]').length === 0) return;
         if(bttv.settings.get("hideDeletedMessages") === true) {
@@ -540,7 +541,7 @@ var clearChat = exports.clearChat = function (user) {
                     timesID: Math.floor(Math.random()*100001)
                 }
                 var displayName = helpers.lookupDisplayName(user);
-                helpers.serverMessage(displayName + ' has been timed out. <span id="times_from_' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + "_" + trackTimeouts[user].timesID + '"></span>');
+                helpers.serverMessage(displayName + ' has been timed out. <span id="times_from_' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + "_" + trackTimeouts[user].timesID + '"></span>', true);
             }
         }
     }
@@ -908,12 +909,11 @@ var suggestions = exports.suggestions = function(words, index) {
         $(this).remove();
     });
 };
-var serverMessage = exports.serverMessage = function(message, timestampOverride) {
-    var handlers = require('./handlers'),
-        disableTimestamp = timestampOverride === true ? true : false;
+var serverMessage = exports.serverMessage = function(message, displayTimestamp) {
+    var handlers = require('./handlers');
     handlers.onPrivmsg(store.currentRoom, {
         from: 'jtv',
-        date:  disableTimestamp ? null : new Date(),
+        date:  displayTimestamp ? new Date() : null,
         message: message,
         style: 'admin'
     });
@@ -1568,8 +1568,8 @@ var takeover = module.exports = function() {
 
     $('.ember-chat .chat-messages .chat-line').remove();
     if(bttv.socketServer) bttv.socketServer.emit('chat history');
-    helpers.serverMessage('<center><small>BetterTTV v' + bttv.info.version + ' Loaded.</small></center>', true);
-    helpers.serverMessage('Welcome to '+helpers.lookupDisplayName(bttv.getChannel())+'\'s chat room!');
+    helpers.serverMessage('<center><small>BetterTTV v' + bttv.info.version + ' Loaded.</small></center>');
+    helpers.serverMessage('Welcome to '+helpers.lookupDisplayName(bttv.getChannel())+'\'s chat room!', true);
 
     // Reset chatters list
     store.chatters = {};
@@ -3864,16 +3864,16 @@ module.exports = function(user, $event) {
     $modCard.find('.mod-card-follow').text('Unfollow').click(function() {
         if ($modCard.find('.mod-card-follow').text() === 'Unfollow') {
             bttv.TwitchAPI.del("users/:login/follows/channels/"+user.name).done(function() {
-                bttv.chat.helpers.serverMessage('User was unfollowed successfully.');
+                bttv.chat.helpers.serverMessage('User was unfollowed successfully.', true);
             }).fail(function() {
-                bttv.chat.helpers.serverMessage('There was an error following this user.');
+                bttv.chat.helpers.serverMessage('There was an error following this user.', true);
             });
             $modCard.find('.mod-card-follow').text('Follow');
         } else {
             bttv.TwitchAPI.put("users/:login/follows/channels/"+user.name).done(function() {
-                bttv.chat.helpers.serverMessage('User was followed successfully.');
+                bttv.chat.helpers.serverMessage('User was followed successfully.', true);
             }).fail(function() {
-                bttv.chat.helpers.serverMessage('There was an error following this user.');
+                bttv.chat.helpers.serverMessage('There was an error following this user.', true);
             });
             $modCard.find('.mod-card-follow').text('Unfollow');
         }
@@ -4385,7 +4385,7 @@ module.exports = [
             if(value === true) {
                 cssLoader.load("blue-buttons", "showBlueButtons");
             } else {
-                cssLoader.unload("showBlueButtons");   
+                cssLoader.unload("showBlueButtons");
             }
         },
         load: function() {
@@ -4527,7 +4527,7 @@ module.exports = [
             if(value === true) {
                 cssLoader.load("hide-group-chat", "groupChatRemoval");
             } else {
-                cssLoader.unload("groupChatRemoval");   
+                cssLoader.unload("groupChatRemoval");
             }
         },
         load: function() {
@@ -4623,7 +4623,7 @@ module.exports = [
             }
         }
     },
-    {   
+    {
         default: '',
         storageKey: 'blacklistKeywords',
         toggle: function(keywords) {
@@ -4639,7 +4639,7 @@ module.exports = [
             }
 
             keywords === "" ? keywords = phraseKeywords : keywords = keywords.split(" ").concat(phraseKeywords);
-            
+
             for(var i=0; i<keywords.length; i++) {
                 if(/^\([a-z0-9_\-\*]+\)$/i.test(keywords[i])) {
                     keywords[i] = keywords[i].replace(/(\(|\))/g, '');
@@ -4648,9 +4648,9 @@ module.exports = [
 
             var keywordList = keywords.join(", ");
             if(keywordList === "") {
-                chat.helpers.serverMessage("Blacklist Keywords list is empty");
+                chat.helpers.serverMessage("Blacklist Keywords list is empty", true);
             } else {
-                chat.helpers.serverMessage("Blacklist Keywords are now set to: " + keywordList);
+                chat.helpers.serverMessage("Blacklist Keywords are now set to: " + keywordList, true);
             }
         }
     },
@@ -4659,9 +4659,9 @@ module.exports = [
         storageKey: 'chatLineHistory',
         toggle: function(value) {
             if(value === true) {
-                chat.helpers.serverMessage("Chat line history enabled.");
+                chat.helpers.serverMessage("Chat line history enabled.", true);
             } else {
-                chat.helpers.serverMessage("Chat line history disabled.");
+                chat.helpers.serverMessage("Chat line history disabled.", true);
             }
         }
     },
@@ -4709,12 +4709,12 @@ module.exports = [
                     keywords[i] = keywords[i].replace(/(\(|\))/g, '');
                 }
             }
-            
+
             var keywordList = keywords.join(", ");
             if(keywordList === "") {
-                chat.helpers.serverMessage("Highlight Keywords list is empty");
+                chat.helpers.serverMessage("Highlight Keywords list is empty", true);
             } else {
-                chat.helpers.serverMessage("Highlight Keywords are now set to: " + keywordList);
+                chat.helpers.serverMessage("Highlight Keywords are now set to: " + keywordList, true);
             }
         }
     },
@@ -4723,13 +4723,14 @@ module.exports = [
         storageKey: 'scrollbackAmount',
         toggle: function(lines) {
             if(lines === 150) {
-                chat.helpers.serverMessage("Chat scrollback is now set to: default (150)");
+                chat.helpers.serverMessage("Chat scrollback is now set to: default (150)", true);
             } else {
-                chat.helpers.serverMessage("Chat scrollback is now set to: " + lines);
+                chat.helpers.serverMessage("Chat scrollback is now set to: " + lines, true);
             }
         }
     }
 ];
+
 },{"./features/beta-chat":12,"./features/channel-reformat":15,"./features/css-loader":23,"./features/darken-page":24,"./features/flip-dashboard":29,"./features/handle-background":32,"./features/split-chat":38,"./helpers/element":41}],46:[function(require,module,exports){
 function template(locals) {
 var buf = [];

--- a/betterttv.js
+++ b/betterttv.js
@@ -429,7 +429,10 @@ var commands = exports.commands = function (input) {
         }).fail(function () {
             helpers.serverMessage("Could not fetch start time.", true);
         });
+    } else {
+        return false;
     }
+    return true;
 };
 var countUnreadMessages = exports.countUnreadMessages = function () {
     var rooms = require('./rooms'),
@@ -1499,7 +1502,8 @@ var takeover = module.exports = function() {
     // Implement our own text senders (+ commands & legacy tab completion)
     $chatInput.on('keydown', function(e) {
         if(e.which === keyCodes.Enter) {
-            var val = $chatInput.val().trim();
+            var val = $chatInput.val().trim(),
+                bttvCommand = false;
             if(e.shiftKey || !val.length) {
                 return e.preventDefault();
             }
@@ -1511,7 +1515,7 @@ var takeover = module.exports = function() {
             }
 
             if(val.charAt(0) === '/') {
-                handlers.commands(val);
+                bttvCommand = handlers.commands(val);
             }
 
             // Easter Egg Kappa
@@ -1520,7 +1524,9 @@ var takeover = module.exports = function() {
                 helpers.serverMessage('<img src="https://cdn.betterttv.net/special/twitchtrollsgoogle.gif"/>');
             }
 
-            helpers.sendMessage(val);
+            if(!bttvCommand) {
+                helpers.sendMessage(val);
+            }
 
             if(bttv.settings.get('chatLineHistory') === true) {
                 if(store.chatHistory.indexOf(val) !== -1) {
@@ -1547,14 +1553,17 @@ var takeover = module.exports = function() {
         helpers.chatLineHistory($chatInput, e);
     });
     $chatSend.on('click', function() {
-        var val = $chatInput.val().trim();
+        var val = $chatInput.val().trim(),
+            bttvCommand = false;
         if(!val.length) return;
 
         if(val.charAt(0) === '/') {
-            handlers.commands(val);
+            bttvCommand = handlers.commands(val);
         }
 
-        helpers.sendMessage(val);
+        if(!bttvCommand) {
+            helpers.sendMessage(val);
+        }
 
         if(bttv.settings.get('chatLineHistory') === true) {
             if(store.chatHistory.indexOf(val) !== -1) {

--- a/src/chat/handlers.js
+++ b/src/chat/handlers.js
@@ -79,7 +79,10 @@ var commands = exports.commands = function (input) {
         }).fail(function () {
             helpers.serverMessage("Could not fetch start time.", true);
         });
+    } else {
+        return false;
     }
+    return true;
 };
 var countUnreadMessages = exports.countUnreadMessages = function () {
     var rooms = require('./rooms'),

--- a/src/chat/handlers.js
+++ b/src/chat/handlers.js
@@ -33,22 +33,22 @@ var commands = exports.commands = function (input) {
     } else if (command === "/suboff") {
         tmi().tmiRoom.stopSubscribersMode();
     } else if (command === "/localsub") {
-        helpers.serverMessage("Local subscribers-only mode enabled.");
+        helpers.serverMessage("Local subscribers-only mode enabled.", true);
         vars.localSubsOnly = true;
     } else if (command === "/localsuboff") {
-        helpers.serverMessage("Local subscribers-only mode disabled.");
+        helpers.serverMessage("Local subscribers-only mode disabled.", true);
         vars.localSubsOnly = false;
     } else if (command === "/viewers") {
         bttv.TwitchAPI.get('streams/' + bttv.getChannel()).done(function(stream) {
-            helpers.serverMessage("Current Viewers: " + Twitch.display.commatize(stream.stream.viewers));
+            helpers.serverMessage("Current Viewers: " + Twitch.display.commatize(stream.stream.viewers), true);
         }).fail(function() {
-            helpers.serverMessage("Could not fetch viewer count.");
+            helpers.serverMessage("Could not fetch viewer count.", true);
         });
     } else if (command === "/followers") {
         bttv.TwitchAPI.get('channels/' + bttv.getChannel() + '/follows').done(function(channel) {
-            helpers.serverMessage("Current Followers: " + Twitch.display.commatize(channel._total));
+            helpers.serverMessage("Current Followers: " + Twitch.display.commatize(channel._total), true);
         }).fail(function() {
-            helpers.serverMessage("Could not fetch follower count.");
+            helpers.serverMessage("Could not fetch follower count.", true);
         });
     } else if (command === "/linehistory") {
         if(sentence[1] === "off") {
@@ -70,13 +70,14 @@ var commands = exports.commands = function (input) {
                     (days > 0 ? days + " days " : "") +
                     (hours > 0 ? hours + " hours " : "") +
                     (minutes > 0 ? minutes + " minutes " : "") +
-                    (seconds > 0 ? seconds + " seconds " : "")
+                    (seconds > 0 ? seconds + " seconds " : ""),
+                    true
                 );
             } else {
-                helpers.serverMessage("Stream offline");
+                helpers.serverMessage("Stream offline", true);
             }
         }).fail(function () {
-            helpers.serverMessage("Could not fetch start time.");
+            helpers.serverMessage("Could not fetch start time.", true);
         });
     }
 };
@@ -109,7 +110,7 @@ var shiftQueue = exports.shiftQueue = function () {
         store.currentRoom = id;
         store.__messageQueue = [];
         rooms.getRoom(id).playQueue();
-        helpers.serverMessage('You switched to: '+tmi().get('name').replace(/</g,"&lt;").replace(/>/g,"&gt;"));
+        helpers.serverMessage('You switched to: '+tmi().get('name').replace(/</g,"&lt;").replace(/>/g,"&gt;"), true);
     } else {
         if(store.__messageQueue.length === 0) return;
         $('.ember-chat .chat-messages .tse-content .chat-lines').append(store.__messageQueue.join(""));
@@ -145,7 +146,7 @@ var clearChat = exports.clearChat = function (user) {
     var trackTimeouts = store.trackTimeouts;
 
     if(!user) {
-        helpers.serverMessage("Chat was cleared by a moderator (Prevented by BetterTTV)");
+        helpers.serverMessage("Chat was cleared by a moderator (Prevented by BetterTTV)", true);
     } else {
         if($('.chat-line[data-sender="' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + '"]').length === 0) return;
         if(bttv.settings.get("hideDeletedMessages") === true) {
@@ -190,7 +191,7 @@ var clearChat = exports.clearChat = function (user) {
                     timesID: Math.floor(Math.random()*100001)
                 }
                 var displayName = helpers.lookupDisplayName(user);
-                helpers.serverMessage(displayName + ' has been timed out. <span id="times_from_' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + "_" + trackTimeouts[user].timesID + '"></span>');
+                helpers.serverMessage(displayName + ' has been timed out. <span id="times_from_' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + "_" + trackTimeouts[user].timesID + '"></span>', true);
             }
         }
     }

--- a/src/chat/handlers.js
+++ b/src/chat/handlers.js
@@ -228,7 +228,7 @@ var privmsg = exports.privmsg = function (channel, data) {
             vars.userData.isLoggedIn ? helpers.isModerator(vars.userData.login) : false,
             {
                 message: data.message,
-                time: data.date.toLocaleTimeString().replace(/^(\d{0,2}):(\d{0,2}):(.*)$/i, '$1:$2'),
+                time: data.date == null ? '' : data.date.toLocaleTimeString().replace(/^(\d{0,2}):(\d{0,2}):(.*)$/i, '$1:$2'),
                 nickname: data.from || 'jtv',
                 sender: data.from,
                 badges: data.badges || (data.from==='twitchnotify'?[{

--- a/src/chat/helpers.js
+++ b/src/chat/helpers.js
@@ -197,11 +197,12 @@ var suggestions = exports.suggestions = function(words, index) {
         $(this).remove();
     });
 };
-var serverMessage = exports.serverMessage = function(message) {
-    var handlers = require('./handlers');
+var serverMessage = exports.serverMessage = function(message, timestampOverride) {
+    var handlers = require('./handlers'),
+        disableTimestamp = timestampOverride === true ? true : false;
     handlers.onPrivmsg(store.currentRoom, {
         from: 'jtv',
-        date: new Date(),
+        date:  disableTimestamp ? null : new Date(),
         message: message,
         style: 'admin'
     });
@@ -330,7 +331,7 @@ var scrollChat = exports.scrollChat = function() {
 
         $chatScroller[0].scrollTop = $chatScroller[0].scrollHeight;
     });
-    
+
     var linesToDelete = $chatLines.length - bttv.settings.get("scrollbackAmount");
 
     if(linesToDelete <= 0) return;

--- a/src/chat/helpers.js
+++ b/src/chat/helpers.js
@@ -197,12 +197,11 @@ var suggestions = exports.suggestions = function(words, index) {
         $(this).remove();
     });
 };
-var serverMessage = exports.serverMessage = function(message, timestampOverride) {
-    var handlers = require('./handlers'),
-        disableTimestamp = timestampOverride === true ? true : false;
+var serverMessage = exports.serverMessage = function(message, displayTimestamp) {
+    var handlers = require('./handlers');
     handlers.onPrivmsg(store.currentRoom, {
         from: 'jtv',
-        date:  disableTimestamp ? null : new Date(),
+        date:  displayTimestamp ? new Date() : null,
         message: message,
         style: 'admin'
     });

--- a/src/chat/takeover.js
+++ b/src/chat/takeover.js
@@ -190,7 +190,8 @@ var takeover = module.exports = function() {
     // Implement our own text senders (+ commands & legacy tab completion)
     $chatInput.on('keydown', function(e) {
         if(e.which === keyCodes.Enter) {
-            var val = $chatInput.val().trim();
+            var val = $chatInput.val().trim(),
+                bttvCommand = false;
             if(e.shiftKey || !val.length) {
                 return e.preventDefault();
             }
@@ -202,7 +203,7 @@ var takeover = module.exports = function() {
             }
 
             if(val.charAt(0) === '/') {
-                handlers.commands(val);
+                bttvCommand = handlers.commands(val);
             }
 
             // Easter Egg Kappa
@@ -211,7 +212,9 @@ var takeover = module.exports = function() {
                 helpers.serverMessage('<img src="https://cdn.betterttv.net/special/twitchtrollsgoogle.gif"/>');
             }
 
-            helpers.sendMessage(val);
+            if(!bttvCommand) {
+                helpers.sendMessage(val);
+            }
 
             if(bttv.settings.get('chatLineHistory') === true) {
                 if(store.chatHistory.indexOf(val) !== -1) {
@@ -238,14 +241,17 @@ var takeover = module.exports = function() {
         helpers.chatLineHistory($chatInput, e);
     });
     $chatSend.on('click', function() {
-        var val = $chatInput.val().trim();
+        var val = $chatInput.val().trim(),
+            bttvCommand = false;
         if(!val.length) return;
 
         if(val.charAt(0) === '/') {
-            handlers.commands(val);
+            bttvCommand = handlers.commands(val);
         }
 
-        helpers.sendMessage(val);
+        if(!bttvCommand) {
+            helpers.sendMessage(val);
+        }
 
         if(bttv.settings.get('chatLineHistory') === true) {
             if(store.chatHistory.indexOf(val) !== -1) {

--- a/src/chat/takeover.js
+++ b/src/chat/takeover.js
@@ -259,8 +259,8 @@ var takeover = module.exports = function() {
 
     $('.ember-chat .chat-messages .chat-line').remove();
     if(bttv.socketServer) bttv.socketServer.emit('chat history');
-    helpers.serverMessage('<center><small>BetterTTV v' + bttv.info.version + ' Loaded.</small></center>', true);
-    helpers.serverMessage('Welcome to '+helpers.lookupDisplayName(bttv.getChannel())+'\'s chat room!');
+    helpers.serverMessage('<center><small>BetterTTV v' + bttv.info.version + ' Loaded.</small></center>');
+    helpers.serverMessage('Welcome to '+helpers.lookupDisplayName(bttv.getChannel())+'\'s chat room!', true);
 
     // Reset chatters list
     store.chatters = {};

--- a/src/chat/takeover.js
+++ b/src/chat/takeover.js
@@ -259,7 +259,7 @@ var takeover = module.exports = function() {
 
     $('.ember-chat .chat-messages .chat-line').remove();
     if(bttv.socketServer) bttv.socketServer.emit('chat history');
-    helpers.serverMessage('<center><small>BetterTTV v' + bttv.info.version + ' Loaded.</small></center>');
+    helpers.serverMessage('<center><small>BetterTTV v' + bttv.info.version + ' Loaded.</small></center>', true);
     helpers.serverMessage('Welcome to '+helpers.lookupDisplayName(bttv.getChannel())+'\'s chat room!');
 
     // Reset chatters list

--- a/src/features/make-card.js
+++ b/src/features/make-card.js
@@ -85,16 +85,16 @@ module.exports = function(user, $event) {
     $modCard.find('.mod-card-follow').text('Unfollow').click(function() {
         if ($modCard.find('.mod-card-follow').text() === 'Unfollow') {
             bttv.TwitchAPI.del("users/:login/follows/channels/"+user.name).done(function() {
-                bttv.chat.helpers.serverMessage('User was unfollowed successfully.');
+                bttv.chat.helpers.serverMessage('User was unfollowed successfully.', true);
             }).fail(function() {
-                bttv.chat.helpers.serverMessage('There was an error following this user.');
+                bttv.chat.helpers.serverMessage('There was an error following this user.', true);
             });
             $modCard.find('.mod-card-follow').text('Follow');
         } else {
             bttv.TwitchAPI.put("users/:login/follows/channels/"+user.name).done(function() {
-                bttv.chat.helpers.serverMessage('User was followed successfully.');
+                bttv.chat.helpers.serverMessage('User was followed successfully.', true);
             }).fail(function() {
-                bttv.chat.helpers.serverMessage('There was an error following this user.');
+                bttv.chat.helpers.serverMessage('There was an error following this user.', true);
             });
             $modCard.find('.mod-card-follow').text('Unfollow');
         }

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -59,7 +59,7 @@ module.exports = [
             if(value === true) {
                 cssLoader.load("blue-buttons", "showBlueButtons");
             } else {
-                cssLoader.unload("showBlueButtons");   
+                cssLoader.unload("showBlueButtons");
             }
         },
         load: function() {
@@ -201,7 +201,7 @@ module.exports = [
             if(value === true) {
                 cssLoader.load("hide-group-chat", "groupChatRemoval");
             } else {
-                cssLoader.unload("groupChatRemoval");   
+                cssLoader.unload("groupChatRemoval");
             }
         },
         load: function() {
@@ -297,7 +297,7 @@ module.exports = [
             }
         }
     },
-    {   
+    {
         default: '',
         storageKey: 'blacklistKeywords',
         toggle: function(keywords) {
@@ -313,7 +313,7 @@ module.exports = [
             }
 
             keywords === "" ? keywords = phraseKeywords : keywords = keywords.split(" ").concat(phraseKeywords);
-            
+
             for(var i=0; i<keywords.length; i++) {
                 if(/^\([a-z0-9_\-\*]+\)$/i.test(keywords[i])) {
                     keywords[i] = keywords[i].replace(/(\(|\))/g, '');
@@ -322,9 +322,9 @@ module.exports = [
 
             var keywordList = keywords.join(", ");
             if(keywordList === "") {
-                chat.helpers.serverMessage("Blacklist Keywords list is empty");
+                chat.helpers.serverMessage("Blacklist Keywords list is empty", true);
             } else {
-                chat.helpers.serverMessage("Blacklist Keywords are now set to: " + keywordList);
+                chat.helpers.serverMessage("Blacklist Keywords are now set to: " + keywordList, true);
             }
         }
     },
@@ -333,9 +333,9 @@ module.exports = [
         storageKey: 'chatLineHistory',
         toggle: function(value) {
             if(value === true) {
-                chat.helpers.serverMessage("Chat line history enabled.");
+                chat.helpers.serverMessage("Chat line history enabled.", true);
             } else {
-                chat.helpers.serverMessage("Chat line history disabled.");
+                chat.helpers.serverMessage("Chat line history disabled.", true);
             }
         }
     },
@@ -383,12 +383,12 @@ module.exports = [
                     keywords[i] = keywords[i].replace(/(\(|\))/g, '');
                 }
             }
-            
+
             var keywordList = keywords.join(", ");
             if(keywordList === "") {
-                chat.helpers.serverMessage("Highlight Keywords list is empty");
+                chat.helpers.serverMessage("Highlight Keywords list is empty", true);
             } else {
-                chat.helpers.serverMessage("Highlight Keywords are now set to: " + keywordList);
+                chat.helpers.serverMessage("Highlight Keywords are now set to: " + keywordList, true);
             }
         }
     },
@@ -397,9 +397,9 @@ module.exports = [
         storageKey: 'scrollbackAmount',
         toggle: function(lines) {
             if(lines === 150) {
-                chat.helpers.serverMessage("Chat scrollback is now set to: default (150)");
+                chat.helpers.serverMessage("Chat scrollback is now set to: default (150)", true);
             } else {
-                chat.helpers.serverMessage("Chat scrollback is now set to: " + lines);
+                chat.helpers.serverMessage("Chat scrollback is now set to: " + lines, true);
             }
         }
     }

--- a/style/stylesheets/betterttv.css
+++ b/style/stylesheets/betterttv.css
@@ -864,7 +864,7 @@ input, textarea, select {
     height:12px;
     background: url(../icons/close_button_white.png);
     opacity: .6;
-  
+
 }
 
 .gritter-title {
@@ -1097,6 +1097,14 @@ body#chat #speak {
     padding-right: 10px;
 }
 
+.ember-chat .chat-messages .chat-line.admin .timestamp {
+    display: inline;
+}
+
+.ember-chat .chat-messages.hideTimestamps .chat-line.admin .timestamp {
+    display: none;
+}
+
 .ember-chat .chatters-view {
     left: 0px;
     right: 0px;
@@ -1193,7 +1201,7 @@ body#chat #speak {
     width: 100%;
 }
 
-.archives-contain .videos { 
+.archives-contain .videos {
     padding:0;
 }
 .archives-contain .list-video {


### PR DESCRIPTION
Notification messages are now tied to the time stamp option in the settings panel. Also added an added override within to code to force time stamps to be disabled because sometimes you don't want them. (e.g. BTTV version load message).

![timestamp message](https://s3.amazonaws.com/f.cl.ly/items/1N1s1p0e1O0g2s17300n/Image%202015-03-31%20at%2010.05.06%20AM.png)