### PR TITLE
Twitch Theater Mode overrides chat header

### DIFF
--- a/style/stylesheets/betterttv-dark.css
+++ b/style/stylesheets/betterttv-dark.css
@@ -356,6 +356,11 @@ body {
     color: #fff;
 }
 
+/* Twitch theater mode chat header text un-override */
+.app-main.theatre .chat-container .chat-header {
+    color: #D3D3D3;
+}
+
 #left_col {
     background-color: #222;
 }


### PR DESCRIPTION
Fix for Twitch changing color of chat header text in theater mode.