### PR TITLE
Added MTGBot back to the bot list.

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -302,7 +302,8 @@ exports.DebugItem = function DebugItem(lineno, filename) {
 module.exports = [
     "nightbot",
     "moobot",
-    "xanbot"
+    "xanbot",
+    "mtgbot"
 ];
 },{}],2:[function(require,module,exports){
 exports.tmi = require('./chat/tmi');

--- a/src/bots.js
+++ b/src/bots.js
@@ -1,5 +1,6 @@
 module.exports = [
     "nightbot",
     "moobot",
-    "xanbot"
+    "xanbot",
+    "mtgbot"
 ];


### PR DESCRIPTION
I fixed the spacing issues. MTGBot will be the primary bot in all magic channels, and hopefully start making it's way into the hearthstone channels as well. I'd like it show up as a bot as it once did a year ago.