### PR TITLE
Add highlighting to the JS code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For Firefox, you can add an exception to Firefox:
 In order to receive debug messages inside the browser's console log, you must toggle the consoleLog localStorage setting.
 
 Type this in the JavaScript console to enable console logging:
-```
+```js
 BetterTTV.settings.save('consoleLog', true);
 ```
 


### PR DESCRIPTION
Using GFM, I simply added a little bit of highlighting to a code block in the README.