### PR TITLE
Added option to tab complete emotes before usernames

### DIFF
--- a/betterttv.js
+++ b/betterttv.js
@@ -1106,7 +1106,7 @@ exports.tabCompletion = function(e) {
 
             // Mix in emotes if not directly asking for a user
             if (lastWord.charAt(0) !== '@' && !detectServerCommand(input)) {
-                users = users.concat(emotes);
+                users = bttv.settings.get('emotePriority') ? emotes.concat(users) : users.concat(emotes);
             }
 
             if (users.indexOf(vars.userData.name) > -1) users.splice(users.indexOf(vars.userData.name), 1);
@@ -6179,6 +6179,12 @@ module.exports = [
                 $('#clickTwitchEmotes').remove();
             }
         }
+    },
+    {
+        name: 'Emote Priority',
+        description: 'Complete emotes before usernames when using tab completion',
+        default: false,
+        storageKey: 'emotePriority'
     },
     {
         name: 'Featured Channels',

--- a/betterttv.js
+++ b/betterttv.js
@@ -6182,7 +6182,7 @@ module.exports = [
     },
     {
         name: 'Emote Priority',
-        description: 'Complete emotes before usernames when using tab completion',
+        description: 'Prioritize emotes over usernames when using tab completion',
         default: false,
         storageKey: 'emotePriority'
     },

--- a/src/chat/helpers.js
+++ b/src/chat/helpers.js
@@ -265,7 +265,7 @@ exports.tabCompletion = function(e) {
 
             // Mix in emotes if not directly asking for a user
             if (lastWord.charAt(0) !== '@' && !detectServerCommand(input)) {
-                users = users.concat(emotes);
+                users = bttv.settings.get('emotePriority') ? emotes.concat(users) : users.concat(emotes);
             }
 
             if (users.indexOf(vars.userData.name) > -1) users.splice(users.indexOf(vars.userData.name), 1);

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -298,6 +298,12 @@ module.exports = [
         }
     },
     {
+        name: 'Emote Priority',
+        description: 'Prioritize emotes over usernames when using tab completion',
+        default: false,
+        storageKey: 'emotePriority'
+    },
+    {
         name: 'Featured Channels',
         description: 'The left sidebar is too cluttered, so BetterTTV removes featured channels by default',
         default: false,


### PR DESCRIPTION
Highly requested feature. For those of us that use tab completion for emotes, we'd much rather have it jump to an emote first than a username (eg by default, 'pogc' will complete to the username PogCaamp before PogChamp if that user is in the chat).