### PR TITLE
Add AngelThump offset

### DIFF
--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -1781,6 +1781,15 @@ body.channel_new.columns.ember-application {
 .bttv-emo-58017bf38faabf4b3d00845d {
     margin-left: -32px;
 }
+/* AngelThump offset */
+.bttv-emo-566ca1a365dbbdab32ec055b + .bttv-emo-58017c088faabf4b3d008460,
+.bttv-emo-566ca1a365dbbdab32ec055b + .bttv-emo-5801777f8faabf4b3d008434,
+.bttv-emo-566ca1a365dbbdab32ec055b + .bttv-emo-58017be38faabf4b3d00845a,
+.bttv-emo-566ca1a365dbbdab32ec055b + .bttv-emo-58017bcc8faabf4b3d008456,
+.bttv-emo-566ca1a365dbbdab32ec055b + .bttv-emo-5802e7a5d336345f3d4e1ed5,
+.bttv-emo-566ca1a365dbbdab32ec055b + .bttv-emo-58017bf38faabf4b3d00845d {
+    margin-left: -60px;
+}
 .bttv-emo-58017bf38faabf4b3d00845d {
     z-index: 0;
 }
@@ -2070,4 +2079,3 @@ body.channel_new.columns.ember-application {
     content: "Hide";
     cursor: pointer;
 }
-

--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -1789,6 +1789,7 @@ body.channel_new.columns.ember-application {
 .bttv-emo-566ca1a365dbbdab32ec055b + .bttv-emo-5802e7a5d336345f3d4e1ed5,
 .bttv-emo-566ca1a365dbbdab32ec055b + .bttv-emo-58017bf38faabf4b3d00845d {
     margin-left: -60px;
+    margin-right: 26px;
 }
 .bttv-emo-58017bf38faabf4b3d00845d {
     z-index: 0;


### PR DESCRIPTION
# Description

Adds css selectors to correct AngelThump offset for overlapping `Hallo` emotes. 

## Before
![screen shot 2016-10-27 at 12 23 12 am](https://cloud.githubusercontent.com/assets/15053417/19754480/ed56e616-9bdb-11e6-9b04-601a0f5bf69d.jpg)

## After
![screen shot 2016-10-27 at 12 22 46 am](https://cloud.githubusercontent.com/assets/15053417/19754482/f0595b8c-9bdb-11e6-827c-879fb7912a94.jpg)
