### PR TITLE
Link Info

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -2085,7 +2085,8 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
                 piece = escape(piece);
                 var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
                     link2 = match[1];
-                piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="twitch" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
+                if ('directory following settings login logout'.indexOf(link2) !== -1) piece = '<a href="' + link + '" target="_blank">' + piece + '</a>';
+                else piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="twitch" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
                 tokenizedString[i] = piece;
                 continue;
             }

--- a/betterttv.js
+++ b/betterttv.js
@@ -2085,7 +2085,7 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
                 piece = escape(piece);
                 var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
                     link2 = match[1];
-                if ('directory following settings login logout'.indexOf(link2) !== -1) piece = '<a href="' + link + '" target="_blank">' + piece + '</a>';
+                if (['directory','following','settings','login','logout'].indexOf(link2) !== -1) piece = '<a href="' + link + '" target="_blank">' + piece + '</a>';
                 else piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="twitch" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
                 tokenizedString[i] = piece;
                 continue;

--- a/betterttv.js
+++ b/betterttv.js
@@ -3888,7 +3888,8 @@ exports.highlighting = function (data) {
 },{"../features/highlight-feedback":36,"../helpers/regex":47,"../vars":61}],39:[function(require,module,exports){
 
 /* CONFIG */
-var refreshTime = 10 * 1000;
+var refreshTime = 60 * 1000;
+var refreshTimeTwitch = 10 * 1000;
 
 /* END CONFIG */
 
@@ -3898,6 +3899,7 @@ var lookup = {
             (typeof d === 'object' && typeof d.title === 'string') ? callback(d.title) : callback(false);
         }).error(function() {
             callback(false);
+            setTimeout(function() {cache[link] = undefined;} , refreshTime);
         });
     },
     'tiny': function(link, data, callback) {
@@ -3905,15 +3907,16 @@ var lookup = {
             (typeof d === 'object' && typeof d.fullurl === 'string') ? callback(d.fullurl) : callback(false);
         }).error(function() {
             callback(false);
+            setTimeout(function() {cache[link] = undefined;} , refreshTime);
         });
     },
     'twitch': function(link, data, callback) {
         bttv.TwitchAPI.get('streams/' + data).done(function(d) {
             (typeof d === 'object' && d.stream !== null) ? callback('This channel is:<br><div style="color: rgb(0, 255, 0);">LIVE NOW</div>') : callback('This channel is:<br><div style="color: rgb(255, 0, 0);">OFFLINE</div>');
-            setTimeout(function() {cache[link] = undefined;} , refreshTime);
+            setTimeout(function() {cache[link] = undefined;} , refreshTimeTwitch);
         }).fail(function() {
             callback(false);
-            setTimeout(function() {cache[link] = undefined;} , refreshTime);
+            setTimeout(function() {cache[link] = undefined;} , refreshTimeTwitch);
         });
     },
 };

--- a/betterttv.js
+++ b/betterttv.js
@@ -229,12 +229,21 @@ exports.attrs = function attrs(obj, terse){
  * @api private
  */
 
-exports.escape = function escape(html){
-  var result = String(html)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+var jade_encode_html_rules = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;'
+};
+var jade_match_html = /[&<>"]/g;
+
+function jade_encode_char(c) {
+  return jade_encode_html_rules[c] || c;
+}
+
+exports.escape = jade_escape;
+function jade_escape(html){
+  var result = String(html).replace(jade_match_html, jade_encode_char);
   if (result === '' + html) return html;
   else return result;
 };
@@ -729,7 +738,7 @@ var privmsg = exports.privmsg = function (channel, data) {
     store.__messageQueue.push(message);
 }
 
-},{"../features/embedded-polling":29,"../features/keywords-lists":38,"../features/make-card":39,"../helpers/colors":42,"../helpers/debug":43,"../helpers/regex":46,"../vars":60,"./helpers":5,"./rooms":7,"./store":8,"./templates":10,"./tmi":11}],5:[function(require,module,exports){
+},{"../features/embedded-polling":29,"../features/keywords-lists":38,"../features/make-card":40,"../helpers/colors":43,"../helpers/debug":44,"../helpers/regex":47,"../vars":61,"./helpers":5,"./rooms":7,"./store":8,"./templates":10,"./tmi":11}],5:[function(require,module,exports){
 var vars = require('../vars'),
     keyCodes = require('../keycodes'),
     tmi = require('./tmi'),
@@ -1453,7 +1462,7 @@ var massUnban = exports.massUnban = function() {
     });
 }*/
 
-},{"../bots":1,"../helpers/colors":42,"../helpers/element":44,"../helpers/regex":46,"../keycodes":47,"../legacy-tags":48,"../vars":60,"./handlers":4,"./store":8,"./templates":10,"./tmi":11,"punycode":62}],6:[function(require,module,exports){
+},{"../bots":1,"../helpers/colors":43,"../helpers/element":45,"../helpers/regex":47,"../keycodes":48,"../legacy-tags":49,"../vars":61,"./handlers":4,"./store":8,"./templates":10,"./tmi":11,"punycode":63}],6:[function(require,module,exports){
 
 // Add mouseover image preview to image links
 module.exports = function(imgUrl) {
@@ -1919,7 +1928,7 @@ var takeover = module.exports = function() {
     });
 }
 
-},{"../features/chat-load-settings":19,"../features/css-loader":25,"../features/override-emotes":40,"../helpers/debug":43,"../keycodes":47,"../vars":60,"./handlers":4,"./helpers":5,"./rooms":7,"./store":8,"./tmi":11}],10:[function(require,module,exports){
+},{"../features/chat-load-settings":19,"../features/css-loader":25,"../features/override-emotes":41,"../helpers/debug":44,"../keycodes":48,"../vars":61,"./handlers":4,"./helpers":5,"./rooms":7,"./store":8,"./tmi":11}],10:[function(require,module,exports){
 var tmi = require('./tmi'),
     store = require('./store');
 
@@ -2054,6 +2063,34 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
             }
         }
 
