### PR TITLE
Regex Highlighting

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -4758,29 +4758,32 @@ exports.highlighting = function(data) {
 
     var highlightKeywords = [];
     var highlightUsers = [];
+    var i;
 
     var extraKeywords = bttv.settings.get('highlightKeywords');
+    var useRegex = bttv.settings.get('regexHighlights');
 
-    // Pull the regular expressions out first so curly braces
-    // in the expression won't double count as phrases
     var highlightRegex = [];
-    var regexPhrase = /;.+?;/g;
-    var regexStrings;
-    var i;
-    try {
-        regexStrings = extraKeywords.match(regexPhrase);
-    } catch (e) {
-        debug.log(e);
-        return false;
-    }
-    if (regexStrings) {
-        for (i = 0; i < regexStrings.length; i++) {
-            var regexString = regexStrings[i];
-            debug.log(regexString);
-            extraKeywords = extraKeywords.replace(regexString, '')
-                .replace(/s\s\s+/g, ' ').trim();
-            highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
-                                .trim());
+    if (useRegex) {
+        // Pull the regular expressions out first so curly braces
+        // in the expression won't double count as phrases
+        var regexPhrase = /;.+?;/g;
+        var regexStrings;
+        try {
+            regexStrings = extraKeywords.match(regexPhrase);
+        } catch (e) {
+            debug.log(e);
+            return false;
+        }
+        if (regexStrings) {
+            for (i = 0; i < regexStrings.length; i++) {
+                var regexString = regexStrings[i];
+                debug.log(regexString);
+                extraKeywords = extraKeywords.replace(regexString, '')
+                    .replace(/s\s\s+/g, ' ').trim();
+                highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
+                                    .trim());
+            }
         }
     }
 
@@ -4832,11 +4835,13 @@ exports.highlighting = function(data) {
         }
     }
 
