### PR TITLE
Correction of #1092 (Use Moment.js format)

### DIFF
--- a/src/templates/moderation-card.jade
+++ b/src/templates/moderation-card.jade
@@ -13,7 +13,7 @@ div.bttv-mod-card.ember-view.moderation-card(data-user=user.name style="top: #{t
       a(href=Twitch.url.profile(user.name), target="_blank")= bttv.storage.getObject("nicknames")[user.name.toLowerCase()] || user.display_name
       svg.svg-edit.mod-card-edit(height='10px', width='10px', version='1.1', viewBox='0 0 16 16', x='0px', y='0px')
           path(clip-rule='evenodd', fill-rule='evenodd', d='M6.414,12.414L3.586,9.586l8-8l2.828,2.828L6.414,12.414z M4.829,14H2l0,0v-2.828l0.586-0.586l2.828,2.828L4.829,14z')
-    h4.created-at="Created " + moment(user.created_at).format("MMM d, YYYY")
+    h4.created-at="Created " + moment(user.created_at).format("ll")
     .channel_background_cover
     if user.profile_banner
       img.channel_background(src=user.profile_banner)


### PR DESCRIPTION
The format "MMM d, YYYY" can show "0" for the day, but "ll" is the intended format with correct data.

Example:
```javascript
> moment('2016-05-01T07:14:22Z').utcOffset(-6).format('MMM d, YYYY')
May 0, 2016
> moment('2016-05-01T07:14:22Z').utcOffset(-6).format('ll')
May 1, 2016
```