+        if(bttv.settings.get('linkInfo') === true) {
+            var match;
+            if (match = /((?:https?:\/\/)?(?:youtu\.be\/|(?:www\.)?youtube\.com\/(?:watch\?v|playlist\?list)=)[-a-zA-Z0-9_]+)[-a-zA-Z0-9@:%_\+.~#?&\/=]*/i.exec(piece)) {
+                piece = escape(piece);
+                var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
+                    link2 = match[1].replace(/^(?!(?:https?:\/\/))/i, 'http://');
+                piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="youtube" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
+                tokenizedString[i] = piece;
+                continue;
+            }
+            else if (match = /((?:https?:\/\/)?(?:www\.)?(?:bit\.ly|goo\.gl|ow\.ly|t\.co|tinyurl\.com|tr\.im)\/[-a-zA-Z0-9_]+)[-a-zA-Z0-9@:%_\+.~#?&\/=]*/i.exec(piece)) {
+                piece = escape(piece);
+                var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
+                    link2 = match[1].replace(/^(?!(?:https?:\/\/))/i, 'http://');
+                piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="tiny" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
+                tokenizedString[i] = piece;
+                continue;
+            }
+            else if (match = /(?:https?:\/\/)?(?:www\.)?twitch\.tv\/([-a-zA-Z0-9_]+)(?:\/[-a-zA-Z0-9@:%_\+.~#?&\/=]*)?/i.exec(piece)) {
+                piece = escape(piece);
+                var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
+                    link2 = match[1];
+                piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="twitch" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
+                tokenizedString[i] = piece;
+                continue;
+            }
+        }
+
         var test = piece.replace(/(^[~!@#$%\^&\*\(\)]+|[~!@#$%\^&\*\(\)]+$)/g, '');
         var emote = null;
 
@@ -2113,7 +2150,7 @@ var whisper = exports.whisper = function(data) {
     return '<div class="chat-line whisper" data-sender="'+data.sender+'">'+timestamp(data.time)+' '+whisperName(data.sender, data.receiver, data.from, data.to, data.fromColor, data.toColor)+message(data.sender, data.message, data.emotes, false)+'</div>';
 }
 
-},{"../templates/chat-suggestions":54,"../templates/moderation-card":56,"./helpers":5,"./store":8,"./tmi":11}],11:[function(require,module,exports){
+},{"../templates/chat-suggestions":55,"../templates/moderation-card":57,"./helpers":5,"./store":8,"./tmi":11}],11:[function(require,module,exports){
 module.exports = function() {
 	return bttv.getChatController() ? bttv.getChatController().currentRoom : false;
 }
@@ -2246,6 +2283,7 @@ var clearClutter = require('./features/clear-clutter'),
     emoticonTextInClipboard = require('./features/emoticon-text-in-clipboard'),
     createSettings = require('./features/create-settings');
     enableImagePreview = require('./features/image-preview').enablePreview;
+    enableLinkInfo = require('./features/link-info').enableLinkInfo;
     enableTheatreMode = require('./features/auto-theatre-mode');
 
 var chatFunctions = function () {
@@ -2381,6 +2419,9 @@ var main = function () {
         if (bttv.settings.get('chatImagePreview') === true) {
             enableImagePreview();
         }
+        if (bttv.settings.get('linkInfo') === true) {
+            enableLinkInfo();
+        }
         if (bttv.settings.get('autoTheatreMode') === true) {
             enableTheatreMode();
         }
@@ -2431,7 +2472,7 @@ debug.log("BTTV LOADED " + document.URL);
 BTTVLOADED = true;
 checkJquery();
 
-},{"./chat":2,"./features/auto-theatre-mode":13,"./features/beta-chat":14,"./features/brand":15,"./features/channel-reformat":17,"./features/check-broadcast-info":20,"./features/check-following":21,"./features/check-messages":22,"./features/clear-clutter":23,"./features/create-settings":24,"./features/darken-page":26,"./features/dashboard-channelinfo":27,"./features/directory-functions":28,"./features/emoticon-text-in-clipboard":30,"./features/flip-dashboard":31,"./features/format-dashboard":32,"./features/giveaway-compatibility":33,"./features/handle-background":34,"./features/handle-twitchchat-emotes":35,"./features/image-preview":37,"./features/split-chat":41,"./helpers/debug":43,"./keycodes":47,"./settings":50,"./socketio":51,"./storage":52,"./twitch-api":59,"./vars":60}],13:[function(require,module,exports){
+},{"./chat":2,"./features/auto-theatre-mode":13,"./features/beta-chat":14,"./features/brand":15,"./features/channel-reformat":17,"./features/check-broadcast-info":20,"./features/check-following":21,"./features/check-messages":22,"./features/clear-clutter":23,"./features/create-settings":24,"./features/darken-page":26,"./features/dashboard-channelinfo":27,"./features/directory-functions":28,"./features/emoticon-text-in-clipboard":30,"./features/flip-dashboard":31,"./features/format-dashboard":32,"./features/giveaway-compatibility":33,"./features/handle-background":34,"./features/handle-twitchchat-emotes":35,"./features/image-preview":37,"./features/link-info":39,"./features/split-chat":42,"./helpers/debug":44,"./keycodes":48,"./settings":51,"./socketio":52,"./storage":53,"./twitch-api":60,"./vars":61}],13:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 module.exports = function () {
@@ -2447,7 +2488,7 @@ module.exports = function () {
     App.__container__.lookup('controller:channel').send('toggleTheatre');
 }
 
-},{"../helpers/debug":43}],14:[function(require,module,exports){
+},{"../helpers/debug":44}],14:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -2488,7 +2529,7 @@ module.exports = function () {
         $('body').append("<style>.ember-chat .chat-interface { height: 140px !important; } .ember-chat .chat-messages { bottom: 140px; } .ember-chat .chat-settings { bottom: 80px; } .ember-chat .emoticon-selector { bottom: 142px !important; }</style>");
     }
 }
-},{"../helpers/debug":43,"../vars":60}],15:[function(require,module,exports){
+},{"../helpers/debug":44,"../vars":61}],15:[function(require,module,exports){
 var debug = require('../helpers/debug');
 var betaChat = require('./beta-chat');
 
@@ -2555,7 +2596,7 @@ module.exports = function () {
     // Run Beta Chat After BTTV CSS
     betaChat();
 };
-},{"../helpers/debug":43,"./beta-chat":14}],16:[function(require,module,exports){
+},{"../helpers/debug":44,"./beta-chat":14}],16:[function(require,module,exports){
 var debug = require('../../helpers/debug'),
     vars = require('../../vars');
 
@@ -2613,7 +2654,7 @@ var handleResize = module.exports = function () {
 
     $("#channel_panels").masonry("reload");
 };
-},{"../../helpers/debug":43,"../../vars":60}],17:[function(require,module,exports){
+},{"../../helpers/debug":44,"../../vars":61}],17:[function(require,module,exports){
 var debug = require('../../helpers/debug'),
     keyCodes = require('../../keycodes'),
     vars = require('../../vars');
@@ -2772,7 +2813,7 @@ module.exports = function () {
         bttv.settings.save("chatWidth", $("#right_col").width());
     }
 }
-},{"../../helpers/debug":43,"../../keycodes":47,"../../vars":60,"./handle-resize":16,"./twitchcast":18}],18:[function(require,module,exports){
+},{"../../helpers/debug":44,"../../keycodes":48,"../../vars":61,"./handle-resize":16,"./twitchcast":18}],18:[function(require,module,exports){
 module.exports = function() {
     if($('.archive_info').length) return;
     
@@ -2948,7 +2989,7 @@ module.exports = function() {
     });
 };
 
-},{"../helpers/debug":43,"../helpers/element":44,"../templates/chat-settings":53,"../vars":60,"./darken-page":26,"./split-chat":41}],20:[function(require,module,exports){
+},{"../helpers/debug":44,"../helpers/element":45,"../templates/chat-settings":54,"../vars":61,"./darken-page":26,"./split-chat":42}],20:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 var checkBroadcastInfo = module.exports = function() {
@@ -2983,7 +3024,7 @@ var checkBroadcastInfo = module.exports = function() {
         setTimeout(checkBroadcastInfo, 60000);
     });
 }
-},{"../helpers/debug":43}],21:[function(require,module,exports){
+},{"../helpers/debug":44}],21:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -3050,7 +3091,7 @@ var checkFollowing = module.exports = function () {
         setTimeout(checkFollowing, 60000);
     });
 }
-},{"../helpers/debug":43,"../vars":60}],22:[function(require,module,exports){
+},{"../helpers/debug":44,"../vars":61}],22:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -3141,7 +3182,7 @@ module.exports = function () {
     setInterval(checkOther, 30000);
     checkOther();
 }
-},{"../helpers/debug":43,"../vars":60}],23:[function(require,module,exports){
+},{"../helpers/debug":44,"../vars":61}],23:[function(require,module,exports){
 var debug = require('../helpers/debug'),
 	removeElement = require('../helpers/element').remove;
 
@@ -3158,7 +3199,7 @@ module.exports = function () {
         $('body').append('<style>#nav_games, #nav_streams, #nav_related_streams { display: none; }</style>');
     }
 }
-},{"../helpers/debug":43,"../helpers/element":44}],24:[function(require,module,exports){
+},{"../helpers/debug":44,"../helpers/element":45}],24:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars'),
     removeElement = require('../helpers/element').remove;
@@ -3225,7 +3266,7 @@ module.exports = function () {
         $(this).parent("li").addClass("active");
     });
 };
-},{"../helpers/debug":43,"../helpers/element":44,"../templates/settings-panel":58,"../vars":60,"./darken-page":26,"./split-chat":41}],25:[function(require,module,exports){
+},{"../helpers/debug":44,"../helpers/element":45,"../templates/settings-panel":59,"../vars":61,"./darken-page":26,"./split-chat":42}],25:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 function load(file, key){
@@ -3244,7 +3285,7 @@ function unload(key){
 
 module.exports.load = load;
 module.exports.unload = unload; 
-},{"../helpers/debug":43}],26:[function(require,module,exports){
+},{"../helpers/debug":44}],26:[function(require,module,exports){
 https:var debug = require('../helpers/debug'),
     handleBackground = require('./handle-background');
 
@@ -3282,7 +3323,7 @@ module.exports = function () {
     }
 
 }
-},{"../helpers/debug":43,"./handle-background":34}],27:[function(require,module,exports){
+},{"../helpers/debug":44,"./handle-background":34}],27:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -3368,7 +3409,7 @@ module.exports = function dashboardChannelInfo() {
         setTimeout(dashboardChannelInfo, 60000);
     }
 };
-},{"../helpers/debug":43,"../vars":60}],28:[function(require,module,exports){
+},{"../helpers/debug":44,"../vars":61}],28:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -3391,7 +3432,7 @@ module.exports = function () {
         }
     });
 }
