### PR TITLE
Added mtgbot back to bot list.

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -305,7 +305,8 @@ module.exports = [
     "sourbot",
     "xanbot",
     "manabot",
-    "ackbot"
+    "ackbot",
+	"mtgbot"
 ];
 },{}],2:[function(require,module,exports){
 exports.tmi = require('./chat/tmi');

--- a/src/bots.js
+++ b/src/bots.js
@@ -4,5 +4,6 @@ module.exports = [
     "sourbot",
     "xanbot",
     "manabot",
-    "ackbot"
+    "ackbot",
+	"mtgbot"
 ];


### PR DESCRIPTION
MTGBot was removed a while back during the cleanup, but will be the primary bot in most of the magic channels.