### PR TITLE
Fix for slow mode tooltip remaining time display

### DIFF
--- a/src/js/chat/handlers.js
+++ b/src/js/chat/handlers.js
@@ -13,18 +13,7 @@ var vars = require('../vars'),
 
 // Helper Functions
 var getRgb = require('../helpers/colors').getRgb;
-
-var secondsToLength = function(s) {
-    var days = Math.floor(s / 86400);
-    var hours = Math.floor(s / 3600) - (days * 24);
-    var minutes = Math.floor(s / 60) - (days * 1440) - (hours * 60);
-    var seconds = s - (days * 86400) - (hours * 3600) - (minutes * 60);
-
-    return (days > 0 ? days + ' day' + (days === 1 ? '' : 's') + ', ' : '') +
-           (hours > 0 ? hours + ' hour' + (hours === 1 ? '' : 's') + ', ' : '') +
-           (minutes > 0 ? minutes + ' minute' + (minutes === 1 ? '' : 's') + ', ' : '') +
-           seconds + ' second' + (seconds === 1 ? '' : 's');
-};
+var secondsToLength = require('../helpers/time').secondsToLength;
 
 exports.commands = function(input) {
     var sentence = input.trim().split(' ');

--- a/src/js/features/channel-state.js
+++ b/src/js/features/channel-state.js
@@ -5,6 +5,8 @@ var stateContainer = '#bttv-channel-state-contain';
 var chatHeader = '.chat-container .chat-header:first';
 var chatButton = '.chat-interface .chat-buttons-container .button.primary.float-right';
 
+var secondsToLength = require('../helpers/time').secondsToLength;
+
 var displaySeconds = function(s) {
     var date = new Date(0);
     date.setSeconds(s);
@@ -77,7 +79,7 @@ module.exports = function(event) {
 
                 $stateContainer
                     .find('.slow-time')
-                    .attr('original-title', length + ' seconds')
+                    .attr('original-title', secondsToLength(length))
                     .text(displaySeconds(length));
 
                 if (length === 0) {

--- a/src/js/helpers/time.js
+++ b/src/js/helpers/time.js
@@ -1,0 +1,11 @@
+exports.secondsToLength = function(s) {
+    var days = Math.floor(s / 86400);
+    var hours = Math.floor(s / 3600) - (days * 24);
+    var minutes = Math.floor(s / 60) - (days * 1440) - (hours * 60);
+    var seconds = s - (days * 86400) - (hours * 3600) - (minutes * 60);
+
+    return (days > 0 ? days + ' day' + (days === 1 ? '' : 's') + ', ' : '') +
+        (hours > 0 ? hours + ' hour' + (hours === 1 ? '' : 's') + ', ' : '') +
+        (minutes > 0 ? minutes + ' minute' + (minutes === 1 ? '' : 's') + ', ' : '') +
+        seconds + ' second' + (seconds === 1 ? '' : 's');
+};


### PR DESCRIPTION
This is a fix for the tooltip that says how long slow mode is configured for. Previously the tooltip always said the length in seconds.