### PR TITLE
Fixes #1265

### DIFF
--- a/src/js/features/channel-state.js
+++ b/src/js/features/channel-state.js
@@ -135,10 +135,11 @@ module.exports = function(event) {
             var msg = event.tags['msg-id'];
 
             if (msg === 'msg_slowmode' || msg === 'msg_timedout') {
-                var matches = /([0-9]+)/.exec(event.message);
+                var matches = event.message.split(' ');
                 if (!matches) return;
 
-                var seconds = parseInt(matches[1], 10);
+                var seconds = 0;
+                if (matches.length >= 9) seconds = parseInt(matches[9], 10);
                 initiateCountDown(seconds);
             } else if (msg === 'msg_banned') {
                 initiateCountDown(86400);

--- a/src/js/features/channel-state.js
+++ b/src/js/features/channel-state.js
@@ -135,11 +135,10 @@ module.exports = function(event) {
             var msg = event.tags['msg-id'];
 
             if (msg === 'msg_slowmode' || msg === 'msg_timedout') {
-                var matches = event.message.split(' ');
+                var matches = /\s([0-9]+)/.exec(event.message);
                 if (!matches) return;
 
-                var seconds = 0;
-                if (matches.length >= 9) seconds = parseInt(matches[9], 10);
+                var seconds = parseInt(matches[0], 10);
                 initiateCountDown(seconds);
             } else if (msg === 'msg_banned') {
                 initiateCountDown(86400);


### PR DESCRIPTION
Hello,

So this solution might not be so good, but i didn't really think of anything better with regular expressions. The timeout duration should always be the 9th word in the message, because twitch doesn't allow spaces in usernames, at least yet.

Let me know if you have any ideas.