### PR TITLE
Remove usage of deprecated variable

### DIFF
--- a/src/js/features/check-broadcast-info.js
+++ b/src/js/features/check-broadcast-info.js
@@ -18,12 +18,10 @@ var checkBroadcastInfo = module.exports = function() {
 
     bttv.TwitchAPI.get('channels/' + channel.id, {}, { version: 3 }).done(function(d) {
         if (d.game) {
-            channel.set('rollbackData.game', d.game);
             channel.set('game', d.game);
         }
 
         if (d.status) {
-            channel.set('rollbackData.status', d.status);
             channel.set('status', d.status);
 
             if (!hostedChannel) {
@@ -41,7 +39,6 @@ var checkBroadcastInfo = module.exports = function() {
         }
 
         if (d.views) {
-            channel.set('rollbackData.views', d.views);
             channel.set('views', d.views);
         }
 


### PR DESCRIPTION
Fix bug with channel data updating. Right now, data, game, viewers and followers don't update anymore because rollback feature was removed for channel model