-},{"../helpers/debug":43,"../vars":60}],29:[function(require,module,exports){
+},{"../helpers/debug":44,"../vars":61}],29:[function(require,module,exports){
 var debug = require('../helpers/debug');
 var pollTemplate = require('../templates/embedded-poll');
 var chatHelpers = require('../chat/helpers');
@@ -3456,7 +3497,7 @@ module.exports = function (message) {
     lastPollId = pollId;
 }
 
-},{"../chat/helpers":5,"../helpers/debug":43,"../templates/embedded-poll":55}],30:[function(require,module,exports){
+},{"../chat/helpers":5,"../helpers/debug":44,"../templates/embedded-poll":56}],30:[function(require,module,exports){
 // Add an event listener to the "copy" event that fires when text is copied to
 // the clipboard to convert any emoticons within the text selection to the
 // corresponding text that will create the emoticon. This allows copy/pasted
@@ -3533,7 +3574,7 @@ module.exports = function () {
     }
 }
 
-},{"../helpers/debug":43}],32:[function(require,module,exports){
+},{"../helpers/debug":44}],32:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 module.exports = function () {
@@ -3553,7 +3594,7 @@ module.exports = function () {
     }
 }
 
-},{"../helpers/debug":43}],33:[function(require,module,exports){
+},{"../helpers/debug":44}],33:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 module.exports = function () {
@@ -3575,7 +3616,7 @@ module.exports = function () {
         });
     }
 };
-},{"../helpers/debug":43}],34:[function(require,module,exports){
+},{"../helpers/debug":44}],34:[function(require,module,exports){
 module.exports = function handleBackground(tiled) {
     var tiled = tiled || false;
     
@@ -3696,7 +3737,7 @@ module.exports = function () {
         }, 1000);
     }
 }
-},{"../helpers/debug":43}],36:[function(require,module,exports){
+},{"../helpers/debug":44}],36:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 var ts_tink;
@@ -3714,7 +3755,7 @@ module.exports = function () {
     };
 };
 
-},{"../helpers/debug":43}],37:[function(require,module,exports){
+},{"../helpers/debug":44}],37:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 var enablePreview = exports.enablePreview = function() {
@@ -3746,7 +3787,7 @@ var disablePreview = exports.disablePreview = function() {
     $(document).off('mouseenter mouseleave mousemove', 'a.chat-preview');
 };
 
-},{"../helpers/debug":43}],38:[function(require,module,exports){
+},{"../helpers/debug":44}],38:[function(require,module,exports){
 var vars = require('../vars');
 var escapeRegExp = require('../helpers/regex').escapeRegExp;
 
@@ -3843,7 +3884,89 @@ exports.highlighting = function (data) {
 
     return false;
 }
-},{"../features/highlight-feedback":36,"../helpers/regex":46,"../vars":60}],39:[function(require,module,exports){
+},{"../features/highlight-feedback":36,"../helpers/regex":47,"../vars":61}],39:[function(require,module,exports){
+
+/* CONFIG */
+var refreshTime = 10 * 1000;
+
+/* END CONFIG */
+
+var lookup = {
+    'youtube': function(link, data, callback) {
+        $.getJSON('https://www.youtube.com/oembed?url=' + data + '&format=json').done(function(d) { /// REQUIRES ATTENTION: change to BTTV API
+            (typeof d === 'object' && typeof d.title === 'string') ? callback(d.title) : callback(false);
+        }).error(function() {
+            callback(false);
+        });
+    },
+    'tiny': function(link, data, callback) {
+        $.getJSON('http://api.unshorten.it?shortURL=' + data + '&responseFormat=json&apiKey=' + 'YOUR_API_KEY').done(function(d) { /// REQUIRES ATTENTION: insert API key
+            (typeof d === 'object' && typeof d.fullurl === 'string') ? callback(d.fullurl) : callback(false);
+        }).error(function() {
+            callback(false);
+        });
+    },
+    'twitch': function(link, data, callback) {
+        bttv.TwitchAPI.get('streams/' + data).done(function(d) {
+            (typeof d === 'object' && d.stream !== null) ? callback('This channel is:<br><div style="color: rgb(0, 255, 0);">LIVE NOW</div>') : callback('This channel is:<br><div style="color: rgb(255, 0, 0);">OFFLINE</div>');
+            setTimeout(function() {cache[link] = undefined;} , refreshTime);
+        }).fail(function() {
+            callback(false);
+            setTimeout(function() {cache[link] = undefined;} , refreshTime);
+        });
+    },
+};
+
+var enableLinkInfo = exports.enableLinkInfo = function() {
+    /* CONFIG */
+    var xOffset = 0,
+        yOffset = -23;
+
+    /* END CONFIG */
+    $(document).on({
+        mouseenter: function (e) {
+            var type = $(this).attr('link-type')
+            var data = decodeURIComponent($(this).attr('link-data'));
+            var link = this.href
+            currentTarget = link;
+            if (typeof cache[link] === 'undefined') {
+                cache[link] = false;
+                $("body").append('<div id="info-link-box" style="display: block; visibility: visible; opacity: 0.8;"><div class="tipsy-inner"><div style="color: rgb(127, 127, 127);">Loading...</div></div></div>');
+                lookup[type](link, data, function(returned) {
+                    cache[link] = returned || '<div style="color: rgb(127, 127, 127);">Failed to load.</div>';
+                    if (link === currentTarget) $("#info-link-box div.tipsy-inner").html(cache[link]);
+                });
+            } else if (cache[link]) {
+                $("body").append('<div id="info-link-box" style="display: block; visibility: visible; opacity: 0.8;"><div class="tipsy-inner">' + cache[link] + '</div></div>');
+            } else {
+                $("body").append('<div id="info-link-box" style="display: block; visibility: visible; opacity: 0.8;"><div class="tipsy-inner"><div style="color: rgb(127, 127, 127);">Loading...</div></div></div>');
+            }
+            $("#info-link-box")
+                .css("top",(e.pageY - yOffset) + "px")
+                .css("left", (e.pageX - xOffset) + "px")
+                .css("position", "absolute")
+                .css("z-index", '100')
+                .fadeIn("fast");
+        }, mouseleave: function (e) {
+            currentTarget = false;
+            $("#info-link-box").remove();
+        }, mousemove: function (e) {
+            $("#info-link-box")
+            .css("top",(e.pageY - yOffset) + "px")
+            .css("left",(e.pageX + xOffset) + "px");
+        }
+    }, 'a.info-link');
+};
+
+var disableLinkInfo = exports.disableLinkInfo = function() {
+    $(document).off('mouseenter mouseleave mousemove', 'a.info-link');
+};
+
+var cache = {};
+
+var currentTarget = false;
+
+},{}],40:[function(require,module,exports){
 module.exports = function(user, $event) {
     var template = bttv.chat.templates.moderationCard(user, $event.offset().top, $('.chat-line:last').offset().left);
     $('.ember-chat .moderation-card').remove();
@@ -3954,7 +4077,7 @@ module.exports = function(user, $event) {
     });
 }
 
-},{}],40:[function(require,module,exports){
+},{}],41:[function(require,module,exports){
 var debug = require('../helpers/debug'),
     vars = require('../vars');
 
@@ -4038,7 +4161,7 @@ module.exports = function () {
         generate(data);
     });
 };
