### PR TITLE
Option to hide Hosted and Recommended streams/videos

### DIFF
--- a/src/js/features/hide-hosts.js
+++ b/src/js/features/hide-hosts.js
@@ -1,0 +1,23 @@
+var debug = require('../helpers/debug');
+
+module.exports = function() {
+    if (bttv.settings.get('hideHostedStreams') !== true) return;
+
+    debug.log('Hiding hosted');
+
+    var hosted = $('*[data-tt_content="live_host"]');
+    if (hosted.length > 0) {
+        var hostedContainer = hosted[0].closest('.js-streams');
+        var hostedTitleContainer = $(hostedContainer).prev();
+
+        $(hostedTitleContainer).remove();
+        $(hostedContainer).remove();
+    } else {
+        var emptyGrid = $('.empty-grid');
+        if (emptyGrid.length > 0) {
+            $(emptyGrid).prev().remove();
+            $(emptyGrid).prev().remove();
+            $(emptyGrid).remove();
+        }
+    }
+};

--- a/src/js/features/hide-recommended-streams.js
+++ b/src/js/features/hide-recommended-streams.js
@@ -1,0 +1,17 @@
+var debug = require('../helpers/debug');
+
+module.exports = function() {
+    if (bttv.settings.get('hideRecommendedStreams') !== true) return;
+
+    debug.log('Hiding Recommended Streams');
+
+    var recommended = $('*[data-tt_content="recommended_videos"]');
+
+    if (recommended.length > 0) {
+        var recommendedContainer = recommended[0].closest('.js-videos');
+        var recommendedTitleContainer = $(recommendedContainer).parent().prev();
+
+        $(recommendedTitleContainer).remove();
+        $(recommendedContainer).remove();
+    }
+};

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -144,7 +144,9 @@ var clearClutter = require('./features/clear-clutter'),
     betterViewerList = require('./features/better-viewer-list'),
     overrideEmotes = require('./features/override-emotes'),
     playerViewerCount = require('./features/player-viewer-count.js'),
-    ChatReplay = require('./features/chat-replay');
+    ChatReplay = require('./features/chat-replay'),
+    hideHosts = require('./features/hide-hosts'),
+    hideRecommendedStreams = require('./features/hide-recommended-streams');
 
 var chatFunctions = function() {
     debug.log('Modifying Chat Functionality');
@@ -253,6 +255,13 @@ var main = function() {
                     break;
             }
 
+            waitForLoad(function(ready) {
+                if (ready) {
+                    hideHosts();
+                    hideRecommendedStreams();
+                }
+            });
+
             lastRoute = data.currentRouteName;
         });
 
@@ -322,6 +331,8 @@ var main = function() {
         window.dispatchEvent(new Event('resize'));
         chatFunctions();
         directoryFunctions();
+        hideHosts();
+        hideRecommendedStreams();
     };
 
     $(document).ready(function() {
@@ -333,6 +344,7 @@ var main = function() {
             debug.log('CALL init ' + document.URL);
 
             initialFuncs();
+
             setTimeout(delayedFuncs, 3000);
         });
     });

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -9,7 +9,9 @@ var splitChat = require('./features/split-chat'),
     betterViewerList = require('./features/better-viewer-list'),
     handleTwitchChatEmotesScript = require('./features/handle-twitchchat-emotes'),
     audibleFeedback = require('./features/audible-feedback'),
-    imagePreview = require('./features/image-preview');
+    imagePreview = require('./features/image-preview'),
+    hideHosts = require('./features/hide-hosts'),
+    hideRecommendedStreams = require('./features/hide-recommended-streams');
 
 var displayElement = require('./helpers/element').display,
     removeElement = require('./helpers/element').remove;
@@ -640,6 +642,32 @@ module.exports = [
                 chat.helpers.serverMessage('Chat scrollback is now set to: default (150)', true);
             } else {
                 chat.helpers.serverMessage('Chat scrollback is now set to: ' + lines, true);
+            }
+        }
+    },
+    {
+        name: 'Hide hosted streams',
+        description: 'Hide the "Live Hosts" section of your following page.',
+        default: false,
+        storageKey: 'hideHostedStreams',
+        toggle: function(value) {
+            if (value === true) {
+                hideHosts();
+            } else {
+                //
+            }
+        }
+    },
+    {
+        name: 'Hide Recommended streams',
+        description: 'Hide the "BASED ON YOUR VIEWING HISTORY" section of your following page.',
+        default: false,
+        storageKey: 'hideRecommendedStreams',
+        toggle: function(value) {
+            if (value === true) {
+                hideRecommendedStreams();
+            } else {
+                //
             }
         }
     }


### PR DESCRIPTION
Couldnt find it in the current version of BTTV, so devided to add it in.

Basic funcitonality to unclutter your directory.following tabs. Really wish i could jump in before they print it out. But alas i did not find a way.

Settings:
- Enable/disable hiding of Hosted Streams
- Enable/disable hiding of Recommended Videos

Functionality:
- Hiding based on data-tt_content attribute