### PR TITLE
You tube links (chrome only)

### DIFF
--- a/chrome/betterttv.js
+++ b/chrome/betterttv.js
@@ -1,0 +1,36 @@
+
+window.addEventListener('message', function(event) {
+	if (event.data.type === 'youtube-title-query') {
+			var query = 'https://www.youtube.com/oembed?url='+event.data.url+'&format=json';
+			
+			var xhr = new XMLHttpRequest();
+			xhr.open("GET", query, true);
+			xhr.onreadystatechange = function() {
+				if (xhr.readyState == 4) {
+					try {
+						var data = JSON.parse(xhr.responseText);
+						
+						window.postMessage({ type: 'youtube-title-response',
+							url: event.data.url,
+							id: event.data.id,
+							title: data.title},
+							'*'
+						);
+					}
+					catch(e) {console.log('YouTube link lookup failed to parse.'); console.log(e);}
+				}
+			}
+			xhr.send();
+	}
+});
+
+function betterttv_init()
+{
+	script = document.createElement('script');
+	script.type = 'text/javascript';
+	script.src = "//cdn.betterttv.net/betterttv.js?"+Math.random();
+	thehead = document.getElementsByTagName('head')[0];
+	if(thehead) thehead.appendChild(script);
+}
+
+betterttv_init();

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,0 +1,19 @@
+{
+   "content_scripts": [ {
+      "all_frames": true,
+      "js": [ "betterttv.js" ],
+      "matches": [ "*://*.twitch.tv/*" ]
+   } ],
+   "description": "Enhances Twitch with new features, bug fixes, and reduced clutter.",
+   "homepage_url": "http://www.betterttv.com",
+   "icons": {
+      "128": "icon.png"
+   },
+   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDGodR8UOS1OhLctEpt4tzWBax9vHSCjff/Ir2Y32FzNq5CyWdKpC7Ak9r+rK8jKBV6VZt+4D+pOPctfof3pO2r3DD2/YDSRhDxu0znYtioLihfTOvS+AlB1pBqLrK0yNMcAvs9Eu/yIgrD/8UoSI/WnVEI/Z5ohv3u0Gha6QSS7wIDAQAB",
+   "manifest_version": 2,
+   "name": "BetterTTV",
+   "permissions": [ "*://*.twitch.tv/*", "*://*.youtube.com/*" ],
+   "short_name": "BTTV",
+   "update_url": "https://clients2.google.com/service/update2/crx",
+   "version": "6.9"
+}

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -319,6 +319,12 @@ module.exports = [
         }
     },
     {
+        name: 'YouTube Links',
+        description: 'Adds titles to YouTube Links',
+        default: false,
+        storageKey: 'youTubeLinks'
+    },
+    {
         default: '',
         storageKey: 'blacklistKeywords',
         toggle: function(keywords) {


### PR DESCRIPTION
Shows the title of a YouTube video or playlist link when the mouse hovers over it.  There are two potential ways of doing it (the other is in a separate branch, the one that I didn't pull request, and includes more details in its commit notes).  This way gives permissions for YouTube URLs to the content script, which makes calls to the YouTube oembed API endpoint (which doesn't require authentication, and is compatible with their recent API changes) on behalf of the injected portion, but requires updating the betterttv.js and manifest.json files of the Chrome extension to work (and so wouldn't work with other browsers as it currently stands).  In short, the other way would be to use the currently-existing BTTV servers to lookup and cache YouTube titles (with some simple PHP and SQL or something similar) and have the client go through that, instead of directly calling the YouTube API.
![temp-temp-temp-rger-crop](https://cloud.githubusercontent.com/assets/11858693/8124954/f9d9f2b6-10ae-11e5-8b58-b38cad80ed4d.png)
