### PR TITLE
Put patching switch inside a route observer instead of render listener

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -166,9 +166,72 @@ var main = function() {
             }, 1000);
         };
 
-        // Some page changes do not trigger a re-render
-        App.__container__.lookup('controller:application').addObserver('currentRouteName', function() {
-            $('#main_col').removeAttr('style');
+        // Keep an eye for route change to reapply fixes
+        var lastRoute;
+        App.__container__.lookup('controller:application').addObserver('currentRouteName', function(data) {
+            debug.log('New route: ' + data.currentRouteName);
+
+            switch (data.currentRouteName) {
+                case 'loading':
+                    return;
+
+                case 'channel.index.index':
+                    waitForLoad(function(ready) {
+                        if (ready) {
+                            handleBackground();
+                            clearClutter();
+                            channelReformat();
+                            hostButtonBelowVideo();
+                            betterViewerList();
+                            if (
+                                App.__container__.lookup('controller:channel').get('isTheatreMode') === false &&
+                                bttv.settings.get('autoTheatreMode') === true
+                            ) {
+                                enableTheatreMode();
+                            }
+                            window.dispatchEvent(new Event('resize'));
+                            setTimeout(function() {
+                                window.dispatchEvent(new Event('resize'));
+                            }, 3000);
+                        }
+                    });
+                    break;
+                case 'vod':
+                    // disconnect old chat replay watcher, spawn new
+                    try {
+                        chatReplay.disconnect();
+                    } catch (e) {}
+                    chatReplay = new ChatReplay();
+                    window.dispatchEvent(new Event('resize'));
+                    break;
+                case 'following.index':
+                    // Switching between tabs in following page
+                    if (lastRoute.substr(0, 9) === 'following') break;
+
+                    $('#main_col').removeAttr('style');
+                    waitForLoad(function(ready) {
+                        if (ready) {
+                            directoryFunctions();
+                        }
+                    });
+                    break;
+                case 'profile.index':
+                    waitForLoad(function(ready) {
+                        if (ready) {
+                            vars.emotesLoaded = false;
+                            chatFunctions();
+                            channelReformat();
+                            window.dispatchEvent(new Event('resize'));
+                        }
+                    });
+                    break;
+                default:
+                    // resets main col width on all non-resized pages
+                    $('#main_col').removeAttr('style');
+                    break;
+            }
+
+            lastRoute = data.currentRouteName;
         });
 
         Ember.subscribe('render', {
@@ -178,72 +241,13 @@ var main = function() {
             after: function(name, ts, payload) {
                 renderingCounter--;
 
-                if (!payload.template) return;
-                debug.log(payload.template, App.__container__.lookup('controller:application').get('currentRouteName'));
-
-                switch (App.__container__.lookup('controller:application').get('currentRouteName')) {
-                    case 'channel.index.index':
-                        waitForLoad(function(ready) {
-                            if (ready) {
-                                handleBackground();
-                                clearClutter();
-                                channelReformat();
-                                hostButtonBelowVideo();
-                                betterViewerList();
-                                if (
-                                    App.__container__.lookup('controller:channel').get('isTheatreMode') === false &&
-                                    bttv.settings.get('autoTheatreMode') === true
-                                ) {
-                                    enableTheatreMode();
-                                }
-                                window.dispatchEvent(new Event('resize'));
-                                setTimeout(function() {
-                                    window.dispatchEvent(new Event('resize'));
-                                }, 3000);
-                            }
-                        });
-                        break;
-                    case 'vod':
-                        // disconnect old chat replay watcher, spawn new
-                        try {
-                            chatReplay.disconnect();
-                        } catch (e) {}
-                        chatReplay = new ChatReplay();
-                        window.dispatchEvent(new Event('resize'));
-                        break;
-                    case 'following.index':
-                        $('#main_col').removeAttr('style');
-                        waitForLoad(function(ready) {
-                            if (ready) {
-                                directoryFunctions();
-                            }
-                        });
-                        break;
-                    case 'profile.index':
-                        waitForLoad(function(ready) {
-                            if (ready) {
-                                vars.emotesLoaded = false;
-                                chatFunctions();
-                                channelReformat();
-                                window.dispatchEvent(new Event('resize'));
-                            }
-                        });
-                        break;
-                    default:
-                        // resets main col width on all non-resized pages
-                        $('#main_col').removeAttr('style');
-                        break;
-                }
-
-                switch (payload.template) {
-                    case 'chat/chat':
-                        waitForLoad(function(ready) {
-                            if (ready) {
-                                bttv.chat.store.isLoaded = false;
-                                chatFunctions();
-                            }
-                        });
-                        break;
+                if (payload.template === 'chat/chat') {
+                    waitForLoad(function(ready) {
+                        if (ready) {
+                            bttv.chat.store.isLoaded = false;
+                            chatFunctions();
+                        }
+                    });
                 }
             }
         });


### PR DESCRIPTION
This seems to work more consistently than the render callback.

In the future, once there's a better plugin API, it'd be cleaner to send an event to the plugin whenever the route changes and let them handle it.