-},{"../helpers/debug":43,"../vars":60}],41:[function(require,module,exports){
+},{"../helpers/debug":44,"../vars":61}],42:[function(require,module,exports){
 var debug = require('../helpers/debug');
 
 module.exports = function () {
@@ -4053,7 +4176,7 @@ module.exports = function () {
         $('body').append(splitCSS);
     }
 }
-},{"../helpers/debug":43}],42:[function(require,module,exports){
+},{"../helpers/debug":44}],43:[function(require,module,exports){
 var calculateColorBackground = exports.calculateColorBackground = function (color) {
     // Converts HEX to YIQ to judge what color background the color would look best on
     color = String(color).replace(/[^0-9a-f]/gi, '');
@@ -4190,13 +4313,13 @@ var getHex = exports.getHex = function (color) {
     return '#'+convert(color['r'])+convert(color['g'])+convert(color['b']);
 };
 
-},{}],43:[function(require,module,exports){
+},{}],44:[function(require,module,exports){
 module.exports = {
     log: function(string) {
         if(window.console && console.log && bttv.settings.get('consoleLog') === true) console.log("BTTV: " + string);
     }
 };
-},{}],44:[function(require,module,exports){
+},{}],45:[function(require,module,exports){
 exports.remove = function (e) {
     // Removes all of an element
     $(e).each(function () {
@@ -4209,7 +4332,7 @@ exports.display = function (e) {
         $(this).show();
     });
 };
-},{}],45:[function(require,module,exports){
+},{}],46:[function(require,module,exports){
 /* FileSaver.js
  * A saveAs() FileSaver implementation.
  * 2015-05-07.2
@@ -4463,7 +4586,7 @@ if (typeof module !== "undefined" && module.exports) {
     return saveAs;
   });
 }
-},{}],46:[function(require,module,exports){
+},{}],47:[function(require,module,exports){
 exports.escapeRegExp = function (text) {
     // Escapes an input to make it usable for regexes
     return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, "\\$&");
@@ -4486,7 +4609,7 @@ exports.getEmoteFromRegEx = function(regex) {
         .replace(/^\\b|\\b$/g, '') // remove boundaries
         .replace(/\\/g, ''); // unescape
 }
-},{}],47:[function(require,module,exports){
+},{}],48:[function(require,module,exports){
 module.exports = {
     'LeftClick': 1,
     'Backspace': 8,
@@ -4577,7 +4700,7 @@ module.exports = {
     'Slash': 191,
     'Backslash': 220
 }
-},{}],48:[function(require,module,exports){
+},{}],49:[function(require,module,exports){
 module.exports = function (data) {
     return {
         //Developers and Supporters
@@ -4643,7 +4766,7 @@ module.exports = function (data) {
         "ackleyman": { mod: true, tagType: "orange", tagName: "Ack" }
     };
 };
-},{}],49:[function(require,module,exports){
+},{}],50:[function(require,module,exports){
 /** BTTV :
  * cssBlueButtons
  * handleTwitchChatEmotesScript
@@ -4837,12 +4960,6 @@ module.exports = [
         }
     },*/
     {
-        name: 'Disable whispers',
-        description: 'Disables the twitch whisper functionalitiy, hiding any whispers you recieve',
-        default: false,
-        storageKey: 'disableWhispers'
-    },
-    {
         name: 'Embedded Polling',
         description: 'See polls posted by the broadcaster embedded right into chat',
         default: true,
@@ -4911,7 +5028,7 @@ module.exports = [
     },
     {
         name: 'Mod Card Keybinds',
-        description: 'Enable keybinds when you click on a username: P(urge), T(imeout), B(an), W(whisper)',
+        description: 'Enable keybinds when you click on a username: P(urge), T(imeout), B(an)',
         default: false,
         storageKey: 'modcardsKeybinds'
     },
@@ -4969,6 +5086,12 @@ module.exports = [
         toggle: function(value) {
             channelReformat();
         }
+    },
+    {
+        name: 'Link Info',
+        description: 'Adds video titles to YouTube links, and the full URL to shortened links (such as bit.ly and goo.gl)',
+        default: true,
+        storageKey: 'linkInfo'
     },
     {
         default: '',
@@ -5078,7 +5201,7 @@ module.exports = [
     }
 ];
 
-},{"./features/auto-theatre-mode":13,"./features/beta-chat":14,"./features/channel-reformat":17,"./features/css-loader":25,"./features/darken-page":26,"./features/flip-dashboard":31,"./features/handle-background":34,"./features/image-preview":37,"./features/split-chat":41,"./helpers/element":44}],50:[function(require,module,exports){
+},{"./features/auto-theatre-mode":13,"./features/beta-chat":14,"./features/channel-reformat":17,"./features/css-loader":25,"./features/darken-page":26,"./features/flip-dashboard":31,"./features/handle-background":34,"./features/image-preview":37,"./features/split-chat":42,"./helpers/element":45}],51:[function(require,module,exports){
 var saveAs = require('./helpers/filesaver').saveAs;
 
 function Settings() {
@@ -5255,7 +5378,7 @@ Settings.prototype.popup = function() {
 }
 
 module.exports = Settings;
-},{"./helpers/filesaver":45,"./settings-list":49,"./templates/setting-switch":57}],51:[function(require,module,exports){
+},{"./helpers/filesaver":46,"./settings-list":50,"./templates/setting-switch":58}],52:[function(require,module,exports){
 var io = require('socket.io-client');
 var debug = require('./helpers/debug');
 var vars = require('./vars');
@@ -5355,7 +5478,7 @@ SocketClient.prototype.giveEmoteTip = function(channel) {
 }
 
 module.exports = SocketClient;
-},{"./helpers/debug":43,"./vars":60,"socket.io-client":63}],52:[function(require,module,exports){
+},{"./helpers/debug":44,"./vars":61,"socket.io-client":64}],53:[function(require,module,exports){
 var cookies = require('cookies-js');
 var debug = require('./helpers/debug');
 
@@ -5431,7 +5554,7 @@ Storage.prototype.spliceObject = function(item, key) {
 }
 
 module.exports = Storage;
-},{"./helpers/debug":43,"cookies-js":61}],53:[function(require,module,exports){
+},{"./helpers/debug":44,"cookies-js":62}],54:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -5457,7 +5580,7 @@ buf.push("</a></p>");
 }
 buf.push("<p><input type=\"checkbox\"" + (jade.attr("checked", bttv.settings.get("darkenedMode"), true, false)) + " class=\"toggleDarkenTTV\"/>Dark Mode</p><p><a href=\"#\" class=\"g18_gear-00000080 setBlacklistKeywords\">Set Blacklist Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setHighlightKeywords\">Set Highlight Keywords</a></p><p><a href=\"#\" class=\"g18_gear-00000080 setScrollbackAmount\">Set Scrollback Amount</a></p><p><a href=\"#\" class=\"g18_trash-00000080 clearChat\">Clear My Chat</a></p><p><a href=\"#\" style=\"display: block;margin-top: 8px;text-align: center;\" class=\"button-simple dark openSettings\">BetterTTV Settings</a></p></div>");}.call(this,"$" in locals_for_with?locals_for_with.$:typeof $!=="undefined"?$:undefined,"window" in locals_for_with?locals_for_with.window:typeof window!=="undefined"?window:undefined,"bttv" in locals_for_with?locals_for_with.bttv:typeof bttv!=="undefined"?bttv:undefined));;return buf.join("");
 };module.exports=template;
-},{}],54:[function(require,module,exports){
+},{}],55:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -5490,7 +5613,7 @@ buf.push("<div" + (jade.cls([highlighted], [true])) + "><div class=\"suggestion\
 
 buf.push("</div>");}.call(this,"suggestions" in locals_for_with?locals_for_with.suggestions:typeof suggestions!=="undefined"?suggestions:undefined,"index" in locals_for_with?locals_for_with.index:typeof index!=="undefined"?index:undefined));;return buf.join("");
 };module.exports=template;
-},{}],55:[function(require,module,exports){
+},{}],56:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -5498,7 +5621,7 @@ var jade_interp;
 ;var locals_for_with = (locals || {});(function (pollId) {
 buf.push("<div id=\"bttv-poll-contain\"><div class=\"title\">New poll available! <span style=\"text-decoration: underline;\">Vote now!</span></div><div class=\"close\"><svg height=\"16px\" version=\"1.1\" viewbox=\"0 0 16 16\" width=\"16px\" x=\"0px\" y=\"0px\" class=\"svg-close\"><path clip-rule=\"evenodd\" d=\"M13.657,3.757L9.414,8l4.243,4.242l-1.415,1.415L8,9.414l-4.243,4.243l-1.414-1.415L6.586,8L2.343,3.757l1.414-1.414L8,6.586l4.242-4.243L13.657,3.757z\" fill-rule=\"evenodd\"></path></svg></div><iframe" + (jade.attr("src", 'https://strawpoll.me/embed_2/' + (pollId) + '', true, false)) + " class=\"frame\"></iframe></div>");}.call(this,"pollId" in locals_for_with?locals_for_with.pollId:typeof pollId!=="undefined"?pollId:undefined));;return buf.join("");
 };module.exports=template;
-},{}],56:[function(require,module,exports){
+},{}],57:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -5531,7 +5654,7 @@ buf.push("</div>");
 }
 buf.push("</div>");}.call(this,"require" in locals_for_with?locals_for_with.require:typeof require!=="undefined"?require:undefined,"user" in locals_for_with?locals_for_with.user:typeof user!=="undefined"?user:undefined,"top" in locals_for_with?locals_for_with.top:typeof top!=="undefined"?top:undefined,"left" in locals_for_with?locals_for_with.left:typeof left!=="undefined"?left:undefined,"Twitch" in locals_for_with?locals_for_with.Twitch:typeof Twitch!=="undefined"?Twitch:undefined,"bttv" in locals_for_with?locals_for_with.bttv:typeof bttv!=="undefined"?bttv:undefined));;return buf.join("");
 };module.exports=template;
