### PR TITLE
Fix button selector for chat send takeover

### DIFF
--- a/src/chat/takeover.js
+++ b/src/chat/takeover.js
@@ -264,7 +264,7 @@ var takeover = module.exports = function() {
 
     var $chatInterface = $('.ember-chat .chat-interface');
     var $chatInput = $chatInterface.find('textarea');
-    var $chatSend = $chatInterface.find('.send-chat-button');
+    var $chatSend = $chatInterface.find('.button.primary.float-right');
 
     // Limit chat input to 500 characters
     $chatInput.attr('maxlength', '500');


### PR DESCRIPTION
This fixes chat history and BTTV chat commands for when using the button instead of pressing Enter.