### PR TITLE
Option to disable front page video

### DIFF
--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -272,6 +272,20 @@ module.exports = [
         storageKey: 'disableWhispers'
     },
     {
+        name: 'Disable Frontpage Video',
+        description: 'Disable video on the frontpage',
+        default: false,
+        storageKey: 'disableFPVideo',
+        load: function() {
+            if (window.location.href === 'https://www.twitch.tv/' && bttv.settings.get('disableFPVideo') === true) {
+                $(window).load(function() {
+                    $('#video-1').hide();
+                    $('.items').css('width', '940px');
+                });
+            }
+        }
+    },
+    {
         name: 'Double-Click Auto-Complete',
         description: 'Double-clicking a username in chat copies it into the chat text box',
         default: false,

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -272,19 +272,18 @@ module.exports = [
         storageKey: 'disableWhispers'
     },
     {
-        name: 'Disable Frontpage Video',
-        description: 'Disable video on the frontpage',
+        name: 'Disable Frontpage Video Autplay',
+        description: 'Disable video autplay on the frontpage',
         default: false,
         storageKey: 'disableFPVideo',
         load: function() {
             if (window.location.href === 'https://www.twitch.tv/' && bttv.settings.get('disableFPVideo') === true) {
                 $(window).load(function() {
-                    $('#video-1').children('iframe').eq(0).attr('src', '');
-                    $('#video-1').hide();
-                    $('.items').css('width', '940px');
+                    var frameSrc = $('#video-1').children('iframe').eq(0).attr('src');
+                    $('#video-1').children('iframe').eq(0).attr('src', frameSrc + '&autoplay=false');
                     $('#video-1').bind('DOMNodeInserted DOMNodeRemoved', function() {
-                        $('#video-1').children('iframe').eq(0).attr('src', '');
-                        $('#video-1').hide();
+                        frameSrc = $('#video-1').children('iframe').eq(0).attr('src');
+                        $('#video-1').children('iframe').eq(0).attr('src', frameSrc + '&autoplay=false');
                     });
                 });
             }

--- a/src/settings-list.js
+++ b/src/settings-list.js
@@ -279,8 +279,13 @@ module.exports = [
         load: function() {
             if (window.location.href === 'https://www.twitch.tv/' && bttv.settings.get('disableFPVideo') === true) {
                 $(window).load(function() {
+                    $('#video-1').children('iframe').eq(0).attr('src', '');
                     $('#video-1').hide();
                     $('.items').css('width', '940px');
+                    $('#video-1').bind('DOMNodeInserted DOMNodeRemoved', function() {
+                        $('#video-1').children('iframe').eq(0).attr('src', '');
+                        $('#video-1').hide();
+                    });
                 });
             }
         }


### PR DESCRIPTION
Someone requested this.

The video player is simply replaced with this:
![80ee98327932f69a35c25d209292ef74](https://cloud.githubusercontent.com/assets/5868954/15076356/e3660b3a-13b1-11e6-8549-13a3687d8455.jpg)