-},{"../vars":60}],57:[function(require,module,exports){
+},{"../vars":61}],58:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -5539,7 +5662,7 @@ var jade_interp;
 ;var locals_for_with = (locals || {});(function (storageKey, name, description) {
 buf.push("<div" + (jade.cls(['option',"bttvOption-" + (storageKey) + ""], [null,true])) + "><span style=\"font-weight:bold;font-size:14px;color:#D3D3D3;\">" + (jade.escape(null == (jade_interp = name) ? "" : jade_interp)) + "</span>&nbsp;&nbsp;&mdash;&nbsp;&nbsp;" + (jade.escape(null == (jade_interp = description) ? "" : jade_interp)) + "<div class=\"bttv-switch\"><input type=\"radio\"" + (jade.attr("name", storageKey, true, false)) + " value=\"false\"" + (jade.attr("id", "" + (storageKey) + "False", true, false)) + " class=\"bttv-switch-input bttv-switch-off\"/><label" + (jade.attr("for", "" + (storageKey) + "False", true, false)) + " class=\"bttv-switch-label bttv-switch-label-off\">Off</label><input type=\"radio\"" + (jade.attr("name", storageKey, true, false)) + " value=\"true\"" + (jade.attr("id", "" + (storageKey) + "True", true, false)) + " class=\"bttv-switch-input\"/><label" + (jade.attr("for", "" + (storageKey) + "True", true, false)) + " class=\"bttv-switch-label bttv-switch-label-on\">On</label><span class=\"bttv-switch-selection\"></span></div></div>");}.call(this,"storageKey" in locals_for_with?locals_for_with.storageKey:typeof storageKey!=="undefined"?storageKey:undefined,"name" in locals_for_with?locals_for_with.name:typeof name!=="undefined"?name:undefined,"description" in locals_for_with?locals_for_with.description:typeof description!=="undefined"?description:undefined));;return buf.join("");
 };module.exports=template;
