### PR TITLE
Dark mode banner color fix

### DIFF
--- a/style/stylesheets/betterttv-dark.css
+++ b/style/stylesheets/betterttv-dark.css
@@ -1969,6 +1969,12 @@ color: white;
 
 .player-column .brick {
     background-color: #222;
+    border-left: 5px solid #6441a5 !important;
+	box-shadow: 0px 0 0 #6441a4 inset !important;
+}
+
+.what {
+    background-color: #6441a5;
 }
 
 /* Video Manager */

--- a/style/stylesheets/betterttv.css
+++ b/style/stylesheets/betterttv.css
@@ -1787,3 +1787,9 @@ body.channel_new.columns.ember-application {
 .chat-container.chatReplay .ember-chat .chat-messages {
     bottom: 5px;
 }
+
+/* host & playlist banner fix */
+.player-column .brick {
+	border-left: 5px solid #6441a5 !important;
+	box-shadow: 0px 0 0 #6441a4 inset !important;
+}


### PR DESCRIPTION
On the side of the banner their is a small purple bar but it doesn't have a consistent width. The explanation button on the banner is also not colored correctly for dark mode.

Without fix:
![image](https://cloud.githubusercontent.com/assets/6759716/14060755/50b2a40c-f344-11e5-907c-fe711dddd14e.png)

With fix:
![image](https://cloud.githubusercontent.com/assets/6759716/14060754/406ef820-f344-11e5-8985-75c8ceb1112f.png)
