### PR TITLE
Emote only auto completion

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -1075,7 +1075,7 @@ exports.tabCompletion = function(e) {
 
             // Mix in emotes if not directly asking for a user
             if (lastWord.charAt(0) !== '@' && !detectServerCommand(input)) {
-                users = users.concat(emotes);
+                users = bttv.setting.get('emoteOnlyAutoComplete') ? emotes : users.concat(emotes);
             }
 
             if (users.indexOf(vars.userData.name) > -1) users.splice(users.indexOf(vars.userData.name), 1);
@@ -6103,6 +6103,12 @@ module.exports = [
                 $('#clickTwitchEmotes').remove();
             }
         }
+    },
+    {
+        name: 'Emote Only Auto-Complete',
+        description: 'Tab auto-completion only uses emotes',
+        default: false,
+        storageKey: 'emoteOnlyAutoComplete'
     },
     {
         name: 'Featured Channels',

--- a/src/chat/helpers.js
+++ b/src/chat/helpers.js
@@ -264,11 +264,7 @@ exports.tabCompletion = function(e) {
 
             // Mix in emotes if not directly asking for a user
             if (lastWord.charAt(0) !== '@' && !detectServerCommand(input)) {
-                if (bttv.settings.get('emoteOnlyAutoComplete') === true) {
-                    users = emotes;
-                } else {
-                    users = users.concat(emotes);
-                }
+                users = bttv.setting.get('emoteOnlyAutoComplete') ? emotes : users.concat(emotes);
             }
 
             if (users.indexOf(vars.userData.name) > -1) users.splice(users.indexOf(vars.userData.name), 1);

--- a/src/chat/helpers.js
+++ b/src/chat/helpers.js
@@ -264,7 +264,11 @@ exports.tabCompletion = function(e) {
 
             // Mix in emotes if not directly asking for a user
             if (lastWord.charAt(0) !== '@' && !detectServerCommand(input)) {
-                users = users.concat(emotes);
+                if (bttv.settings.get('emoteOnlyAutoComplete') === true) {
+                    users = emotes;
+                } else {
+                    users = users.concat(emotes);
+                }
             }
 
             if (users.indexOf(vars.userData.name) > -1) users.splice(users.indexOf(vars.userData.name), 1);

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -298,6 +298,12 @@ module.exports = [
         }
     },
     {
+        name: 'Emote Only Auto-Complete',
+        description: 'Tab auto-completion only uses emotes',
+        default: false,
+        storageKey: 'emoteOnlyAutoComplete'
+    },
+    {
         name: 'Featured Channels',
         description: 'The left sidebar is too cluttered, so BetterTTV removes featured channels by default',
         default: false,


### PR DESCRIPTION
I use @ style auto completion for users so when trying to auto complete emotes without using @ I would have to tab many times to get past users with similar names to emotes.

A couple examples:

In TriHex's stream. If I type ```tri``` the first completion would be ```Trihex, ```. With this pull request ```tri``` will complete to ```TriHard```. If I type ```kap``` at this moment in chat it brought up ```KappaMasterSwag3, ``` with the feature on it now brings up ```KappaCool``` with the next tab being ```Kappa```. Finally, ```dan``` without became ```dank__doge, ``` while with it becomes ```DansGame```.

@ style auto completion still works so I can now have the best of both worlds.

The setting headline is **Emote Only Auto-Complete** with the description **Tab auto-completion only uses emotes**. These could be changed, I'm not sure what the best would be.

Thanks for the great addon!