### PR TITLE
Fixed Dark Mode channel title hover

### DIFF
--- a/style/stylesheets/betterttv-dark.css
+++ b/style/stylesheets/betterttv-dark.css
@@ -300,12 +300,8 @@ body {
     border-top: 1px solid rgba(0, 0, 0, 0.65);
 }
 
-.channel-main, .title_over, #channel .player-column #broadcast-meta .info .title .over {
-    background: #000;
-}
-
-#channel .player-column #broadcast-meta .info .title .over {
-    color: #fff;
+.channel-main, .title_over, #channel .player-column #broadcast-meta .info .title:hover {
+    background-color: rgb(20, 20, 20);
 }
 
 #main_col .content #broadcast_meta .image, #main_col #broadcast-meta .image {


### PR DESCRIPTION
The `div.title` channel title element has styling applied on its `:hover` state now rather than a child element (which isn't there anymore) getting `.over` applied to it (presumably was done by JS).

Text is still styled properly with some more general Dark Mode styling, so this fixes Twitch's new styling by that puts a `background-color: white;` on `.title:hover`.