### PR TITLE
Add an option to disable Chat Freeze

### DIFF
--- a/src/js/features/chat-freeze.js
+++ b/src/js/features/chat-freeze.js
@@ -7,10 +7,10 @@ module.exports = function() {
     if (isLoaded) return shouldFreeze;
 
     $('body').on('keydown.chat-freeze', function(e) {
-        if (!(e.metaKey || e.ctrlKey) || !$('.chat-room:hover').length) return;
+        if (bttv.settings.get('chatFreeze') !== true || !(e.metaKey || e.ctrlKey) || !$('.chat-room:hover').length) return;
         shouldFreeze = true;
     }).on('keyup.chat-freeze', function(e) {
-        if (e.metaKey || e.ctrlKey) return;
+        if (bttv.settings.get('chatFreeze') !== true || e.metaKey || e.ctrlKey) return;
         shouldFreeze = false;
         helpers.scrollChat();
         $('.chat-room .chat-interface .more-messages-indicator').click();

--- a/src/js/features/chat-freeze.js
+++ b/src/js/features/chat-freeze.js
@@ -4,6 +4,8 @@ var shouldFreeze = false;
 var isLoaded = false;
 
 module.exports = function() {
+    if (shouldFreeze === true && bttv.chat.store.activeView !== true) shouldFreeze = false;
+
     if (isLoaded) return shouldFreeze;
 
     $('body').on('keydown.chat-freeze', function(e) {

--- a/src/js/features/chat-freeze.js
+++ b/src/js/features/chat-freeze.js
@@ -7,10 +7,10 @@ module.exports = function() {
     if (isLoaded) return shouldFreeze;
 
     $('body').on('keydown.chat-freeze', function(e) {
-        if (bttv.settings.get('chatFreeze') !== true || !(e.metaKey || e.ctrlKey) || !$('.chat-room:hover').length) return;
+        if (!(e.metaKey || e.ctrlKey) || !$('.chat-room:hover').length) return;
         shouldFreeze = true;
     }).on('keyup.chat-freeze', function(e) {
-        if (bttv.settings.get('chatFreeze') !== true || e.metaKey || e.ctrlKey) return;
+        if (e.metaKey || e.ctrlKey) return;
         shouldFreeze = false;
         helpers.scrollChat();
         $('.chat-room .chat-interface .more-messages-indicator').click();

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -509,12 +509,6 @@ module.exports = [
         storageKey: 'customTOShiftOnly'
     },
     {
-        name: 'Chat Freeze',
-        description: 'Pauses the chat when hovering it and holding Ctrl or the Windows / Command key',
-        default: true,
-        storageKey: 'chatFreeze'
-    },
-    {
         name: 'Show Deleted Messages',
         description: 'Turn this on to change <message deleted> back to users\' messages.',
         default: false,

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -509,6 +509,12 @@ module.exports = [
         storageKey: 'customTOShiftOnly'
     },
     {
+        name: 'Chat Freeze',
+        description: 'Pauses the chat when hovering it and holding Ctrl or the Windows / Command key',
+        default: true,
+        storageKey: 'chatFreeze'
+    },
+    {
         name: 'Show Deleted Messages',
         description: 'Turn this on to change <message deleted> back to users\' messages.',
         default: false,


### PR DESCRIPTION
This change allows users to enable or disable the Chat Freeze feature (enabled by default like it's the case at the moment).

_Reason behind this change:_ this feature is sometimes involuntary triggering for me when cmd-tabbing (Mac alt-tabbing) while moving at the same time the mouse off the window.
I can reproduce this issue 100% of the time on Mac. I can't say anything about Windows, I don't have one to test it.

Anyway, having an option to disable this feature (while keeping it enabled by default) could be a nice improvement.