### PR TITLE
Abstract tokenize for conversations and chatreplay

### DIFF
--- a/src/js/chat/templates.js
+++ b/src/js/chat/templates.js
@@ -193,7 +193,7 @@ exports.bttvElementTokenize = function(senderEl, messageEl) {
     var tokens = $(messageEl).contents();
     var sender = $(senderEl).text().trim().toLowerCase();
     for (var i = 0; i < tokens.length; i++) {
-        if (tokens[i].nodeType === Node.TEXT_NODE) {
+        if (tokens[i].nodeType === window.Node.TEXT_NODE) {
             newTokens.push(bttvMessageTokenize(sender, tokens[i].data));
         } else {
             newTokens.push(tokens[i].outerHTML);

--- a/src/js/chat/templates.js
+++ b/src/js/chat/templates.js
@@ -141,7 +141,7 @@ var bttvEmoticonize = exports.bttvEmoticonize = function(message, emote, sender)
 };
 
 var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message) {
-    var tokenizedString = message.split(' ');
+    var tokenizedString = message.trim().split(' ');
 
     for (var i = 0; i < tokenizedString.length; i++) {
         var piece = tokenizedString[i];
@@ -186,6 +186,21 @@ var bttvMessageTokenize = exports.bttvMessageTokenize = function(sender, message
     }
 
     return tokenizedString.join(' ');
+};
+
+exports.bttvElementTokenize = function(senderEl, messageEl) {
+    var newTokens = [];
+    var tokens = $(messageEl).contents();
+    var sender = $(senderEl).text().trim().toLowerCase();
+    for (var i = 0; i < tokens.length; i++) {
+        if (tokens[i].nodeType === Node.TEXT_NODE) {
+            newTokens.push(bttvMessageTokenize(sender, tokens[i].data));
+        } else {
+            newTokens.push(tokens[i].outerHTML);
+        }
+    }
+
+    return newTokens.join(' ');
 };
 
 exports.moderationCard = function(user, top, left) {

--- a/src/js/features/chat-replay.js
+++ b/src/js/features/chat-replay.js
@@ -1,5 +1,4 @@
 var chatHelpers = require('../chat/helpers');
-var chatStore = require('../chat/store');
 var chatTemplates = require('../chat/templates');
 
 function ChatReplay() {
@@ -69,36 +68,7 @@ ChatReplay.prototype.messageParser = function(element) {
 
     if ($message.attr('style')) $message.css('color', newColor);
 
-    message.innerHTML = this.emoticonize(message.innerHTML);
-};
-
-ChatReplay.prototype.emoticonize = function(message) {
-    if (bttv.settings.get('bttvEmotes') === false) return message;
-
-    var parts = message.split(' ');
-    var test;
-    var emote;
-
-    for (var i = 0; i < parts.length; i++) {
-        if (parts[i].length > 1) parts[i] = parts[i].replace(/\n/, '');
-        test = parts[i].replace(/(^[~!@#$%\^&\*\(\)]+|[~!@#$%\^&\*\(\)]+$)/g, '');
-        emote = null;
-
-        if (chatStore.bttvEmotes.hasOwnProperty(parts[i])) {
-            emote = chatStore.bttvEmotes[parts[i]];
-        } else if (chatStore.bttvEmotes.hasOwnProperty(test)) {
-            emote = chatStore.bttvEmotes[test];
-        }
-        if (
-            emote &&
-            emote.urlTemplate &&
-            (emote.imageType === 'png' || (emote.imageType === 'gif' && bttv.settings.get('bttvGIFEmotes') === true))
-        ) {
-            parts[i] = chatTemplates.bttvEmoticonize(parts[i], emote);
-            changed = true;
-        }
-    }
-    return parts.join(' ');
+    message.innerHTML = chatTemplates.bttvElementTokenize($name[0], message);
 };
 
 module.exports = ChatReplay;

--- a/src/js/features/conversations.js
+++ b/src/js/features/conversations.js
@@ -1,5 +1,4 @@
 var audibleFeedback = require('../features/audible-feedback');
-var chatStore = require('../chat/store');
 var chatTemplates = require('../chat/templates');
 var chatHelpers = require('../chat/helpers');
 var colors = require('../helpers/colors');
@@ -83,7 +82,7 @@ Conversations.prototype.messageParser = function(element) {
     from.style.color = this.usernameRecolor(from.style.color);
 
     if ($element.hasClass('conversation-chat-line') && !$element.hasClass('conversation-preview-line')) {
-        $element.append('<span class="message">' + this.emoticonize(message.innerHTML) + '</span>');
+        $element.append(chatTemplates.bttvElementTokenize(from, message));
         message.style.display = 'none';
     }
 
@@ -97,35 +96,6 @@ Conversations.prototype.scrollDownParent = function(element) {
         if (!container) return;
         container.scrollTop = container.scrollHeight;
     }, 500);
-};
-
-Conversations.prototype.emoticonize = function(message) {
-    if (bttv.settings.get('bttvEmotes') === false) return message;
-
-    var parts = message.trim().split(' ');
-    var test;
-    var emote;
-
-    for (var i = 0; i < parts.length; i++) {
-        test = parts[i].replace(/(^[~!@#$%\^&\*\(\)]+|[~!@#$%\^&\*\(\)]+$)/g, '');
-        emote = null;
-
-        if (chatStore.bttvEmotes.hasOwnProperty(parts[i])) {
-            emote = chatStore.bttvEmotes[parts[i]];
-        } else if (chatStore.bttvEmotes.hasOwnProperty(test)) {
-            emote = chatStore.bttvEmotes[test];
-        }
-
-        if (
-            emote &&
-            emote.urlTemplate &&
-            (emote.imageType === 'png' || (emote.imageType === 'gif' && bttv.settings.get('bttvGIFEmotes') === true))
-        ) {
-            parts[i] = chatTemplates.bttvEmoticonize(parts[i], emote);
-        }
-    }
-
-    return parts.join(' ');
 };
 
 Conversations.prototype.usernameRecolor = function(color) {

--- a/src/js/features/conversations.js
+++ b/src/js/features/conversations.js
@@ -33,6 +33,9 @@ function Conversations(timeout) {
     if (window.App && App.__container__.lookup('service:whispers-shim')) {
         var whisperShim = App.__container__.lookup('service:whispers-shim');
         whisperShim.on('whisper', _self.onWhisper);
+        whisperShim.on('thread', function(data) {
+            bttv.ws.joinConversation(data.id);
+        });
     }
 
     var watcher = new MutationObserver(function(mutations) {

--- a/src/js/features/conversations.js
+++ b/src/js/features/conversations.js
@@ -33,6 +33,8 @@ function Conversations(timeout) {
     if (window.App && App.__container__.lookup('service:whispers-shim')) {
         var whisperShim = App.__container__.lookup('service:whispers-shim');
         whisperShim.on('whisper', _self.onWhisper);
+
+        // Called every time new messages are marked as read
         whisperShim.on('thread', function(data) {
             bttv.ws.joinConversation(data.id);
         });

--- a/src/js/ws.js
+++ b/src/js/ws.js
@@ -68,6 +68,7 @@ function SocketClient() {
     this._connecting = false;
     this._connectAttempts = 1;
     this._joinedChannel = null;
+    this._joinedConversations = [];
     this._events = events;
 
     this.connect();
@@ -180,6 +181,14 @@ SocketClient.prototype.joinChannel = function() {
     element.type = 'text/css';
     element.innerHTML = '.badge.subscriber { background-image: url("https://cdn.betterttv.net/tags/subscriber.png") !important; }';
     bttv.jQuery('.ember-chat .chat-room').append(element);
+};
+
+SocketClient.prototype.joinConversation = function(threadId) {
+    if (this._joinedConversations.indexOf(threadId) < 0) {
+        this.emit('join_channel', { name: threadId });
+    }
+
+    this.emit('broadcast_me', { name: vars.userData.name, channel: threadId });
 };
 
 module.exports = SocketClient;


### PR DESCRIPTION
Fix for #1267 

This will reuse the same tokenize function as chat.
It will add support for personal emotes, and as a bonus, url image hover.

That being said, personal emotes won't show unless they are already in the store,
which only happens if you have seen the user in chat type.

So we'd need some websocket protocol to request an update for a specific user?