### PR TITLE
Keep channel viewers and followers up to date

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -2968,10 +2968,10 @@ var checkBroadcastInfo = module.exports = function() {
 
     debug.log("Check Channel Title/Game");
 
-    bttv.TwitchAPI.get("channels/"+channel+"?api_version=3").done(function(d) {
+    bttv.TwitchAPI.get("channels/"+channel, {}, {version: 3}).done(function(d) {
         if(d.game) {
             var $channel = $('#broadcast-meta .channel');
-            
+
             if($channel.find('.playing').length) {
                 $channel.find('a:eq(1)').text(d.game).attr("href", Twitch.uri.game(d.game)).removeAttr('data-ember-action');
             }
@@ -5578,11 +5578,11 @@ module.exports = {
 
         bttv.TwitchAPI._ref.call(Twitch.api, e, t);
     },
-    _call: function(method, url, data) {
+    _call: function(method, url, data, options) {
         // Replace Twitch's beforeSend with ours (to add Client ID)
         var rep = this._takeover();
 
-        var callTwitchAPI = window.Twitch.api[method].call(this, url, data);
+        var callTwitchAPI = window.Twitch.api[method].call(this, url, data, options);
 
         // Replace Twitch's beforeSend back with theirs
         this._untakeover();
@@ -5602,17 +5602,17 @@ module.exports = {
         window.Twitch.api._beforeSend = this._ref;
         this._ref = null;
     },
-    get: function(url) {
-        return this._call('get', url);
+    get: function(url, data, options) {
+        return this._call('get', url, data, options);
     },
-    post: function(url, data) {
-        return this._call('post', url, data);
+    post: function(url, data, options) {
+        return this._call('post', url, data, options);
     },
-    put: function(url, data) {
-        return this._call('put', url, data);
+    put: function(url, data, options) {
+        return this._call('put', url, data, options);
     },
-    del: function(url) {
-        return this._call('del', url);
+    del: function(url, data, options) {
+        return this._call('del', url, data, options);
     }
 };
 },{}],60:[function(require,module,exports){

--- a/src/features/check-broadcast-info.js
+++ b/src/features/check-broadcast-info.js
@@ -29,6 +29,19 @@ var checkBroadcastInfo = module.exports = function() {
             }
         }
 
+        if(window.Ember && window.App) {
+            var emberCtrl = App.__container__.lookup('controller:channel');
+            if(d.views) {
+                var fmtViews = Twitch.display.commatize(d.views);
+                emberCtrl.set('views', fmtViews);
+            }
+
+            if (d.followers) {
+                var fmtFollowers = Twitch.display.commatize(d.followers);
+                emberCtrl.set('followersTotal', fmtFollowers);
+            }
+        }
+
         setTimeout(checkBroadcastInfo, 60000);
     });
 }

--- a/src/features/check-broadcast-info.js
+++ b/src/features/check-broadcast-info.js
@@ -7,7 +7,7 @@ var checkBroadcastInfo = module.exports = function() {
 
     debug.log("Check Channel Title/Game");
 
-    bttv.TwitchAPI.get("channels/"+channel).done(function(d) {
+    bttv.TwitchAPI.get("channels/"+channel+"?api_version=3").done(function(d) {
         if(d.game) {
             var $channel = $('#broadcast-meta .channel');
             

--- a/src/features/check-broadcast-info.js
+++ b/src/features/check-broadcast-info.js
@@ -7,10 +7,10 @@ var checkBroadcastInfo = module.exports = function() {
 
     debug.log("Check Channel Title/Game");
 
-    bttv.TwitchAPI.get("channels/"+channel+"?api_version=3").done(function(d) {
+    bttv.TwitchAPI.get("channels/"+channel, {}, {version: 3}).done(function(d) {
         if(d.game) {
             var $channel = $('#broadcast-meta .channel');
-            
+
             if($channel.find('.playing').length) {
                 $channel.find('a:eq(1)').text(d.game).attr("href", Twitch.uri.game(d.game)).removeAttr('data-ember-action');
             }

--- a/src/twitch-api.js
+++ b/src/twitch-api.js
@@ -5,11 +5,11 @@ module.exports = {
 
         bttv.TwitchAPI._ref.call(Twitch.api, e, t);
     },
-    _call: function(method, url, data) {
+    _call: function(method, url, data, options) {
         // Replace Twitch's beforeSend with ours (to add Client ID)
         var rep = this._takeover();
 
-        var callTwitchAPI = window.Twitch.api[method].call(this, url, data);
+        var callTwitchAPI = window.Twitch.api[method].call(this, url, data, options);
 
         // Replace Twitch's beforeSend back with theirs
         this._untakeover();
@@ -29,16 +29,16 @@ module.exports = {
         window.Twitch.api._beforeSend = this._ref;
         this._ref = null;
     },
-    get: function(url) {
-        return this._call('get', url);
+    get: function(url, data, options) {
+        return this._call('get', url, data, options);
     },
-    post: function(url, data) {
-        return this._call('post', url, data);
+    post: function(url, data, options) {
+        return this._call('post', url, data, options);
     },
-    put: function(url, data) {
-        return this._call('put', url, data);
+    put: function(url, data, options) {
+        return this._call('put', url, data, options);
     },
-    del: function(url) {
-        return this._call('del', url);
+    del: function(url, data, options) {
+        return this._call('del', url, data, options);
     }
 };


### PR DESCRIPTION
This one is for #471

It currently doesn't actually work, as the `/channels/:channel` API request seems to be V2, but the extra information needed (views and followers) are only in V3. Not quite sure where the header for the API version is set (is it in the client-id?), and I don't know how safe it is to switch to V3, but once you do, this code should work as expected, and come at no extra cost since it's done alongside the title/game update request.