-},{}],58:[function(require,module,exports){
+},{}],59:[function(require,module,exports){
 function template(locals) {
 var buf = [];
 var jade_mixins = {};
@@ -5547,7 +5670,7 @@ var jade_interp;
 ;var locals_for_with = (locals || {});(function (bttv) {
 buf.push("<div id=\"header\"><span id=\"logo\"><img height=\"45px\" src=\"https://cdn.betterttv.net/style/logos/settings_logo.png\"/></span><ul class=\"nav\"><li><a href=\"#bttvAbout\">About</a></li><li class=\"active\"><a href=\"#bttvSettings\">Settings</a></li><li><a href=\"#bttvChannel\" target=\"_blank\">Channel</a></li><li><a href=\"#bttvChangelog\">Changelog</a></li><li><a href=\"#bttvPrivacy\">Privacy Policy</a></li><li><a href=\"#bttvBackup\">Backup/Import</a></li></ul><span id=\"close\">&times;</span></div><div id=\"bttvSettings\" style=\"height:425px;\" class=\"scroll scroll-dark\"><div class=\"tse-content options-list\"><h2 class=\"option\">Here you can manage the various BetterTTV options. Click On or Off to toggle settings.</h2></div></div><div id=\"bttvAbout\" style=\"display:none;\"><div class=\"aboutHalf\"><img src=\"https://cdn.betterttv.net/style/logos/mascot.png\" class=\"bttvAboutIcon\"/><h1>BetterTTV v " + (jade.escape((jade_interp = bttv.info.versionString()) == null ? '' : jade_interp)) + "</h1><h2>from your friends at <a href=\"https://www.nightdev.com\" target=\"_blank\">NightDev</a></h2><br/></div><div class=\"aboutHalf\"><h1 style=\"margin-top: 100px;\">Think this addon is awesome?</h1><br/><br/><h2><a target=\"_blank\" href=\"https://chrome.google.com/webstore/detail/ajopnjidmegmdimjlfnijceegpefgped\">Drop a Review on the Chrome Webstore</a></h2><br/><h2>or maybe</h2><br/><h2><a target=\"_blank\" href=\"https://streamtip.com/t/night\">Support the Developer</a></h2><br/></div></div><div id=\"bttvChannel\" style=\"display:none;\"><iframe src=\"https://manage.betterttv.net\" frameborder=\"0\" width=\"100%\" height=\"425\"></iframe></div><div id=\"bttvPrivacy\" style=\"display:none;height:425px;\" class=\"scroll scroll-dark\"><div class=\"tse-content\"></div></div><div id=\"bttvChangelog\" style=\"display:none;height:425px;\" class=\"scroll scroll-dark\"><div class=\"tse-content\"></div></div><div id=\"bttvBackup\" style=\"display:none;height:425px;padding:25px;\"><h1 style=\"padding-bottom:15px;\">Backup Settings</h1><button id=\"bttvBackupButton\" class=\"primary_button\"><span>Download</span></button><h1 style=\"padding-top:25px;padding-bottom:15px;\">Import Settings</h1><input id=\"bttvImportInput\" type=\"file\" style=\"height: 25px;width: 250px;\"/></div><div id=\"footer\"><span>BetterTTV &copy; <a href=\"https://www.nightdev.com\" target=\"_blank\">NightDev, LLC</a> 2015</span><span style=\"float:right;\"><a href=\"https://community.nightdev.com/c/betterttv\" target=\"_blank\">Get Support</a> | <a href=\"https://github.com/night/BetterTTV/issues/new?labels=bug\" target=\"_blank\">Report a Bug</a> | <a href=\"https://streamtip.com/t/night\" target=\"_blank\">Support the Developer</a></span></div>");}.call(this,"bttv" in locals_for_with?locals_for_with.bttv:typeof bttv!=="undefined"?bttv:undefined));;return buf.join("");
 };module.exports=template;
-},{}],59:[function(require,module,exports){
+},{}],60:[function(require,module,exports){
 module.exports = {
     _ref: null,
     _headers: function(e, t) {
@@ -5592,7 +5715,7 @@ module.exports = {
         return this._call('del', url);
     }
 };
-},{}],60:[function(require,module,exports){
+},{}],61:[function(require,module,exports){
 module.exports = {
     userData: {
         isLoggedIn: window.Twitch ? Twitch.user.isLoggedIn() : false,
@@ -5602,7 +5725,7 @@ module.exports = {
     liveChannels: [],
     blackChat: false
 };
-},{}],61:[function(require,module,exports){
+},{}],62:[function(require,module,exports){
 /*
  * Cookies.js - 1.2.1
  * https://github.com/ScottHamper/Cookies
@@ -5764,7 +5887,7 @@ module.exports = {
         global.Cookies = cookiesExport;
     }
 })(typeof window === 'undefined' ? this : window);
-},{}],62:[function(require,module,exports){
+},{}],63:[function(require,module,exports){
 (function (global){
 /*! http://mths.be/punycode v1.2.4 by @mathias */
 ;(function(root) {
@@ -6275,11 +6398,11 @@ module.exports = {
 }(this));
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],63:[function(require,module,exports){
+},{}],64:[function(require,module,exports){
 
 module.exports = require('./lib/');
 
-},{"./lib/":64}],64:[function(require,module,exports){
+},{"./lib/":65}],65:[function(require,module,exports){
 
 /**
  * Module dependencies.
@@ -6368,7 +6491,7 @@ exports.connect = lookup;
 exports.Manager = require('./manager');
 exports.Socket = require('./socket');
 
-},{"./manager":65,"./socket":67,"./url":68,"debug":72,"socket.io-parser":108}],65:[function(require,module,exports){
+},{"./manager":66,"./socket":68,"./url":69,"debug":73,"socket.io-parser":109}],66:[function(require,module,exports){
 
 /**
  * Module dependencies.
@@ -6873,7 +6996,7 @@ Manager.prototype.onreconnect = function(){
   this.emitAll('reconnect', attempt);
 };
 
-},{"./on":66,"./socket":67,"./url":68,"backo2":69,"component-bind":70,"component-emitter":71,"debug":72,"engine.io-client":73,"indexof":104,"object-component":105,"socket.io-parser":108}],66:[function(require,module,exports){
+},{"./on":67,"./socket":68,"./url":69,"backo2":70,"component-bind":71,"component-emitter":72,"debug":73,"engine.io-client":74,"indexof":105,"object-component":106,"socket.io-parser":109}],67:[function(require,module,exports){
 
 /**
  * Module exports.
@@ -6899,7 +7022,7 @@ function on(obj, ev, fn) {
   };
 }
 
-},{}],67:[function(require,module,exports){
+},{}],68:[function(require,module,exports){
 
 /**
  * Module dependencies.
@@ -7286,7 +7409,7 @@ Socket.prototype.disconnect = function(){
   return this;
 };
 
-},{"./on":66,"component-bind":70,"component-emitter":71,"debug":72,"has-binary":102,"socket.io-parser":108,"to-array":112}],68:[function(require,module,exports){
+},{"./on":67,"component-bind":71,"component-emitter":72,"debug":73,"has-binary":103,"socket.io-parser":109,"to-array":113}],69:[function(require,module,exports){
 (function (global){
 
 /**
@@ -7363,7 +7486,7 @@ function url(uri, loc){
 }
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"debug":72,"parseuri":106}],69:[function(require,module,exports){
+},{"debug":73,"parseuri":107}],70:[function(require,module,exports){
 
 /**
  * Expose `Backoff`.
@@ -7450,7 +7573,7 @@ Backoff.prototype.setJitter = function(jitter){
 };
 
 
-},{}],70:[function(require,module,exports){
+},{}],71:[function(require,module,exports){
 /**
  * Slice reference.
  */
@@ -7475,7 +7598,7 @@ module.exports = function(obj, fn){
   }
 };
 
-},{}],71:[function(require,module,exports){
+},{}],72:[function(require,module,exports){
 
 /**
  * Expose `Emitter`.
@@ -7641,7 +7764,7 @@ Emitter.prototype.hasListeners = function(event){
   return !! this.listeners(event).length;
 };
 
-},{}],72:[function(require,module,exports){
+},{}],73:[function(require,module,exports){
 
 /**
  * Expose `debug()` as the module.
@@ -7780,11 +7903,11 @@ try {
   if (window.localStorage) debug.enable(localStorage.debug);
 } catch(e){}
 
-},{}],73:[function(require,module,exports){
+},{}],74:[function(require,module,exports){
 
 module.exports =  require('./lib/');
 
-},{"./lib/":74}],74:[function(require,module,exports){
+},{"./lib/":75}],75:[function(require,module,exports){
 
 module.exports = require('./socket');
 
@@ -7796,7 +7919,7 @@ module.exports = require('./socket');
  */
 module.exports.parser = require('engine.io-parser');
 
-},{"./socket":75,"engine.io-parser":87}],75:[function(require,module,exports){
+},{"./socket":76,"engine.io-parser":88}],76:[function(require,module,exports){
 (function (global){
 /**
  * Module dependencies.
@@ -8505,7 +8628,7 @@ Socket.prototype.filterUpgrades = function (upgrades) {
 };
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./transport":76,"./transports":77,"component-emitter":71,"debug":84,"engine.io-parser":87,"indexof":104,"parsejson":98,"parseqs":99,"parseuri":100}],76:[function(require,module,exports){
+},{"./transport":77,"./transports":78,"component-emitter":72,"debug":85,"engine.io-parser":88,"indexof":105,"parsejson":99,"parseqs":100,"parseuri":101}],77:[function(require,module,exports){
 /**
  * Module dependencies.
  */
@@ -8666,7 +8789,7 @@ Transport.prototype.onClose = function () {
   this.emit('close');
 };
 
-},{"component-emitter":71,"engine.io-parser":87}],77:[function(require,module,exports){
+},{"component-emitter":72,"engine.io-parser":88}],78:[function(require,module,exports){
 (function (global){
 /**
  * Module dependencies
@@ -8723,7 +8846,7 @@ function polling(opts){
 }
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./polling-jsonp":78,"./polling-xhr":79,"./websocket":81,"xmlhttprequest":82}],78:[function(require,module,exports){
+},{"./polling-jsonp":79,"./polling-xhr":80,"./websocket":82,"xmlhttprequest":83}],79:[function(require,module,exports){
 (function (global){
 
 /**
@@ -8960,7 +9083,7 @@ JSONPPolling.prototype.doWrite = function (data, fn) {
 };
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./polling":80,"component-inherit":83}],79:[function(require,module,exports){
+},{"./polling":81,"component-inherit":84}],80:[function(require,module,exports){
 (function (global){
 /**
  * Module requirements.
@@ -9348,7 +9471,7 @@ function unloadHandler() {
 }
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./polling":80,"component-emitter":71,"component-inherit":83,"debug":84,"xmlhttprequest":82}],80:[function(require,module,exports){
+},{"./polling":81,"component-emitter":72,"component-inherit":84,"debug":85,"xmlhttprequest":83}],81:[function(require,module,exports){
 /**
  * Module dependencies.
  */
@@ -9595,7 +9718,7 @@ Polling.prototype.uri = function(){
   return schema + '://' + this.hostname + port + this.path + query;
 };
 
-},{"../transport":76,"component-inherit":83,"debug":84,"engine.io-parser":87,"parseqs":99,"xmlhttprequest":82}],81:[function(require,module,exports){
+},{"../transport":77,"component-inherit":84,"debug":85,"engine.io-parser":88,"parseqs":100,"xmlhttprequest":83}],82:[function(require,module,exports){
 /**
  * Module dependencies.
  */
@@ -9835,7 +9958,7 @@ WS.prototype.check = function(){
   return !!WebSocket && !('__initialize' in WebSocket && this.name === WS.prototype.name);
 };
 
-},{"../transport":76,"component-inherit":83,"debug":84,"engine.io-parser":87,"parseqs":99,"ws":101}],82:[function(require,module,exports){
+},{"../transport":77,"component-inherit":84,"debug":85,"engine.io-parser":88,"parseqs":100,"ws":102}],83:[function(require,module,exports){
 // browser shim for xmlhttprequest module
 var hasCORS = require('has-cors');
 
@@ -9873,7 +9996,7 @@ module.exports = function(opts) {
   }
 }
 
-},{"has-cors":96}],83:[function(require,module,exports){
+},{"has-cors":97}],84:[function(require,module,exports){
 
 module.exports = function(a, b){
   var fn = function(){};
@@ -9881,7 +10004,7 @@ module.exports = function(a, b){
   a.prototype = new fn;
   a.prototype.constructor = a;
 };
-},{}],84:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 
 /**
  * This is the web browser implementation of `debug()`.
@@ -10030,7 +10153,7 @@ function load() {
 
 exports.enable(load());
 
-},{"./debug":85}],85:[function(require,module,exports){
+},{"./debug":86}],86:[function(require,module,exports){
 
 /**
  * This is the common logic for both the Node.js and web browser
@@ -10229,7 +10352,7 @@ function coerce(val) {
   return val;
 }
 
-},{"ms":86}],86:[function(require,module,exports){
+},{"ms":87}],87:[function(require,module,exports){
 /**
  * Helpers.
  */
@@ -10342,7 +10465,7 @@ function plural(ms, n, name) {
   return Math.ceil(ms / n) + ' ' + name + 's';
 }
 
-},{}],87:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 (function (global){
 /**
  * Module dependencies.
@@ -10940,7 +11063,7 @@ exports.decodePayloadAsBinary = function (data, binaryType, callback) {
 };
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./keys":88,"after":89,"arraybuffer.slice":90,"base64-arraybuffer":91,"blob":92,"has-binary":93,"utf8":95}],88:[function(require,module,exports){
+},{"./keys":89,"after":90,"arraybuffer.slice":91,"base64-arraybuffer":92,"blob":93,"has-binary":94,"utf8":96}],89:[function(require,module,exports){
 
 /**
  * Gets the keys for an object.
@@ -10961,7 +11084,7 @@ module.exports = Object.keys || function keys (obj){
   return arr;
 };
 
-},{}],89:[function(require,module,exports){
+},{}],90:[function(require,module,exports){
 module.exports = after
 
 function after(count, callback, err_cb) {
@@ -10991,7 +11114,7 @@ function after(count, callback, err_cb) {
 
 function noop() {}
 
-},{}],90:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 /**
  * An abstraction for slicing an arraybuffer even when
  * ArrayBuffer.prototype.slice is not supported
@@ -11022,7 +11145,7 @@ module.exports = function(arraybuffer, start, end) {
   return result.buffer;
 };
 
-},{}],91:[function(require,module,exports){
+},{}],92:[function(require,module,exports){
 /*
  * base64-arraybuffer
  * https://github.com/niklasvh/base64-arraybuffer
@@ -11083,7 +11206,7 @@ module.exports = function(arraybuffer, start, end) {
   };
 })("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
 
-},{}],92:[function(require,module,exports){
+},{}],93:[function(require,module,exports){
 (function (global){
 /**
  * Create a blob builder even when vendor prefixes exist
@@ -11136,7 +11259,7 @@ module.exports = (function() {
 })();
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],93:[function(require,module,exports){
+},{}],94:[function(require,module,exports){
 (function (global){
 
 /*
@@ -11198,12 +11321,12 @@ function hasBinary(data) {
 }
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"isarray":94}],94:[function(require,module,exports){
+},{"isarray":95}],95:[function(require,module,exports){
 module.exports = Array.isArray || function (arr) {
   return Object.prototype.toString.call(arr) == '[object Array]';
 };
 
-},{}],95:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
 (function (global){
 /*! http://mths.be/utf8js v2.0.0 by @mathias */
 ;(function(root) {
@@ -11446,7 +11569,7 @@ module.exports = Array.isArray || function (arr) {
 }(this));
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],96:[function(require,module,exports){
+},{}],97:[function(require,module,exports){
 
 /**
  * Module dependencies.
@@ -11471,7 +11594,7 @@ try {
   module.exports = false;
 }
 
-},{"global":97}],97:[function(require,module,exports){
+},{"global":98}],98:[function(require,module,exports){
 
 /**
  * Returns `this`. Execute this without a "context" (i.e. without it being
@@ -11481,7 +11604,7 @@ try {
 
 module.exports = (function () { return this; })();
 
-},{}],98:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 (function (global){
 /**
  * JSON parse.
@@ -11516,7 +11639,7 @@ module.exports = function parsejson(data) {
   }
 };
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],99:[function(require,module,exports){
+},{}],100:[function(require,module,exports){
 /**
  * Compiles a querystring
  * Returns string representation of the object
@@ -11555,7 +11678,7 @@ exports.decode = function(qs){
   return qry;
 };
 
-},{}],100:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 /**
  * Parses an URI
  *
@@ -11596,7 +11719,7 @@ module.exports = function parseuri(str) {
     return uri;
 };
 
-},{}],101:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 
 /**
  * Module dependencies.
@@ -11641,7 +11764,7 @@ function ws(uri, protocols, opts) {
 
 if (WebSocket) ws.prototype = WebSocket.prototype;
 
-},{}],102:[function(require,module,exports){
+},{}],103:[function(require,module,exports){
 (function (global){
 
 /*
@@ -11703,9 +11826,9 @@ function hasBinary(data) {
 }
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"isarray":103}],103:[function(require,module,exports){
-module.exports=require(94)
-},{}],104:[function(require,module,exports){
+},{"isarray":104}],104:[function(require,module,exports){
+module.exports=require(95)
+},{}],105:[function(require,module,exports){
 
 var indexOf = [].indexOf;
 
@@ -11716,7 +11839,7 @@ module.exports = function(arr, obj){
   }
   return -1;
 };
-},{}],105:[function(require,module,exports){
+},{}],106:[function(require,module,exports){
 
 /**
  * HOP ref.
@@ -11801,7 +11924,7 @@ exports.length = function(obj){
 exports.isEmpty = function(obj){
   return 0 == exports.length(obj);
 };
-},{}],106:[function(require,module,exports){
+},{}],107:[function(require,module,exports){
 /**
  * Parses an URI
  *
@@ -11828,7 +11951,7 @@ module.exports = function parseuri(str) {
   return uri;
 };
 
-},{}],107:[function(require,module,exports){
+},{}],108:[function(require,module,exports){
 (function (global){
 /*global Blob,File*/
 
@@ -11973,7 +12096,7 @@ exports.removeBlobs = function(data, callback) {
 };
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./is-buffer":109,"isarray":110}],108:[function(require,module,exports){
+},{"./is-buffer":110,"isarray":111}],109:[function(require,module,exports){
 
 /**
  * Module dependencies.
@@ -12375,7 +12498,7 @@ function error(data){
   };
 }
 
-},{"./binary":107,"./is-buffer":109,"component-emitter":71,"debug":72,"isarray":110,"json3":111}],109:[function(require,module,exports){
+},{"./binary":108,"./is-buffer":110,"component-emitter":72,"debug":73,"isarray":111,"json3":112}],110:[function(require,module,exports){
 (function (global){
 
 module.exports = isBuf;
@@ -12392,9 +12515,9 @@ function isBuf(obj) {
 }
 
 }).call(this,typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],110:[function(require,module,exports){
-module.exports=require(94)
 },{}],111:[function(require,module,exports){
+module.exports=require(95)
+},{}],112:[function(require,module,exports){
 /*! JSON v3.2.6 | http://bestiejs.github.io/json3 | Copyright 2012-2013, Kit Cambridge | http://kit.mit-license.org */
 ;(function (window) {
   // Convenience aliases.
@@ -13257,7 +13380,7 @@ module.exports=require(94)
   }
 }(this));
 
-},{}],112:[function(require,module,exports){
+},{}],113:[function(require,module,exports){
 module.exports = toArray
 
 function toArray(list, index) {

--- a/src/chat/templates.js
+++ b/src/chat/templates.js
@@ -154,7 +154,7 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
                 piece = escape(piece);
                 var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
                     link2 = match[1];
-                if ('directory following settings login logout'.indexOf(link2) !== -1) piece = '<a href="' + link + '" target="_blank">' + piece + '</a>';
+                if (['directory','following','settings','login','logout'].indexOf(link2) !== -1) piece = '<a href="' + link + '" target="_blank">' + piece + '</a>';
                 else piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="twitch" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
                 tokenizedString[i] = piece;
                 continue;

--- a/src/chat/templates.js
+++ b/src/chat/templates.js
@@ -154,7 +154,8 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
                 piece = escape(piece);
                 var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
                     link2 = match[1];
-                piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="twitch" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
+                if ('directory following settings login logout'.indexOf(link2) !== -1) piece = '<a href="' + link + '" target="_blank">' + piece + '</a>';
+                else piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="twitch" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
                 tokenizedString[i] = piece;
                 continue;
             }

--- a/src/chat/templates.js
+++ b/src/chat/templates.js
@@ -132,6 +132,34 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
             }
         }
 
+        if(bttv.settings.get('linkInfo') === true) {
+            var match;
+            if (match = /((?:https?:\/\/)?(?:youtu\.be\/|(?:www\.)?youtube\.com\/(?:watch\?v|playlist\?list)=)[-a-zA-Z0-9_]+)[-a-zA-Z0-9@:%_\+.~#?&\/=]*/i.exec(piece)) {
+                piece = escape(piece);
+                var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
+                    link2 = match[1].replace(/^(?!(?:https?:\/\/))/i, 'http://');
+                piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="youtube" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
+                tokenizedString[i] = piece;
+                continue;
+            }
+            else if (match = /((?:https?:\/\/)?(?:www\.)?(?:bit\.ly|goo\.gl|ow\.ly|t\.co|tinyurl\.com|tr\.im)\/[-a-zA-Z0-9_]+)[-a-zA-Z0-9@:%_\+.~#?&\/=]*/i.exec(piece)) {
+                piece = escape(piece);
+                var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
+                    link2 = match[1].replace(/^(?!(?:https?:\/\/))/i, 'http://');
+                piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="tiny" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
+                tokenizedString[i] = piece;
+                continue;
+            }
+            else if (match = /(?:https?:\/\/)?(?:www\.)?twitch\.tv\/([-a-zA-Z0-9_]+)(?:\/[-a-zA-Z0-9@:%_\+.~#?&\/=]*)?/i.exec(piece)) {
+                piece = escape(piece);
+                var link = piece.replace(/^(?!(?:https?:\/\/))/i, 'http://'),
+                    link2 = match[1];
+                piece = '<a href="' + link + '" target="_blank" class="info-link" link-type="twitch" link-data="' + encodeURIComponent(link2) + '">' + piece + '</a>';
+                tokenizedString[i] = piece;
+                continue;
+            }
+        }
+
         var test = piece.replace(/(^[~!@#$%\^&\*\(\)]+|[~!@#$%\^&\*\(\)]+$)/g, '');
         var emote = null;
 

--- a/src/features/link-info.js
+++ b/src/features/link-info.js
@@ -1,6 +1,7 @@
 
 /* CONFIG */
-var refreshTime = 10 * 1000;
+var refreshTime = 60 * 1000;
+var refreshTimeTwitch = 10 * 1000;
 
 /* END CONFIG */
 
@@ -10,6 +11,7 @@ var lookup = {
             (typeof d === 'object' && typeof d.title === 'string') ? callback(d.title) : callback(false);
         }).error(function() {
             callback(false);
+            setTimeout(function() {cache[link] = undefined;} , refreshTime);
         });
     },
     'tiny': function(link, data, callback) {
@@ -17,15 +19,16 @@ var lookup = {
             (typeof d === 'object' && typeof d.fullurl === 'string') ? callback(d.fullurl) : callback(false);
         }).error(function() {
             callback(false);
+            setTimeout(function() {cache[link] = undefined;} , refreshTime);
         });
     },
     'twitch': function(link, data, callback) {
         bttv.TwitchAPI.get('streams/' + data).done(function(d) {
             (typeof d === 'object' && d.stream !== null) ? callback('This channel is:<br><div style="color: rgb(0, 255, 0);">LIVE NOW</div>') : callback('This channel is:<br><div style="color: rgb(255, 0, 0);">OFFLINE</div>');
-            setTimeout(function() {cache[link] = undefined;} , refreshTime);
+            setTimeout(function() {cache[link] = undefined;} , refreshTimeTwitch);
         }).fail(function() {
             callback(false);
-            setTimeout(function() {cache[link] = undefined;} , refreshTime);
+            setTimeout(function() {cache[link] = undefined;} , refreshTimeTwitch);
         });
     },
 };

--- a/src/features/link-info.js
+++ b/src/features/link-info.js
@@ -1,0 +1,80 @@
+
+/* CONFIG */
+var refreshTime = 10 * 1000;
+
+/* END CONFIG */
+
+var lookup = {
+    'youtube': function(link, data, callback) {
+        $.getJSON('https://www.youtube.com/oembed?url=' + data + '&format=json').done(function(d) { /// REQUIRES ATTENTION: change to BTTV API
+            (typeof d === 'object' && typeof d.title === 'string') ? callback(d.title) : callback(false);
+        }).error(function() {
+            callback(false);
+        });
+    },
+    'tiny': function(link, data, callback) {
+        $.getJSON('http://api.unshorten.it?shortURL=' + data + '&responseFormat=json&apiKey=' + 'YOUR_API_KEY').done(function(d) { /// REQUIRES ATTENTION: insert API key
+            (typeof d === 'object' && typeof d.fullurl === 'string') ? callback(d.fullurl) : callback(false);
+        }).error(function() {
+            callback(false);
+        });
+    },
+    'twitch': function(link, data, callback) {
+        bttv.TwitchAPI.get('streams/' + data).done(function(d) {
+            (typeof d === 'object' && d.stream !== null) ? callback('This channel is:<br><div style="color: rgb(0, 255, 0);">LIVE NOW</div>') : callback('This channel is:<br><div style="color: rgb(255, 0, 0);">OFFLINE</div>');
+            setTimeout(function() {cache[link] = undefined;} , refreshTime);
+        }).fail(function() {
+            callback(false);
+            setTimeout(function() {cache[link] = undefined;} , refreshTime);
+        });
+    },
+};
+
+var enableLinkInfo = exports.enableLinkInfo = function() {
+    /* CONFIG */
+    var xOffset = 0,
+        yOffset = -23;
+
+    /* END CONFIG */
+    $(document).on({
+        mouseenter: function (e) {
+            var type = $(this).attr('link-type')
+            var data = decodeURIComponent($(this).attr('link-data'));
+            var link = this.href
+            currentTarget = link;
+            if (typeof cache[link] === 'undefined') {
+                cache[link] = false;
+                $("body").append('<div id="info-link-box" style="display: block; visibility: visible; opacity: 0.8;"><div class="tipsy-inner"><div style="color: rgb(127, 127, 127);">Loading...</div></div></div>');
+                lookup[type](link, data, function(returned) {
+                    cache[link] = returned || '<div style="color: rgb(127, 127, 127);">Failed to load.</div>';
+                    if (link === currentTarget) $("#info-link-box div.tipsy-inner").html(cache[link]);
+                });
+            } else if (cache[link]) {
+                $("body").append('<div id="info-link-box" style="display: block; visibility: visible; opacity: 0.8;"><div class="tipsy-inner">' + cache[link] + '</div></div>');
+            } else {
+                $("body").append('<div id="info-link-box" style="display: block; visibility: visible; opacity: 0.8;"><div class="tipsy-inner"><div style="color: rgb(127, 127, 127);">Loading...</div></div></div>');
+            }
+            $("#info-link-box")
+                .css("top",(e.pageY - yOffset) + "px")
+                .css("left", (e.pageX - xOffset) + "px")
+                .css("position", "absolute")
+                .css("z-index", '100')
+                .fadeIn("fast");
+        }, mouseleave: function (e) {
+            currentTarget = false;
+            $("#info-link-box").remove();
+        }, mousemove: function (e) {
+            $("#info-link-box")
+            .css("top",(e.pageY - yOffset) + "px")
+            .css("left",(e.pageX + xOffset) + "px");
+        }
+    }, 'a.info-link');
+};
+
+var disableLinkInfo = exports.disableLinkInfo = function() {
+    $(document).off('mouseenter mouseleave mousemove', 'a.info-link');
+};
+
+var cache = {};
+
+var currentTarget = false;

--- a/src/main.js
+++ b/src/main.js
@@ -126,6 +126,7 @@ var clearClutter = require('./features/clear-clutter'),
     emoticonTextInClipboard = require('./features/emoticon-text-in-clipboard'),
     createSettings = require('./features/create-settings');
     enableImagePreview = require('./features/image-preview').enablePreview;
+    enableLinkInfo = require('./features/link-info').enableLinkInfo;
     enableTheatreMode = require('./features/auto-theatre-mode');
 
 var chatFunctions = function () {
@@ -260,6 +261,9 @@ var main = function () {
         emoticonTextInClipboard();
         if (bttv.settings.get('chatImagePreview') === true) {
             enableImagePreview();
+        }
+        if (bttv.settings.get('linkInfo') === true) {
+            enableLinkInfo();
         }
         if (bttv.settings.get('autoTheatreMode') === true) {
             enableTheatreMode();

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -264,6 +264,12 @@ module.exports = [
         }
     },
     {
+        name: 'Link Info',
+        description: 'Adds video titles to YouTube links, and the full URL to shortened links (such as bit.ly and goo.gl)',
+        default: true,
+        storageKey: 'linkInfo'
+    },
+    {
         name: 'Mod Card Keybinds',
         description: 'Enable keybinds when you click on a username: P(urge), T(imeout), B(an), W(whisper)',
         default: false,


### PR DESCRIPTION
Complete rewrite from last revision.  Lazy-loads the data now, as well as showing the info as soon as the mouse touches it.  The following links are supported in this revision:
-YouTube: displays the title for videos and playlists
-Twitch streams: displays the online status for Twitch links to a streamer's page or info
-URL shortening services with unshorten.it (6 supported in total): displays the expanded URL

Requiring attention:
-YouTube: ready for the YouTube oembed API lookup+caching to be implemented in the BTTV API (the YouTube API URL being used in this pull request is the same one, and is fully functional, though only with browser security disabled for testing)
-unshorten.it: night needs to register for a free API key (I tried to register for a temporary one, but it never arrived in my inbox); registration page is at http://unshorten.it/api/register

I'll continue to test and tune things while I wait to hear back, unless otherwise directed.  And then once everything is ready, I can make the final pull request.

Note:
-loading only takes a fraction of a second, I only showed the 'Loading...' text for demonstration purposes
-link unshortening was not depicted, since I don't have an API key to work with yet
-everything behaves as would be expected

![temp-temp-temp-youtube_links_hover-04-01-crop](https://cloud.githubusercontent.com/assets/11858693/8177657/03e9c1e0-13d5-11e5-9ef1-68f36d371546.png)
![temp-temp-temp-youtube_links_hover-04-02-crop](https://cloud.githubusercontent.com/assets/11858693/8177661/0916adae-13d5-11e5-9d1d-825f95f717c5.png)
![temp-temp-temp-youtube_links_hover-04-03-crop](https://cloud.githubusercontent.com/assets/11858693/8177664/0e3c5c02-13d5-11e5-82ee-14cc3c50d859.png)
![temp-temp-temp-youtube_links_hover-04-04-crop](https://cloud.githubusercontent.com/assets/11858693/8177667/12612646-13d5-11e5-84bf-9e6e0c66878a.png)


