### PR TITLE
replace deprecated gulp-browserify with browserify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,16 @@
 var fs = require('fs'),
     gulp = require('gulp'),
     jade = require('gulp-jade'),
-    browserify = require('gulp-browserify'),
+    browserify = require('browserify'),
     header = require('gulp-header'),
     footer = require('gulp-footer'),
-    concat = require('gulp-concat'),
     del = require('del'),
     eslint = require('gulp-eslint'),
     uglify = require('gulp-uglify'),
     saveLicense = require('uglify-save-license'),
-    enviro = require('gulp-environments');
+    enviro = require('gulp-environments'),
+    source = require('vinyl-source-stream'),
+    buffer = require('vinyl-buffer');
 
 gulp.task('cleanup', function() {
     return del('build/**/*');
@@ -42,9 +43,10 @@ var jadeDefinition = fs.readFileSync('node_modules/jade/runtime.js').toString();
 var license = fs.readFileSync('src/license.txt').toString();
 
 gulp.task('scripts', ['prepare'], function() {
-    gulp.src(['build/js/main.js'])
-        .pipe(browserify())
-        .pipe(concat('betterttv.js'))
+    return browserify('build/js/main.js')
+        .bundle()
+        .pipe(source('betterttv.js'))
+        .pipe(buffer())
         .pipe(header('(function(bttv) {'))
         .pipe(header(jadeDefinition))
         .pipe(header(license + '\n'))

--- a/package.json
+++ b/package.json
@@ -12,29 +12,29 @@
     "url": "https://github.com/night/BetterTTV.git"
   },
   "dependencies": {
+    "browserify": "^13.1.0",
     "cookies-js": "^1.2.1",
     "del": "^2.2.0",
     "emojilib": "^2.0.2",
     "es6-object-assign": "^1.0.3",
     "gulp": "^3.8.0",
-    "gulp-browserify": "^0.5.0",
-    "gulp-changed": "~0.3.0",
-    "gulp-concat": "^2.2.0",
     "gulp-environments": "^0.1.1",
-    "gulp-eslint": "^2.0.0",
+    "gulp-eslint": "^3.0.1",
     "gulp-footer": "^1.0.4",
     "gulp-header": "^1.0.2",
-    "gulp-jade": "^0.7.0",
+    "gulp-jade": "^1.1.0",
     "gulp-rename": "^1.2.0",
-    "gulp-uglify": "^1.5.3",
+    "gulp-uglify": "^2.0.0",
     "jade": "^1.5.0",
     "lodash.debounce": "^4.0.6",
-    "lodash.throttle": "^3.0.4",
-    "request": "2.36.0",
+    "lodash.throttle": "^4.1.1",
+    "request": "2.75.0",
     "resizable": "^1.1.1",
     "twemoji": "^2.1.0",
     "twitch-chat-emotes": "github:cletusc/Userscript--Twitch-Chat-Emotes#47a247445d7a1d10dceada6800aefd4a28e38b90",
     "uglify-save-license": "^0.4.1",
-    "view-list": "^2.1.0"
+    "view-list": "^2.1.0",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
   }
 }


### PR DESCRIPTION
The `gulp-browserify` module has been [deprecated](https://github.com/deepak1556/gulp-browserify/blob/db0f8c151458703ea2eedd30f651ae2e2e912475/README.md) for over a year now, in favor of simply using plain `browserify`. Since `browserify` already works with streams, it works perfectly alongside other gulp plugins like `gulp-header` and `gulp-uglify`, provided that we convert the stream to a `vinyl-buffer`.

This PR implements just that. I added the new dependencies under [`"devDependencies'`](https://docs.npmjs.com/files/package.json#devdependencies), since that's where build dependencies like these are intended to go. I can send another PR to move the rest of the `gulp` stuff there too, if that's desired.

Tested locally and everything appears to work, but let me know of any issues you encounter :)