-    for (i = 0; i < highlightRegex.length; i++) {
-        debug.log('Testing' + highlightRegex);
-        regex = new RegExp(highlightRegex[i], 'g');
-        if (regex.test(data.message)) {
-            return true;
+    if (useRegex) {
+        for (i = 0; i < highlightRegex.length; i++) {
+            debug.log('Testing' + highlightRegex);
+            regex = new RegExp(highlightRegex[i], 'g');
+            if (regex.test(data.message)) {
+                return true;
+            }
         }
     }
 
@@ -6314,6 +6319,12 @@ module.exports = [
         description: 'Automatically hide pinned highlights after 1 minute',
         default: false,
         storageKey: 'timeoutHighlights',
+    },
+    {
+        name: 'Regular Expression Highlighting',
+        description: 'Surround keywords with semicolons to treat them as regular expressions',
+        default: false,
+        storageKey: 'regexHighlights',
     },
     {
         default: '',

--- a/betterttv.js
+++ b/betterttv.js
@@ -588,7 +588,7 @@ exports.clearChat = function(user) {
             return false;
         });
 
-        $chatLines = $(queuedMessages.concat($chatLines));
+        $chatLines = $chatLines.length ? $(queuedMessages.concat($chatLines)) : queuedMessages;
 
         if (!$chatLines.length) return;
         if (bttv.settings.get('hideDeletedMessages') === true) {

--- a/betterttv.js
+++ b/betterttv.js
@@ -582,13 +582,17 @@ exports.clearChat = function(user) {
     if (!user) {
         helpers.serverMessage('Chat was cleared by a moderator (Prevented by BetterTTV)', true);
     } else {
-        var $chatLines = $('.chat-line[data-sender="' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + '"]');
-        var queuedMessages = store.__messageQueue.filter(function($message) {
+        var printedChatLines = [];
+        $('.chat-line[data-sender="' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + '"]').each(function() {
+            printedChatLines.push($(this));
+        });
+
+        var queuedLines = store.__messageQueue.filter(function($message) {
             if ($message.data('sender') === user) return true;
             return false;
         });
 
-        $chatLines = $chatLines.length ? $(queuedMessages.concat($chatLines)) : queuedMessages;
+        $chatLines = $(printedChatLines.concat(queuedLines));
 
         if (!$chatLines.length) return;
         if (bttv.settings.get('hideDeletedMessages') === true) {

--- a/betterttv.js
+++ b/betterttv.js
@@ -4767,7 +4767,7 @@ exports.highlighting = function(data) {
     if (useRegex) {
         // Pull the regular expressions out first so curly braces
         // in the expression won't double count as phrases
-        var regexPhrase = /;.+?;/g;
+        var regexPhrase = /\/.+?\//g;
         var regexStrings;
         try {
             regexStrings = extraKeywords.match(regexPhrase);
@@ -4781,7 +4781,7 @@ exports.highlighting = function(data) {
                 debug.log(regexString);
                 extraKeywords = extraKeywords.replace(regexString, '')
                     .replace(/s\s\s+/g, ' ').trim();
-                highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
+                highlightRegex.push(regexString.replace(/(^\/|\/$)/g, '')
                                     .trim());
             }
         }
@@ -6278,6 +6278,12 @@ module.exports = [
         storageKey: 'highlightFeedback'
     },
     {
+        name: 'Regular Expression Highlighting',
+        description: 'Surround keywords with forward slashes to use them as regular expressions',
+        default: false,
+        storageKey: 'regexHighlights',
+    },
+    {
         name: 'Remove Deleted Messages',
         description: 'Completely removes timed out messages from view',
         default: false,
@@ -6319,12 +6325,6 @@ module.exports = [
         description: 'Automatically hide pinned highlights after 1 minute',
         default: false,
         storageKey: 'timeoutHighlights',
-    },
-    {
-        name: 'Regular Expression Highlighting',
-        description: 'Surround keywords with semicolons to treat them as regular expressions',
-        default: false,
-        storageKey: 'regexHighlights',
     },
     {
         default: '',

--- a/src/chat/handlers.js
+++ b/src/chat/handlers.js
@@ -224,7 +224,7 @@ exports.clearChat = function(user) {
             return false;
         });
 
-        $chatLines = $(queuedMessages.concat($chatLines));
+        $chatLines = $chatLines.length ? $(queuedMessages.concat($chatLines)) : queuedMessages;
 
         if (!$chatLines.length) return;
         if (bttv.settings.get('hideDeletedMessages') === true) {

--- a/src/chat/handlers.js
+++ b/src/chat/handlers.js
@@ -218,13 +218,17 @@ exports.clearChat = function(user) {
     if (!user) {
         helpers.serverMessage('Chat was cleared by a moderator (Prevented by BetterTTV)', true);
     } else {
-        var $chatLines = $('.chat-line[data-sender="' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + '"]');
-        var queuedMessages = store.__messageQueue.filter(function($message) {
+        var printedChatLines = [];
+        $('.chat-line[data-sender="' + user.replace(/%/g, '_').replace(/[<>,]/g, '') + '"]').each(function() {
+            printedChatLines.push($(this));
+        });
+
+        var queuedLines = store.__messageQueue.filter(function($message) {
             if ($message.data('sender') === user) return true;
             return false;
         });
 
-        $chatLines = $chatLines.length ? $(queuedMessages.concat($chatLines)) : queuedMessages;
+        $chatLines = $(printedChatLines.concat(queuedLines));
 
         if (!$chatLines.length) return;
         if (bttv.settings.get('hideDeletedMessages') === true) {

--- a/src/features/keywords-lists.js
+++ b/src/features/keywords-lists.js
@@ -69,7 +69,7 @@ exports.highlighting = function(data) {
     if (useRegex) {
         // Pull the regular expressions out first so curly braces
         // in the expression won't double count as phrases
-        var regexPhrase = /;.+?;/g;
+        var regexPhrase = /\/.+?\//g;
         var regexStrings;
         try {
             regexStrings = extraKeywords.match(regexPhrase);
@@ -83,7 +83,7 @@ exports.highlighting = function(data) {
                 debug.log(regexString);
                 extraKeywords = extraKeywords.replace(regexString, '')
                     .replace(/s\s\s+/g, ' ').trim();
-                highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
+                highlightRegex.push(regexString.replace(/(^\/|\/$)/g, '')
                                     .trim());
             }
         }

--- a/src/features/keywords-lists.js
+++ b/src/features/keywords-lists.js
@@ -60,29 +60,32 @@ exports.highlighting = function(data) {
 
     var highlightKeywords = [];
     var highlightUsers = [];
+    var i;
 
     var extraKeywords = bttv.settings.get('highlightKeywords');
+    var useRegex = bttv.settings.get('regexHighlights');
 
-    // Pull the regular expressions out first so curly braces
-    // in the expression won't double count as phrases
     var highlightRegex = [];
-    var regexPhrase = /;.+?;/g;
-    var regexStrings;
-    var i;
-    try {
-        regexStrings = extraKeywords.match(regexPhrase);
-    } catch (e) {
-        debug.log(e);
-        return false;
-    }
-    if (regexStrings) {
-        for (i = 0; i < regexStrings.length; i++) {
-            var regexString = regexStrings[i];
-            debug.log(regexString);
-            extraKeywords = extraKeywords.replace(regexString, '')
-                .replace(/s\s\s+/g, ' ').trim();
-            highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
-                                .trim());
+    if (useRegex) {
+        // Pull the regular expressions out first so curly braces
+        // in the expression won't double count as phrases
+        var regexPhrase = /;.+?;/g;
+        var regexStrings;
+        try {
+            regexStrings = extraKeywords.match(regexPhrase);
+        } catch (e) {
+            debug.log(e);
+            return false;
+        }
+        if (regexStrings) {
+            for (i = 0; i < regexStrings.length; i++) {
+                var regexString = regexStrings[i];
+                debug.log(regexString);
+                extraKeywords = extraKeywords.replace(regexString, '')
+                    .replace(/s\s\s+/g, ' ').trim();
+                highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
+                                    .trim());
+            }
         }
     }
 
@@ -134,11 +137,13 @@ exports.highlighting = function(data) {
         }
     }
 
-    for (i = 0; i < highlightRegex.length; i++) {
-        debug.log('Testing' + highlightRegex);
-        regex = new RegExp(highlightRegex[i], 'g');
-        if (regex.test(data.message)) {
-            return true;
+    if (useRegex) {
+        for (i = 0; i < highlightRegex.length; i++) {
+            debug.log('Testing' + highlightRegex);
+            regex = new RegExp(highlightRegex[i], 'g');
+            if (regex.test(data.message)) {
+                return true;
+            }
         }
     }
 

--- a/src/features/keywords-lists.js
+++ b/src/features/keywords-lists.js
@@ -62,8 +62,31 @@ exports.highlighting = function(data) {
     var highlightUsers = [];
 
     var extraKeywords = bttv.settings.get('highlightKeywords');
-    var phraseRegex = /\{.+?\}/g;
 
+    // Pull the regular expressions out first so curly braces
+    // in the expression won't double count as phrases
+    var highlightRegex = [];
+    var regexPhrase = /;.+?;/g;
+    var regexStrings;
+    var i;
+    try {
+        regexStrings = extraKeywords.match(regexPhrase);
+    } catch (e) {
+        debug.log(e);
+        return false;
+    }
+    if (regexStrings) {
+        for (i = 0; i < regexStrings.length; i++) {
+            var regexString = regexStrings[i];
+            debug.log(regexString);
+            extraKeywords = extraKeywords.replace(regexString, '')
+                .replace(/s\s\s+/g, ' ').trim();
+            highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
+                                .trim());
+        }
+    }
+
+    var phraseRegex = /\{.+?\}/g;
     var testCases;
     try {
         testCases = extraKeywords.match(phraseRegex);
@@ -72,7 +95,6 @@ exports.highlighting = function(data) {
         return false;
     }
 
-    var i;
     if (testCases) {
         for (i = 0; i < testCases.length; i++) {
             var testCase = testCases[i];
@@ -80,6 +102,7 @@ exports.highlighting = function(data) {
             highlightKeywords.push(testCase.replace(/(^\{|\}$)/g, '').trim());
         }
     }
+
     if (extraKeywords !== '') {
         extraKeywords = extraKeywords.split(' ');
         extraKeywords.forEach(function(keyword) {
@@ -110,6 +133,15 @@ exports.highlighting = function(data) {
             return true;
         }
     }
+
+    for (i = 0; i < highlightRegex.length; i++) {
+        debug.log('Testing' + highlightRegex);
+        regex = new RegExp(highlightRegex[i], 'g');
+        if (regex.test(data.message)) {
+            return true;
+        }
+    }
+
 
     return false;
 };

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -440,6 +440,12 @@ module.exports = [
         storageKey: 'timeoutHighlights',
     },
     {
+        name: 'Regular Expression Highlighting',
+        description: 'Surround keywords with semicolons to treat them as regular expressions',
+        default: false,
+        storageKey: 'regexHighlights',
+    },
+    {
         default: '',
         storageKey: 'blacklistKeywords',
         toggle: function(keywords) {

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -397,6 +397,12 @@ module.exports = [
         storageKey: 'highlightFeedback'
     },
     {
+        name: 'Regular Expression Highlighting',
+        description: 'Surround keywords with forward slashes to use them as regular expressions',
+        default: false,
+        storageKey: 'regexHighlights',
+    },
+    {
         name: 'Remove Deleted Messages',
         description: 'Completely removes timed out messages from view',
         default: false,
@@ -438,12 +444,6 @@ module.exports = [
         description: 'Automatically hide pinned highlights after 1 minute',
         default: false,
         storageKey: 'timeoutHighlights',
-    },
-    {
-        name: 'Regular Expression Highlighting',
-        description: 'Surround keywords with semicolons to treat them as regular expressions',
-        default: false,
-        storageKey: 'regexHighlights',
     },
     {
         default: '',


### PR DESCRIPTION
This includes my modifications in order to support regular expression highlighting for messages as per Issue #267 which I created in March. It's nothing fancy, but I figure most people have no desire to use JS regular expressions so I included the option to turn it on/off. Otherwise, I made it so the user has to delimit their regular expression with semicolons, but can otherwise treat it like a regular highlight keyword -- it's not the greatest, but it worked. 

Comments, criticisms, etc. welcome. Thanks.