### PR TITLE
Regular Expression Highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lodash.throttle": "^4.1.1",
     "request": "2.75.0",
     "resizable": "^1.2.0",
+    "safe-regex": "^1.1.0",
     "twemoji": "^2.2.0",
     "twitch-chat-emotes": "github:night/Userscript--Twitch-Chat-Emotes#1fcd73bdfe491235506cecf3f32f56c2e06a31ff",
     "uglify-save-license": "^0.4.1",

--- a/src/js/features/keywords-lists.js
+++ b/src/js/features/keywords-lists.js
@@ -69,7 +69,7 @@ exports.highlighting = function(data) {
     if (useRegex) {
         // Pull the regular expressions out first so curly braces
         // in the expression won't double count as phrases
-        var regexPhrase = /;.+?;/g;
+        var regexPhrase = /\/.+?\//g;
         var regexStrings;
         try {
             regexStrings = extraKeywords.match(regexPhrase);
@@ -83,7 +83,7 @@ exports.highlighting = function(data) {
                 debug.log(regexString);
                 extraKeywords = extraKeywords.replace(regexString, '')
                     .replace(/s\s\s+/g, ' ').trim();
-                highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
+                highlightRegex.push(regexString.replace(/(^\/|\/$)/g, '')
                                     .trim());
             }
         }

--- a/src/js/features/keywords-lists.js
+++ b/src/js/features/keywords-lists.js
@@ -61,9 +61,32 @@ exports.highlighting = function(data) {
     var highlightKeywords = [];
     var highlightUsers = [];
 
-    var extraKeywords = bttv.settings.get('highlightKeywords').toString();
-    var phraseRegex = /\{.+?\}/g;
+    var extraKeywords = bttv.settings.get('highlightKeywords');
 
+    // Pull the regular expressions out first so curly braces
+    // in the expression won't double count as phrases
+    var highlightRegex = [];
+    var regexPhrase = /;.+?;/g;
+    var regexStrings;
+    var i;
+    try {
+        regexStrings = extraKeywords.match(regexPhrase);
+    } catch (e) {
+        debug.log(e);
+        return false;
+    }
+    if (regexStrings) {
+        for (i = 0; i < regexStrings.length; i++) {
+            var regexString = regexStrings[i];
+            debug.log(regexString);
+            extraKeywords = extraKeywords.replace(regexString, '')
+                .replace(/s\s\s+/g, ' ').trim();
+            highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
+                                .trim());
+        }
+    }
+
+    var phraseRegex = /\{.+?\}/g;
     var testCases;
     try {
         testCases = extraKeywords.match(phraseRegex);
@@ -72,7 +95,6 @@ exports.highlighting = function(data) {
         return false;
     }
 
-    var i;
     if (testCases) {
         for (i = 0; i < testCases.length; i++) {
             var testCase = testCases[i];
@@ -80,6 +102,7 @@ exports.highlighting = function(data) {
             highlightKeywords.push(testCase.replace(/(^\{|\}$)/g, '').trim());
         }
     }
+
     if (extraKeywords !== '') {
         extraKeywords = extraKeywords.split(' ');
         extraKeywords.forEach(function(keyword) {
@@ -118,6 +141,15 @@ exports.highlighting = function(data) {
             return true;
         }
     }
+
+    for (i = 0; i < highlightRegex.length; i++) {
+        debug.log('Testing' + highlightRegex);
+        regex = new RegExp(highlightRegex[i], 'g');
+        if (regex.test(data.message)) {
+            return true;
+        }
+    }
+
 
     return false;
 };

--- a/src/js/features/keywords-lists.js
+++ b/src/js/features/keywords-lists.js
@@ -81,10 +81,12 @@ exports.blacklistFilter = function(data) {
 
     if (useRegex) {
         for (i = 0; i < blacklistRegexes.length; i++) {
-            debug.log('Testing' + blacklistRegexes[i]);
+            debug.log('Testing ' + blacklistRegexes[i]);
             regex = new RegExp(blacklistRegexes[i], 'g');
             if (safeRegex(regex) && regex.test(data.message)) {
                 return true;
+            } else if (!safeRegex(regex)) {
+                debug.log('Unsafe regex detected, not evaluating: ' + regex);
             }
         }
     }
@@ -102,7 +104,7 @@ exports.highlighting = function(data) {
     var extraKeywords = bttv.settings.get('highlightKeywords');
     var useRegex = bttv.settings.get('regexHighlights');
 
-    var highlightRegex = [];
+    var highlightRegexes = [];
     if (useRegex) {
         // Pull the regular expressions out first so curly braces
         // in the expression won't double count as phrases
@@ -120,7 +122,7 @@ exports.highlighting = function(data) {
                 debug.log(regexString);
                 extraKeywords = extraKeywords.replace(regexString, '')
                     .replace(/s\s\s+/g, ' ').trim();
-                highlightRegex.push(regexString.replace(/(^\/|\/$)/g, '')
+                highlightRegexes.push(regexString.replace(/(^\/|\/$)/g, '')
                                     .trim());
             }
         }
@@ -183,11 +185,13 @@ exports.highlighting = function(data) {
     }
 
     if (useRegex) {
-        for (i = 0; i < highlightRegex.length; i++) {
-            debug.log('Testing' + highlightRegex);
-            regex = new RegExp(highlightRegex[i], 'g');
+        for (i = 0; i < highlightRegexes.length; i++) {
+            debug.log('Testing ' + highlightRegexes[i]);
+            regex = new RegExp(highlightRegexes[i], 'g');
             if (safeRegex(regex) && regex.test(data.message)) {
                 return true;
+            } else if (!safeRegex(regex)) {
+                debug.log('Unsafe regex detected, not evaluating: ' + regex);
             }
         }
     }

--- a/src/js/features/keywords-lists.js
+++ b/src/js/features/keywords-lists.js
@@ -60,29 +60,32 @@ exports.highlighting = function(data) {
 
     var highlightKeywords = [];
     var highlightUsers = [];
+    var i;
 
     var extraKeywords = bttv.settings.get('highlightKeywords');
+    var useRegex = bttv.settings.get('regexHighlights');
 
-    // Pull the regular expressions out first so curly braces
-    // in the expression won't double count as phrases
     var highlightRegex = [];
-    var regexPhrase = /;.+?;/g;
-    var regexStrings;
-    var i;
-    try {
-        regexStrings = extraKeywords.match(regexPhrase);
-    } catch (e) {
-        debug.log(e);
-        return false;
-    }
-    if (regexStrings) {
-        for (i = 0; i < regexStrings.length; i++) {
-            var regexString = regexStrings[i];
-            debug.log(regexString);
-            extraKeywords = extraKeywords.replace(regexString, '')
-                .replace(/s\s\s+/g, ' ').trim();
-            highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
-                                .trim());
+    if (useRegex) {
+        // Pull the regular expressions out first so curly braces
+        // in the expression won't double count as phrases
+        var regexPhrase = /;.+?;/g;
+        var regexStrings;
+        try {
+            regexStrings = extraKeywords.match(regexPhrase);
+        } catch (e) {
+            debug.log(e);
+            return false;
+        }
+        if (regexStrings) {
+            for (i = 0; i < regexStrings.length; i++) {
+                var regexString = regexStrings[i];
+                debug.log(regexString);
+                extraKeywords = extraKeywords.replace(regexString, '')
+                    .replace(/s\s\s+/g, ' ').trim();
+                highlightRegex.push(regexString.replace(/(^;|;$)/g, '')
+                                    .trim());
+            }
         }
     }
 
@@ -142,11 +145,13 @@ exports.highlighting = function(data) {
         }
     }
 
-    for (i = 0; i < highlightRegex.length; i++) {
-        debug.log('Testing' + highlightRegex);
-        regex = new RegExp(highlightRegex[i], 'g');
-        if (regex.test(data.message)) {
-            return true;
+    if (useRegex) {
+        for (i = 0; i < highlightRegex.length; i++) {
+            debug.log('Testing' + highlightRegex);
+            regex = new RegExp(highlightRegex[i], 'g');
+            if (regex.test(data.message)) {
+                return true;
+            }
         }
     }
 

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -511,6 +511,12 @@ module.exports = [
         load: audibleFeedback.load
     },
     {
+        name: 'Regular Expression Highlighting',
+        description: 'Surround keywords with forward slashes to use them as regular expressions',
+        default: false,
+        storageKey: 'regexHighlights',
+    },
+    {
         name: 'Remove Deleted Messages',
         description: 'Completely removes timed out messages from view',
         default: false,
@@ -552,12 +558,6 @@ module.exports = [
         description: 'Automatically hide pinned highlights after 1 minute',
         default: false,
         storageKey: 'timeoutHighlights',
-    },
-    {
-        name: 'Regular Expression Highlighting',
-        description: 'Surround keywords with semicolons to treat them as regular expressions',
-        default: false,
-        storageKey: 'regexHighlights',
     },
     {
         name: 'Unread Whispers Count in Title',

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -511,8 +511,8 @@ module.exports = [
         load: audibleFeedback.load
     },
     {
-        name: 'Regular Expression Highlighting',
-        description: 'Surround keywords with forward slashes to use them as regular expressions',
+        name: 'Regex Highlighting/Blacklisting',
+        description: 'Surround terms with "/"s to use them as regular expressions',
         default: false,
         storageKey: 'regexHighlights',
     },
@@ -569,10 +569,32 @@ module.exports = [
         default: '',
         storageKey: 'blacklistKeywords',
         toggle: function(keywords) {
+            var blacklistRegexes = [];
+            var useRegex = bttv.settings.get('regexHighlights');
+            var i;
+            if (useRegex) {
+                // Pull the regular expressions out first so curly braces
+                // in the expression won't double count as phrases
+                var regexPhrase = /\/.+?\//g;
+                var regexStrings;
+                try {
+                    regexStrings = keywords.match(regexPhrase);
+                } catch (e) {
+                }
+                if (regexStrings) {
+                    for (i = 0; i < regexStrings.length; i++) {
+                        var regexString = regexStrings[i];
+                        keywords = keywords.replace(regexString, '')
+                            .replace(/s\s\s+/g, ' ').trim();
+                        blacklistRegexes.push('/' + regexString.replace(/(^\/|\/$)/g, '')
+                                              .trim() + '/');
+                    }
+                }
+            }
+
             var phraseRegex = /\{.+?\}/g;
             var testCases = keywords.match(phraseRegex);
             var phraseKeywords = [];
-            var i;
             if (testCases) {
                 for (i = 0; i < testCases.length; i++) {
                     var testCase = testCases[i];
@@ -581,7 +603,7 @@ module.exports = [
                 }
             }
 
-            keywords === '' ? keywords = phraseKeywords : keywords = keywords.split(' ').concat(phraseKeywords);
+            keywords === '' ? keywords = phraseKeywords.concat(blacklistRegexes) : keywords = keywords.split(' ').concat(phraseKeywords).concat(blacklistRegexes);
 
             for (i = 0; i < keywords.length; i++) {
                 if (/^\([a-z0-9_\-\*]+\)$/i.test(keywords[i])) {
@@ -637,19 +659,41 @@ module.exports = [
         default: (vars.userData.isLoggedIn ? vars.userData.name : ''),
         storageKey: 'highlightKeywords',
         toggle: function(keywords) {
+            var highlightRegexes = [];
+            var useRegex = bttv.settings.get('regexHighlights');
+            var i;
+            if (useRegex) {
+                // Pull the regular expressions out first so curly braces
+                // in the expression won't double count as phrases
+                var regexPhrase = /\/.+?\//g;
+                var regexStrings;
+                try {
+                    regexStrings = keywords.match(regexPhrase);
+                } catch (e) {
+                }
+                if (regexStrings) {
+                    for (i = 0; i < regexStrings.length; i++) {
+                        var regexString = regexStrings[i];
+                        keywords = keywords.replace(regexString, '')
+                            .replace(/s\s\s+/g, ' ').trim();
+                        highlightRegexes.push('/' + regexString.replace(/(^\/|\/$)/g, '')
+                                            .trim() + '/');
+                    }
+                }
+            }
+
             var phraseRegex = /\{.+?\}/g;
             var testCases = keywords.match(phraseRegex);
             var phraseKeywords = [];
-
             if (testCases) {
-                for (var i = 0; i < testCases.length; i++) {
+                for (i = 0; i < testCases.length; i++) {
                     var testCase = testCases[i];
                     keywords = keywords.replace(testCase, '').replace(/\s\s+/g, ' ').trim();
                     phraseKeywords.push('"' + testCase.replace(/(^\{|\}$)/g, '').trim() + '"');
                 }
             }
 
-            keywords === '' ? keywords = phraseKeywords : keywords = keywords.split(' ').concat(phraseKeywords);
+            keywords === '' ? keywords = phraseKeywords.concat(highlightRegexes) : keywords = keywords.split(' ').concat(phraseKeywords).concat(highlightRegexes);
 
             for (var j = 0; j < keywords.length; j++) {
                 if (/^\([a-z0-9_\-\*]+\)$/i.test(keywords[j])) {

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -554,6 +554,12 @@ module.exports = [
         storageKey: 'timeoutHighlights',
     },
     {
+        name: 'Regular Expression Highlighting',
+        description: 'Surround keywords with semicolons to treat them as regular expressions',
+        default: false,
+        storageKey: 'regexHighlights',
+    },
+    {
         name: 'Unread Whispers Count in Title',
         description: 'Display the number of unread whispers in the tab title',
         default: true,


### PR DESCRIPTION
Hey there,

Same old deal: PR to add regular expression highlighting for #267 after my last PR was closed (it's cool, I was lazy about getting it done :P). Anyway, I added the safe-regex package as suggested to deal with potentially browser-locking regexes. Curiously, I couldn't get Chrome or Firefox to lock up on an unsafe-regex like `(a+){10}` without it anyway, but, there are a multitude of bad regex's I agree should be avoided.

Hope this meets your expectations!
