### PR TITLE
Add whisper reply support and whisper reply template in chat history

### DIFF
--- a/src/chat/handlers.js
+++ b/src/chat/handlers.js
@@ -100,6 +100,7 @@ var commands = exports.commands = function (input) {
         helpers.serverMessage("/suboff -- Shortcut for /subscribersoff");
         helpers.serverMessage("/t [username] [time in seconds] -- Shortcut for /timeout");
         helpers.serverMessage("/u [username] -- Shortcut for /unban");
+        helpers.serverMessage("/r [message] -- Shortcut for /w [last whisper sender] [message]");
         helpers.serverMessage("/uptime -- Retrieves the amount of time the channel has been live");
         helpers.serverMessage("/viewers -- Retrieves the number of viewers watching the channel");
         helpers.serverMessage("Native Chat Commands:");
@@ -354,7 +355,7 @@ var privmsg = exports.privmsg = function (channel, data) {
         if (data.to === vars.userData.login) {
             if (data.from !== vars.lastWhisperFrom) {
                 // Only reset timer if sender changes
-                vars.lastWhisperTime = new Date().getTime();
+                vars.lastWhisperTime = Date.now();
                 vars.lastWhisperFrom = data.from;
             }
 

--- a/src/chat/handlers.js
+++ b/src/chat/handlers.js
@@ -28,6 +28,8 @@ var commands = exports.commands = function (input) {
         helpers.massUnban();
     } else if (command === "/u") {
         helpers.unban(sentence[1]);
+    } else if (command === "/r") {
+        helpers.whisperReply(sentence[1]);
     } else if (command === "/sub") {
         tmi().tmiRoom.startSubscribersMode();
     } else if (command === "/suboff") {
@@ -352,6 +354,11 @@ var privmsg = exports.privmsg = function (channel, data) {
         if (data.to === vars.userData.login) {
             if(bttv.settings.get('chatLineHistory') === true) {
                 var val = "/w " + data.from + " ";
+                if (data.from !== vars.lastWhisperFrom) {
+                    // Only reset timer if sender changes
+                    vars.lastWhisperTime = new Date().getTime();
+                }
+                vars.lastWhisperFrom = data.from;
                 if(store.chatHistory.indexOf(val) !== -1) {
                     store.chatHistory.splice(store.chatHistory.indexOf(val), 1);
                 }

--- a/src/chat/handlers.js
+++ b/src/chat/handlers.js
@@ -352,13 +352,14 @@ var privmsg = exports.privmsg = function (channel, data) {
 
         // Add prepared reply template to chat history
         if (data.to === vars.userData.login) {
+            if (data.from !== vars.lastWhisperFrom) {
+                // Only reset timer if sender changes
+                vars.lastWhisperTime = new Date().getTime();
+                vars.lastWhisperFrom = data.from;
+            }
+
             if(bttv.settings.get('chatLineHistory') === true) {
                 var val = "/w " + data.from + " ";
-                if (data.from !== vars.lastWhisperFrom) {
-                    // Only reset timer if sender changes
-                    vars.lastWhisperTime = new Date().getTime();
-                }
-                vars.lastWhisperFrom = data.from;
                 if(store.chatHistory.indexOf(val) !== -1) {
                     store.chatHistory.splice(store.chatHistory.indexOf(val), 1);
                 }

--- a/src/chat/handlers.js
+++ b/src/chat/handlers.js
@@ -348,6 +348,17 @@ var privmsg = exports.privmsg = function (channel, data) {
             emotes: data.tags.emotes
         });
 
+        // Add prepared reply template to chat history
+        if (data.to === vars.userData.login) {
+            if(bttv.settings.get('chatLineHistory') === true) {
+                var val = "/w " + data.from + " ";
+                if(store.chatHistory.indexOf(val) !== -1) {
+                    store.chatHistory.splice(store.chatHistory.indexOf(val), 1);
+                }
+                store.chatHistory.unshift(val);
+            }
+        }
+
         $('.ember-chat .chat-messages .tse-content .chat-lines').append(message);
         helpers.scrollChat();
         return;

--- a/src/chat/helpers.js
+++ b/src/chat/helpers.js
@@ -705,13 +705,13 @@ var whisperReply = exports.whisperReply = function(msg) {
     if(!msg || msg === "") return;
 
     if (!vars.lastWhisperFrom) {
-        serverMessage("There is no recorded whisper to reply to.");
+        serverMessage("There is no whisper to reply to.");
         return;
     }
 
     var currentTime = new Date().getTime();
-    if (currentTime - vars.lastWhisperTime < 3000) {
-        serverMessage("Message not sent because the reply target just changed.");
+    if (currentTime - vars.lastWhisperTime < 2000) {
+        serverMessage("Message not sent because the whisper recipient just changed.");
         return;
     }
 

--- a/src/chat/helpers.js
+++ b/src/chat/helpers.js
@@ -19,7 +19,7 @@ var lookupDisplayName = exports.lookupDisplayName = function(user) {
     if(vars.userData.isLoggedIn && user === vars.userData.login) {
         store.displayNames[user] = Twitch.user.displayName() || user;
     }
-    
+
     // Get subscription status (Night's subs)
     bttv.io.lookupUser(user);
 
@@ -130,7 +130,7 @@ var tabCompletion = exports.tabCompletion = function(e) {
         } else {
             var search = currentMatch;
             var users = store.tabCompleteHistory;
-            
+
             users = users.concat(Object.keys(store.chatters));
 
             users = users.sort();
@@ -700,3 +700,20 @@ var massUnban = exports.massUnban = function() {
         }
     });
 }*/
+var whisperReply = exports.whisperReply = function(msg) {
+    if(!msg || msg === "") return;
+
+    if (!vars.lastWhisperFrom) {
+        serverMessage("There is no recorded whisper to reply to.");
+        return;
+    }
+
+    var currentTime = new Date().getTime();
+    if (currentTime - vars.lastWhisperTime < 3000) {
+        serverMessage("Message not sent because the reply target just changed.");
+        return;
+    }
+
+    var reply = "/w " + vars.lastWhisperFrom + " " + msg;
+    tmi().tmiRoom.sendMessage(reply);
+};

--- a/src/chat/helpers.js
+++ b/src/chat/helpers.js
@@ -206,6 +206,7 @@ var chatLineHistory = exports.chatLineHistory = function($chatInput, e) {
                 $chatInput.val(store.chatHistory[0]);
             }
         }
+        e.preventDefault(); // Prevent cursor going to start of line
     } else if(keyCode === keyCodes.DownArrow) {
         if(historyIndex >= 0) {
             if(store.chatHistory[historyIndex-1]) {

--- a/src/chat/helpers.js
+++ b/src/chat/helpers.js
@@ -709,8 +709,7 @@ var whisperReply = exports.whisperReply = function(msg) {
         return;
     }
 
-    var currentTime = new Date().getTime();
-    if (currentTime - vars.lastWhisperTime < 2000) {
+    if (Date.now() - vars.lastWhisperTime < 2000) {
         serverMessage("Message not sent because the whisper recipient just changed.");
         return;
     }


### PR DESCRIPTION
The first commit appends "/w [user] " to the chat history, just like the default twitch chat does.
There's a tiny issue with the implementation, but I'm not sure what the best way to fix is.
The prefered behavior would be that your cursor automatically gets set at the end of the line.
All the solutions I have seem a bit too hacky, I'd like to hear from you guys.

The second commit adds support for "/r" to reply to the last whisper.
There's also a warning if your reply recipient changes within 3s of you replying.
The warning messages seem a bit weak and may need tweaking.

Any code review suggestions are welcomed.
As a side note, it seems like my editor stripped some whitespace, I hope that isn't an issue.