### PR TITLE
Vertically center align chat header items

### DIFF
--- a/style/stylesheets/betterttv.css
+++ b/style/stylesheets/betterttv.css
@@ -1294,7 +1294,12 @@ body#chat #speak {
     padding: 0px;
 }
 
+.ember-chat .chat-header .room-title {
+    padding-top: 10px;
+}
+
 .ember-chat .chat-header .button.left {
+    top: 5px;
     left: 10px;
 }
 
@@ -1687,7 +1692,7 @@ body.channel_new.columns.ember-application {
 /* channel state feature */
 #bttv-channel-state-contain {
     position: absolute;
-    top: 12px;
+    top: 7px;
     right: 5px;
     width: 150px;
     height: 24px;


### PR DESCRIPTION
I vertically center aligned the text and icons in the header of the chat sidebar. I believe this is how it used to be before Twitch made some styling changes. Either way, it looks much better now.