### PR TITLE
Fix typo in settings list

### DIFF
--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -369,7 +369,7 @@ module.exports = [
     },
     {
         name: 'Mod Card Keybinds',
-        description: 'Enable keybinds when you click on a username: P(urge), T(imeout), B(an), W(whisper)',
+        description: 'Enable keybinds when you click on a username: P(urge), T(imeout), B(an), W(hisper)',
         default: false,
         storageKey: 'modcardsKeybinds'
     },


### PR DESCRIPTION
This fixes a typo in the settings list by keeping the mod card keybind's descriptions consistent.