### PR TITLE
Fixed linkify regex

### DIFF
--- a/src/chat/templates.js
+++ b/src/chat/templates.js
@@ -32,7 +32,7 @@ var modicons = exports.modicons = function() {
 };
 
 var linkify = exports.linkify = function(message) {
-    var regex = /(?:https?:\/\/)?(?:[-a-zA-Z0-9@:%_\+~#=]+\.)+[a-z]{2,6}\b(?:(?:[-a-zA-Z0-9@:%_\+.~#?&\/=!,]+)(?:[-a-zA-Z0-9@:%_\+.~#?&\/=]))?/gi;
+    var regex = /(?:https?:\/\/)?(?:[-a-zA-Z0-9@:%_\+~#=]+\.)+[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/=!,]*[-a-zA-Z0-9@:%_\+.~#?&\/=])?/gi;
     return message.replace(regex, function(e) {
         if (/\x02/.test(e)) return e;
         if (e.indexOf('@') > -1 && (e.indexOf('/') === -1 || e.indexOf('@') < e.indexOf('/'))) return '<a href="mailto:' + e + '">' + e + '</a>';

--- a/src/chat/templates.js
+++ b/src/chat/templates.js
@@ -32,7 +32,7 @@ var modicons = exports.modicons = function() {
 };
 
 var linkify = exports.linkify = function(message) {
-    var regex = /(?:https?:\/\/)?(?:[-a-zA-Z0-9@:%_\+~#=]+\.)+[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/=!,]*[-a-zA-Z0-9@:%_\+.~#?&\/=])?/gi;
+    var regex = /(?:https?:\/\/)?(?:[-a-zA-Z0-9@:%_\+~#=]+\.)+[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/=;!,]*[-a-zA-Z0-9@:%_\+.~#?&\/=;])?/gi;
     return message.replace(regex, function(e) {
         if (/\x02/.test(e)) return e;
         if (e.indexOf('@') > -1 && (e.indexOf('/') === -1 || e.indexOf('@') < e.indexOf('/'))) return '<a href="mailto:' + e + '">' + e + '</a>';


### PR DESCRIPTION
Minor change.

Wasn't capturing some links properly; i.e. "http://www.google.com/" only captured "http://www.google.com".

I saw what changed the last time (ensuring a link could contain "!" or "," but not end in it) and left that part the same. Just fixed the the capturing and removed the 2 non-capturing groups that had no function in that context.