### PR TITLE
Add change chat font family and size feature

### DIFF
--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -980,10 +980,9 @@ input, textarea, select {
 
 #chat_line_list .line p .chat_line, .ember-chat .chat-messages .chat-line {
     word-break: break-word;
-    padding-top: 5px;
+    padding: 0.4em 0.8em;
     margin-top: inherit;
-    padding-left: 10px;
-    padding-right: 10px;
+    line-height: 1.3em;
 }
 
 #chat_line_list li .nick, .ember-chat .chat-messages .from {

--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -980,8 +980,10 @@ input, textarea, select {
 
 #chat_line_list .line p .chat_line, .ember-chat .chat-messages .chat-line {
     word-break: break-word;
-    padding: .4em .8em;
+    padding-top: 5px;
     margin-top: inherit;
+    padding-left: 10px;
+    padding-right: 10px;
 }
 
 #chat_line_list li .nick, .ember-chat .chat-messages .from {

--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -980,10 +980,8 @@ input, textarea, select {
 
 #chat_line_list .line p .chat_line, .ember-chat .chat-messages .chat-line {
     word-break: break-word;
-    padding-top: 5px;
+    padding: .4em .8em;
     margin-top: inherit;
-    padding-left: 10px;
-    padding-right: 10px;
 }
 
 #chat_line_list li .nick, .ember-chat .chat-messages .from {

--- a/src/js/features/chat-font-settings.js
+++ b/src/js/features/chat-font-settings.js
@@ -16,11 +16,11 @@ var initFamilyCalled = false;
 var initSizeCalled = false;
 
 var styleSheetTextNode = (function() {
-	  var styleElement = document.createElement('style');
-	  document.head.appendChild(styleElement);
-	  styleElement.appendChild(document.createTextNode('/* ChatFontSettings for BetterTTV */'));
+    var styleElement = document.createElement('style');
+    document.head.appendChild(styleElement);
+    styleElement.appendChild(document.createTextNode('/* ChatFontSettings for BetterTTV */'));
     var styleTextNode = document.createTextNode('');
-	  styleElement.appendChild(styleTextNode);
+    styleElement.appendChild(styleTextNode);
     return styleTextNode;
 })();
 

--- a/src/js/features/chat-font-settings.js
+++ b/src/js/features/chat-font-settings.js
@@ -25,7 +25,10 @@ var styleSheetTextNode = (function() {
 })();
 
 function update() {
-    if (fontSize > 0) {
+    if (fontFamily === '' && fontSize === defaultFontSize) {
+        styleSheetTextNode.nodeValue = '';
+        return true;
+    } else if (fontSize > 0) {
         var padding = topPaddingRatio * fontSize + 'px ' + rightPaddingRatio * fontSize + 'px ' + bottomPaddingRatio * fontSize + 'px ' + leftPaddingRatio * fontSize + 'px';
         var font = (fontFamily.length > 0 ? fontFamily : defaultFontFamily);
         var cssText = styleRule.replace('<padding>', padding).replace('<family>', font).replace('<size>', fontSize);

--- a/src/js/features/chat-font-settings.js
+++ b/src/js/features/chat-font-settings.js
@@ -1,21 +1,10 @@
 var styleRule = '.chat-messages, .chat-messages .chat-line { <declarations> }';
 var styleFontFamilyDeclaration = 'font-family: <family> !important; ';
 var styleFontSizeDeclaration = 'font-size: <size> !important; ';
-var stylePaddingDeclaration = 'padding: <padding> !important; ';
-// Defaults from BTTV 6.8R55, fetching dynamically takes too long
-var defaultFontSize = 13.33333;
-var defaultTopPadding = 5;
-var defaultBottomPadding = 6;
-var defaultLeftPadding = 10;
-var defaultRightPadding = 10;
 
-var topPaddingRatio = defaultTopPadding / defaultFontSize;
-var bottomPaddingRatio = defaultBottomPadding / defaultFontSize;
-var leftPaddingRatio = defaultLeftPadding / defaultFontSize;
-var rightPaddingRatio = defaultRightPadding / defaultFontSize;
 var styleNode = null;
 var fontFamily = '';
-var fontSize = defaultFontSize;
+var fontSize = 0;
 var initFamilyCalled = false;
 var initSizeCalled = false;
 
@@ -27,13 +16,9 @@ function createStyleSheet() {
     styleElement.appendChild(styleNode);
 }
 
-function getPadding(ratioToFont) {
-    return (Math.round(ratioToFont * fontSize * 100) / 100) + 'px';
-}
-
 function update() {
-    if (fontSize > 0) {
-        if (fontFamily === '' && fontSize === defaultFontSize) {
+    if (fontSize >= 0) {
+        if (fontFamily === '' && fontSize === 0) {
             styleNode.nodeValue = '';
         } else {
             var styleDeclarations = '';
@@ -41,17 +26,16 @@ function update() {
                 var fontFamilyValue = (fontFamily.indexOf(' ') >= 0 ? '\"' + fontFamily + '\"' : fontFamily);
                 styleDeclarations = styleFontFamilyDeclaration.replace('<family>', fontFamilyValue);
             }
-            if (fontSize !== defaultFontSize) {
+            if (fontSize > 0) {
                 var fontSizeValue = fontSize + 'px';
-                var paddingValue = getPadding(topPaddingRatio) + ' ' + getPadding(rightPaddingRatio) + ' ' + getPadding(bottomPaddingRatio) + ' ' + getPadding(leftPaddingRatio);
-                styleDeclarations = styleDeclarations + styleFontSizeDeclaration.replace('<size>', fontSizeValue) + stylePaddingDeclaration.replace('<padding>', paddingValue);
+                styleDeclarations = styleFontSizeDeclaration.replace('<size>', fontSizeValue);
             }
             styleNode.nodeValue = styleRule.replace('<declarations>', styleDeclarations);
         }
         return true;
     } else {
-        fontSize = defaultFontSize;
-        bttv.settings.save('chatFontSize', defaultFontSize);
+        fontSize = 0;
+        bttv.settings.save('chatFontSize', 0);
         return false;
     }
 }
@@ -78,9 +62,11 @@ exports.initFontSize = function() {
 exports.setFontFamily = function(font) {
     fontFamily = font;
     if (update()) {
-        var message = 'Chat font is now set to: ' + fontFamily;
-        if (fontFamily.length === 0) {
-            message = message + '(default)';
+        var message;
+        if (fontFamily.length > 0) {
+            message = 'Chat font is now set to: ' + fontFamily;
+        } else {
+            message = 'Chat font is now set to default.';
         }
         bttv.chat.helpers.serverMessage(message, true);
     }
@@ -89,9 +75,11 @@ exports.setFontFamily = function(font) {
 exports.setFontSize = function(size) {
     fontSize = size;
     if (update()) {
-        var message = 'Chat font size is now set to: ' + fontSize + 'px';
-        if (fontSize === defaultFontSize) {
-            message = message + ' (default)';
+        var message;
+        if (fontSize > 0) {
+            message = 'Chat font size is now set to: ' + fontSize + 'px';
+        } else {
+            message = 'Chat font size is now set to default.';
         }
         bttv.chat.helpers.serverMessage(message, true);
     }

--- a/src/js/features/chat-font-settings.js
+++ b/src/js/features/chat-font-settings.js
@@ -1,7 +1,22 @@
-var styleRule = '.chat-messages, .chat-messages .chat-line { <declarations> }';
-var styleFontFamilyDeclaration = 'font-family: <family> !important; ';
-var styleFontSizeDeclaration = 'font-size: <size> !important; ';
+var styleRule = '.ember-chat .chat-messages, .ember-chat .chat-messages .chat-line { <var> }';
+var styleFontFamilyDeclaration = 'font-family: <var>; ';
+var styleFontSizeDeclaration = 'font-size: <var>; ';
+var styleLineHeightDeclaration = 'line-height: <var>; ';
+var stylePaddingDeclaration = 'padding: <var>; ';
+var defaultCheckingInterval = 200;
+var styleSheetBttvFileName = 'betterttv.css';
 
+var defaultFontFamily = '';
+var defaultFontSize = 0;
+var defaultLineHeight = 0;
+var defaultTopPadding = 0;
+var defaultRightPadding = 0;
+var defaultBottomPadding = 0;
+var defaultLeftPadding = 0;
+
+var styleSheetBttvLoaded = false;
+var defaultsLoaded = false;
+var styleSheetCreated = false;
 var styleNode = null;
 var fontFamily = '';
 var fontSize = 0;
@@ -10,27 +25,50 @@ var initSizeCalled = false;
 
 function createStyleSheet() {
     var styleElement = document.createElement('style');
-    document.head.appendChild(styleElement);
+    document.body.appendChild(styleElement);
     styleElement.appendChild(document.createTextNode('/* ChatFontSettings for BetterTTV */'));
     styleNode = document.createTextNode('');
     styleElement.appendChild(styleNode);
 }
 
+function getLineHeight() {
+    return (Math.round(defaultLineHeight / defaultFontSize * fontSize * 100) / 100) + 'px';
+}
+
+function getPaddingSide(ratioToFont) {
+    return (Math.round(ratioToFont * fontSize * 100) / 100) + 'px';
+}
+
+function getPadding() {
+    var topPadding = getPaddingSide(defaultTopPadding / defaultFontSize);
+    var rightPadding = getPaddingSide(defaultRightPadding / defaultFontSize);
+    var bottomPadding = getPaddingSide(defaultBottomPadding / defaultFontSize);
+    var leftPadding = getPaddingSide(defaultLeftPadding / defaultFontSize);
+    return topPadding + ' ' + rightPadding + ' ' + bottomPadding + ' ' + leftPadding;
+}
+
 function update() {
-    if (fontSize >= 0) {
+    if (!defaultsLoaded) {
+    } else if (fontSize >= 0) {
+        if (!styleSheetCreated) {
+            // Create after defaults are loaded, so that it's placed after defaults in DOM.
+            createStyleSheet();
+            styleSheetCreated = true;
+        }
         if (fontFamily === '' && fontSize === 0) {
             styleNode.nodeValue = '';
         } else {
             var styleDeclarations = '';
             if (fontFamily.length > 0) {
                 var fontFamilyValue = (fontFamily.indexOf(' ') >= 0 ? '\"' + fontFamily + '\"' : fontFamily);
-                styleDeclarations = styleFontFamilyDeclaration.replace('<family>', fontFamilyValue);
+                styleDeclarations += styleFontFamilyDeclaration.replace('<var>', fontFamilyValue);
             }
             if (fontSize > 0) {
-                var fontSizeValue = fontSize + 'px';
-                styleDeclarations = styleFontSizeDeclaration.replace('<size>', fontSizeValue);
+                styleDeclarations += styleFontSizeDeclaration.replace('<var>', fontSize + 'px');
+                styleDeclarations += styleLineHeightDeclaration.replace('<var>', getLineHeight());
+                styleDeclarations += stylePaddingDeclaration.replace('<var>', getPadding());
             }
-            styleNode.nodeValue = styleRule.replace('<declarations>', styleDeclarations);
+            styleNode.nodeValue = styleRule.replace('<var>', styleDeclarations);
         }
         return true;
     } else {
@@ -40,11 +78,45 @@ function update() {
     }
 }
 
+function loadDefaults(style) {
+    defaultFontFamily = style.fontFamily.split(',')[0].replace('\"', '').replace('\"', '');
+    defaultFontSize = parseFloat(style.fontSize);
+    defaultLineHeight = parseFloat(style.lineHeight);
+    defaultTopPadding = parseFloat(style.paddingTop);
+    defaultRightPadding = parseFloat(style.paddingRight);
+    defaultBottomPadding = parseFloat(style.paddingBottom);
+    defaultLeftPadding = parseFloat(style.paddingLeft);
+}
+
+function checkDefaults() {
+    if (!styleSheetBttvLoaded) {
+        var sheets = document.styleSheets;
+        for (var i = 0; i < sheets.length; i++) {
+            if (sheets[i].href && sheets[i].href.toLowerCase().indexOf(styleSheetBttvFileName)) {
+                styleSheetBttvLoaded = true;
+                break;
+            }
+        }
+    }
+    if (styleSheetBttvLoaded) {
+        var firstChatLine = document.querySelector('.chat-messages .chat-line');
+        if (firstChatLine !== null) {
+            var style = window.getComputedStyle(firstChatLine);
+            loadDefaults(style);
+            defaultsLoaded = true;
+            update();
+        }
+    }
+    if (!defaultsLoaded) {
+        setTimeout(checkDefaults, defaultCheckingInterval);
+    }
+}
+
 function init() {
     if (initFamilyCalled && initSizeCalled) {
+        checkDefaults();
         fontFamily = bttv.settings.get('chatFontFamily');
         fontSize = bttv.settings.get('chatFontSize');
-        createStyleSheet();
         update();
     }
 }
@@ -62,11 +134,11 @@ exports.initFontSize = function() {
 exports.setFontFamily = function(font) {
     fontFamily = font;
     if (update()) {
-        var message;
+        var message = 'Chat font is now set to: ';
         if (fontFamily.length > 0) {
-            message = 'Chat font is now set to: ' + fontFamily;
+            message += fontFamily;
         } else {
-            message = 'Chat font is now set to default.';
+            message += defaultFontFamily + ' (default)';
         }
         bttv.chat.helpers.serverMessage(message, true);
     }
@@ -75,11 +147,11 @@ exports.setFontFamily = function(font) {
 exports.setFontSize = function(size) {
     fontSize = size;
     if (update()) {
-        var message;
+        var message = 'Chat font size is now set to: ';
         if (fontSize > 0) {
-            message = 'Chat font size is now set to: ' + fontSize + 'px';
+            message += fontSize + 'px';
         } else {
-            message = 'Chat font size is now set to default.';
+            message += defaultFontSize + 'px (default)';
         }
         bttv.chat.helpers.serverMessage(message, true);
     }

--- a/src/js/features/chat-font-settings.js
+++ b/src/js/features/chat-font-settings.js
@@ -1,0 +1,79 @@
+var styleRule = '.chat-messages, .chat-messages .chat-line { padding: <padding> !important; font-family: <family> !important; font-size: <size>px !important; }';
+var defaultFontFamily = 'inherit'; // Inherit from parent
+// Fetching these defaults dynamically takes too long since some style sheets load late
+var defaultFontSize = 13.33333; // Fallback value (from BTTV 6.8R55)
+var defaultTopPadding = 5; // Fallback value (from BTTV 6.8R55)
+var defaultBottomPadding = 6; // Fallback value (from Twitch nov 2016)
+var defaultLeftPadding = 10; // Fallback value (from BTTV 6.8R55)
+var defaultRightPadding = 10; // Fallback value (from BTTV 6.8R55)
+var topPaddingRatio = defaultTopPadding / defaultFontSize;
+var bottomPaddingRatio = defaultBottomPadding / defaultFontSize;
+var leftPaddingRatio = defaultLeftPadding / defaultFontSize;
+var rightPaddingRatio = defaultRightPadding / defaultFontSize;
+var fontFamily = '';
+var fontSize = defaultFontSize;
+var initFamilyCalled = false;
+var initSizeCalled = false;
+
+var styleSheetTextNode = (function() {
+	  var styleElement = document.createElement('style');
+	  document.head.appendChild(styleElement);
+	  styleElement.appendChild(document.createTextNode('/* ChatFontSettings for BetterTTV */'));
+    var styleTextNode = document.createTextNode('');
+	  styleElement.appendChild(styleTextNode);
+    return styleTextNode;
+})();
+
+function update() {
+    if (fontSize > 0) {
+        var padding = topPaddingRatio * fontSize + 'px ' + rightPaddingRatio * fontSize + 'px ' + bottomPaddingRatio * fontSize + 'px ' + leftPaddingRatio * fontSize + 'px';
+        var font = (fontFamily.length > 0 ? fontFamily : defaultFontFamily);
+        var cssText = styleRule.replace('<padding>', padding).replace('<family>', font).replace('<size>', fontSize);
+        styleSheetTextNode.nodeValue = cssText;
+        return true;
+    } else {
+        fontSize = defaultFontSize;
+        bttv.settings.save('chatFontSize', defaultFontSize);
+        return false;
+    }
+}
+
+function init() {
+    if (initFamilyCalled && initSizeCalled) {
+        fontFamily = bttv.settings.get('chatFontFamily');
+        fontSize = bttv.settings.get('chatFontSize');
+        update();
+    }
+}
+
+exports.initFontFamily = function() {
+    initFamilyCalled = true;
+    init();
+};
+
+exports.initFontSize = function() {
+    initSizeCalled = true;
+    init();
+};
+
+exports.setFontFamily = function(font) {
+    fontFamily = font;
+    if (update()) {
+        var message = 'Chat font is now set to: ' + fontFamily;
+        if (fontFamily.length === 0) {
+            message = message + '(default)';
+        }
+        bttv.chat.helpers.serverMessage(message, true);
+    }
+};
+
+exports.setFontSize = function(size) {
+    fontSize = size;
+    if (update()) {
+        var message = 'Chat font size is now set to: ' + fontSize + 'px';
+        if (fontSize === defaultFontSize) {
+            message = message + ' (default)';
+        }
+        bttv.chat.helpers.serverMessage(message, true);
+    }
+};

--- a/src/js/features/chat-font-settings.js
+++ b/src/js/features/chat-font-settings.js
@@ -1,38 +1,53 @@
-var styleRule = '.chat-messages, .chat-messages .chat-line { padding: <padding> !important; font-family: <family> !important; font-size: <size>px !important; }';
-var defaultFontFamily = 'inherit'; // Inherit from parent
-// Fetching these defaults dynamically takes too long since some style sheets load late
-var defaultFontSize = 13.33333; // Fallback value (from BTTV 6.8R55)
-var defaultTopPadding = 5; // Fallback value (from BTTV 6.8R55)
-var defaultBottomPadding = 6; // Fallback value (from Twitch nov 2016)
-var defaultLeftPadding = 10; // Fallback value (from BTTV 6.8R55)
-var defaultRightPadding = 10; // Fallback value (from BTTV 6.8R55)
+var styleRule = '.chat-messages, .chat-messages .chat-line { <declarations> }';
+var styleFontFamilyDeclaration = 'font-family: <family> !important; ';
+var styleFontSizeDeclaration = 'font-size: <size> !important; ';
+var stylePaddingDeclaration = 'padding: <padding> !important; ';
+// Defaults from BTTV 6.8R55, fetching dynamically takes too long
+var defaultFontSize = 13.33333;
+var defaultTopPadding = 5;
+var defaultBottomPadding = 6;
+var defaultLeftPadding = 10;
+var defaultRightPadding = 10;
+
 var topPaddingRatio = defaultTopPadding / defaultFontSize;
 var bottomPaddingRatio = defaultBottomPadding / defaultFontSize;
 var leftPaddingRatio = defaultLeftPadding / defaultFontSize;
 var rightPaddingRatio = defaultRightPadding / defaultFontSize;
+var styleNode = null;
 var fontFamily = '';
 var fontSize = defaultFontSize;
 var initFamilyCalled = false;
 var initSizeCalled = false;
 
-var styleSheetTextNode = (function() {
+function createStyleSheet() {
     var styleElement = document.createElement('style');
     document.head.appendChild(styleElement);
     styleElement.appendChild(document.createTextNode('/* ChatFontSettings for BetterTTV */'));
-    var styleTextNode = document.createTextNode('');
-    styleElement.appendChild(styleTextNode);
-    return styleTextNode;
-})();
+    styleNode = document.createTextNode('');
+    styleElement.appendChild(styleNode);
+}
+
+function getPadding(ratioToFont) {
+    return (Math.round(ratioToFont * fontSize * 100) / 100) + 'px';
+}
 
 function update() {
-    if (fontFamily === '' && fontSize === defaultFontSize) {
-        styleSheetTextNode.nodeValue = '';
-        return true;
-    } else if (fontSize > 0) {
-        var padding = topPaddingRatio * fontSize + 'px ' + rightPaddingRatio * fontSize + 'px ' + bottomPaddingRatio * fontSize + 'px ' + leftPaddingRatio * fontSize + 'px';
-        var font = (fontFamily.length > 0 ? fontFamily : defaultFontFamily);
-        var cssText = styleRule.replace('<padding>', padding).replace('<family>', font).replace('<size>', fontSize);
-        styleSheetTextNode.nodeValue = cssText;
+    if (fontSize > 0) {
+        if (fontFamily === '' && fontSize === defaultFontSize) {
+            styleNode.nodeValue = '';
+        } else {
+            var styleDeclarations = '';
+            if (fontFamily.length > 0) {
+                var fontFamilyValue = (fontFamily.indexOf(' ') >= 0 ? '\"' + fontFamily + '\"' : fontFamily);
+                styleDeclarations = styleFontFamilyDeclaration.replace('<family>', fontFamilyValue);
+            }
+            if (fontSize !== defaultFontSize) {
+                var fontSizeValue = fontSize + 'px';
+                var paddingValue = getPadding(topPaddingRatio) + ' ' + getPadding(rightPaddingRatio) + ' ' + getPadding(bottomPaddingRatio) + ' ' + getPadding(leftPaddingRatio);
+                styleDeclarations = styleDeclarations + styleFontSizeDeclaration.replace('<size>', fontSizeValue) + stylePaddingDeclaration.replace('<padding>', paddingValue);
+            }
+            styleNode.nodeValue = styleRule.replace('<declarations>', styleDeclarations);
+        }
         return true;
     } else {
         fontSize = defaultFontSize;
@@ -45,6 +60,7 @@ function init() {
     if (initFamilyCalled && initSizeCalled) {
         fontFamily = bttv.settings.get('chatFontFamily');
         fontSize = bttv.settings.get('chatFontSize');
+        createStyleSheet();
         update();
     }
 }

--- a/src/js/features/chat-font-settings.js
+++ b/src/js/features/chat-font-settings.js
@@ -1,22 +1,8 @@
 var styleRule = '.ember-chat .chat-messages, .ember-chat .chat-messages .chat-line { <var> }';
-var styleFontFamilyDeclaration = 'font-family: <var>; ';
-var styleFontSizeDeclaration = 'font-size: <var>; ';
-var styleLineHeightDeclaration = 'line-height: <var>; ';
-var stylePaddingDeclaration = 'padding: <var>; ';
-var defaultCheckingInterval = 200;
-var styleSheetBttvFileName = 'betterttv.css';
+var styleFontFamilyDeclaration = 'font-family: <var> !important; ';
+var styleFontSizeDeclaration = 'font-size: <var> !important; ';
+var fallbackFontFamily = 'sans-serif';
 
-var defaultFontFamily = '';
-var defaultFontSize = 0;
-var defaultLineHeight = 0;
-var defaultTopPadding = 0;
-var defaultRightPadding = 0;
-var defaultBottomPadding = 0;
-var defaultLeftPadding = 0;
-
-var styleSheetBttvLoaded = false;
-var defaultsLoaded = false;
-var styleSheetCreated = false;
 var styleNode = null;
 var fontFamily = '';
 var fontSize = 0;
@@ -31,92 +17,27 @@ function createStyleSheet() {
     styleElement.appendChild(styleNode);
 }
 
-function getLineHeight() {
-    return (Math.round(defaultLineHeight / defaultFontSize * fontSize * 100) / 100) + 'px';
-}
-
-function getPaddingSide(ratioToFont) {
-    return (Math.round(ratioToFont * fontSize * 100) / 100) + 'px';
-}
-
-function getPadding() {
-    var topPadding = getPaddingSide(defaultTopPadding / defaultFontSize);
-    var rightPadding = getPaddingSide(defaultRightPadding / defaultFontSize);
-    var bottomPadding = getPaddingSide(defaultBottomPadding / defaultFontSize);
-    var leftPadding = getPaddingSide(defaultLeftPadding / defaultFontSize);
-    return topPadding + ' ' + rightPadding + ' ' + bottomPadding + ' ' + leftPadding;
-}
-
 function update() {
-    if (!defaultsLoaded) {
-    } else if (fontSize >= 0) {
-        if (!styleSheetCreated) {
-            // Create after defaults are loaded, so that it's placed after defaults in DOM.
-            createStyleSheet();
-            styleSheetCreated = true;
-        }
-        if (fontFamily === '' && fontSize === 0) {
-            styleNode.nodeValue = '';
-        } else {
-            var styleDeclarations = '';
-            if (fontFamily.length > 0) {
-                var fontFamilyValue = (fontFamily.indexOf(' ') >= 0 ? '\"' + fontFamily + '\"' : fontFamily);
-                styleDeclarations += styleFontFamilyDeclaration.replace('<var>', fontFamilyValue);
-            }
-            if (fontSize > 0) {
-                styleDeclarations += styleFontSizeDeclaration.replace('<var>', fontSize + 'px');
-                styleDeclarations += styleLineHeightDeclaration.replace('<var>', getLineHeight());
-                styleDeclarations += stylePaddingDeclaration.replace('<var>', getPadding());
-            }
-            styleNode.nodeValue = styleRule.replace('<var>', styleDeclarations);
-        }
-        return true;
+    if (fontFamily === '' && fontSize === 0) {
+        styleNode.nodeValue = '';
     } else {
-        fontSize = 0;
-        bttv.settings.save('chatFontSize', 0);
-        return false;
-    }
-}
-
-function loadDefaults(style) {
-    defaultFontFamily = style.fontFamily.split(',')[0].replace('\"', '').replace('\"', '');
-    defaultFontSize = parseFloat(style.fontSize);
-    defaultLineHeight = parseFloat(style.lineHeight);
-    defaultTopPadding = parseFloat(style.paddingTop);
-    defaultRightPadding = parseFloat(style.paddingRight);
-    defaultBottomPadding = parseFloat(style.paddingBottom);
-    defaultLeftPadding = parseFloat(style.paddingLeft);
-}
-
-function checkDefaults() {
-    if (!styleSheetBttvLoaded) {
-        var sheets = document.styleSheets;
-        for (var i = 0; i < sheets.length; i++) {
-            if (sheets[i].href && sheets[i].href.toLowerCase().indexOf(styleSheetBttvFileName)) {
-                styleSheetBttvLoaded = true;
-                break;
-            }
+        var styleDeclarations = '';
+        if (fontFamily.length > 0) {
+            var fontFamilyValue = (fontFamily.indexOf(' ') >= 0 ? '\"' + fontFamily + '\"' : fontFamily) + ', ' + fallbackFontFamily;
+            styleDeclarations += styleFontFamilyDeclaration.replace('<var>', fontFamilyValue);
         }
-    }
-    if (styleSheetBttvLoaded) {
-        var firstChatLine = document.querySelector('.chat-messages .chat-line');
-        if (firstChatLine !== null) {
-            var style = window.getComputedStyle(firstChatLine);
-            loadDefaults(style);
-            defaultsLoaded = true;
-            update();
+        if (fontSize > 0) {
+            styleDeclarations += styleFontSizeDeclaration.replace('<var>', fontSize + 'px');
         }
-    }
-    if (!defaultsLoaded) {
-        setTimeout(checkDefaults, defaultCheckingInterval);
+        styleNode.nodeValue = styleRule.replace('<var>', styleDeclarations);
     }
 }
 
 function init() {
     if (initFamilyCalled && initSizeCalled) {
-        checkDefaults();
         fontFamily = bttv.settings.get('chatFontFamily');
         fontSize = bttv.settings.get('chatFontSize');
+        createStyleSheet();
         update();
     }
 }
@@ -133,26 +54,24 @@ exports.initFontSize = function() {
 
 exports.setFontFamily = function(font) {
     fontFamily = font;
-    if (update()) {
-        var message = 'Chat font is now set to: ';
-        if (fontFamily.length > 0) {
-            message += fontFamily;
-        } else {
-            message += defaultFontFamily + ' (default)';
-        }
-        bttv.chat.helpers.serverMessage(message, true);
+    update();
+    var message;
+    if (fontFamily.length > 0) {
+        message = message = 'Chat font is now set to: ' + fontFamily;
+    } else {
+        message = message = 'Chat font is now set to default.';
     }
+    bttv.chat.helpers.serverMessage(message, true);
 };
 
 exports.setFontSize = function(size) {
     fontSize = size;
-    if (update()) {
-        var message = 'Chat font size is now set to: ';
-        if (fontSize > 0) {
-            message += fontSize + 'px';
-        } else {
-            message += defaultFontSize + 'px (default)';
-        }
-        bttv.chat.helpers.serverMessage(message, true);
+    update();
+    var message;
+    if (fontSize > 0) {
+        message = 'Chat font size is now set to: ' + fontSize + 'px';
+    } else {
+        message = 'Chat font size is now set to default.';
     }
+    bttv.chat.helpers.serverMessage(message, true);
 };

--- a/src/js/features/chat-load-settings.js
+++ b/src/js/features/chat-load-settings.js
@@ -83,6 +83,24 @@ module.exports = function() {
         }
     });
 
+    $('.setFontFamily').click(function(e) {
+        e.preventDefault();
+        var font = prompt('What font family do you want for chat? You can have multiple font families separated by comma if you want fallbacks. If a font family contains spaces, it must be in quotation marks. Try monospace or "Comic Sans MS" or leave the field blank to use default.', bttv.settings.get('chatFontFamily'));
+        if (font !== null) {
+            bttv.settings.save('chatFontFamily', font);
+        }
+    });
+
+    $('.setFontSize').click(function(e) {
+        e.preventDefault();
+        var size = prompt('What font size (in pixels) do you want for chat? Twitch default is 12, BetterTTV default is 13.33333. Leave the field blank to use BetterTTV default.', bttv.settings.get('chatFontSize'));
+        if (size !== null && size === '') {
+            bttv.settings.save('chatFontSize', -1);
+        } else if (size !== null && !isNaN(size)) {
+            bttv.settings.save('chatFontSize', parseInt(size, 10));
+        }
+    });
+
     // Make chat settings scrollable
     $('.ember-chat .chat-settings').css('max-height', $(window).height() - 100);
 };

--- a/src/js/features/chat-load-settings.js
+++ b/src/js/features/chat-load-settings.js
@@ -97,11 +97,16 @@ module.exports = function() {
     $('.setFontSize').click(function(e) {
         e.preventDefault();
         var currentSize = bttv.settings.get('chatFontSize');
-        var size = prompt('Enter font size for chat (in pixels, but don\'t write that). Twitch default is 12, BetterTTV default is 13.33333. Leave the field blank to use default.', (currentSize > 0 ? currentSize : ''));
-        if (size !== null && size === '') {
-            bttv.settings.save('chatFontSize', 0);
-        } else if (size !== null && !isNaN(size)) {
-            bttv.settings.save('chatFontSize', parseFloat(size, 10));
+        var size = prompt('Enter font size for chat. Leave the blank to use default (13.33333).', (currentSize > 0 ? currentSize : ''));
+        if (size !== null) {
+            var fontSize = 0;
+            if (!isNaN(size)) {
+                var inputSize = parseFloat(size, 10);
+                if (inputSize > 0) {
+                    fontSize = inputSize;
+                }
+            }
+            bttv.settings.save('chatFontSize', fontSize);
         }
     });
 

--- a/src/js/features/chat-load-settings.js
+++ b/src/js/features/chat-load-settings.js
@@ -96,11 +96,12 @@ module.exports = function() {
 
     $('.setFontSize').click(function(e) {
         e.preventDefault();
-        var size = prompt('Enter font size for chat (in pixels, but don\'t write that). Twitch default is 12, BetterTTV default is 13.33333. Leave the field blank to use default.', bttv.settings.get('chatFontSize'));
+        var currentSize = bttv.settings.get('chatFontSize');
+        var size = prompt('Enter font size for chat (in pixels, but don\'t write that). Twitch default is 12, BetterTTV default is 13.33333. Leave the field blank to use default.', (currentSize > 0 ? currentSize : ''));
         if (size !== null && size === '') {
-            bttv.settings.save('chatFontSize', -1);
+            bttv.settings.save('chatFontSize', 0);
         } else if (size !== null && !isNaN(size)) {
-            bttv.settings.save('chatFontSize', parseInt(size, 10));
+            bttv.settings.save('chatFontSize', parseFloat(size, 10));
         }
     });
 

--- a/src/js/features/chat-load-settings.js
+++ b/src/js/features/chat-load-settings.js
@@ -85,15 +85,18 @@ module.exports = function() {
 
     $('.setFontFamily').click(function(e) {
         e.preventDefault();
-        var font = prompt('What font family do you want for chat? You can have multiple font families separated by comma if you want fallbacks. If a font family contains spaces, it must be in quotation marks. Try monospace or "Comic Sans MS" or leave the field blank to use default.', bttv.settings.get('chatFontFamily'));
-        if (font !== null) {
+        var font = prompt('Enter font name for chat. Try "monospace" or "Comic Sans MS" or leave the field blank to use default.', bttv.settings.get('chatFontFamily'));
+        var unsafeFontRegex = /[^A-Za-z0-9\s\.,&\+\-_!]/;
+        if (font !== null && unsafeFontRegex.test(font)) {
+            bttv.chat.helpers.serverMessage('Chat font could not be changed: It contained illegal characters.', true);
+        } else if (font !== null) {
             bttv.settings.save('chatFontFamily', font);
         }
     });
 
     $('.setFontSize').click(function(e) {
         e.preventDefault();
-        var size = prompt('What font size (in pixels) do you want for chat? Twitch default is 12, BetterTTV default is 13.33333. Leave the field blank to use BetterTTV default.', bttv.settings.get('chatFontSize'));
+        var size = prompt('Enter font size for chat (in pixels, but don\'t write that). Twitch default is 12, BetterTTV default is 13.33333. Leave the field blank to use default.', bttv.settings.get('chatFontSize'));
         if (size !== null && size === '') {
             bttv.settings.save('chatFontSize', -1);
         } else if (size !== null && !isNaN(size)) {

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -692,7 +692,7 @@ module.exports = [
     },
     {
         storageKey: 'chatFontSize',
-        default: -1,
+        default: 0,
         load: function() {
             chatFontSettings.initFontSize();
         },

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -10,7 +10,8 @@ var splitChat = require('./features/split-chat'),
     disableChannelHeader = require('./features/disable-channel-header'),
     handleTwitchChatEmotesScript = require('./features/handle-twitchchat-emotes'),
     audibleFeedback = require('./features/audible-feedback'),
-    imagePreview = require('./features/image-preview');
+    imagePreview = require('./features/image-preview'),
+    chatFontSettings = require('./features/chat-font-settings');
 
 var displayElement = require('./helpers/element').display,
     removeElement = require('./helpers/element').remove;
@@ -677,6 +678,26 @@ module.exports = [
             } else {
                 chat.helpers.serverMessage('Chat scrollback is now set to: ' + lines, true);
             }
+        }
+    },
+    {
+        storageKey: 'chatFontFamily',
+        default: '',
+        load: function() {
+            chatFontSettings.initFontFamily();
+        },
+        toggle: function(font) {
+            chatFontSettings.setFontFamily(font);
+        }
+    },
+    {
+        storageKey: 'chatFontSize',
+        default: -1,
+        load: function() {
+            chatFontSettings.initFontSize();
+        },
+        toggle: function(size) {
+            chatFontSettings.setFontSize(size);
         }
     }
 ];

--- a/src/templates/chat-settings.pug
+++ b/src/templates/chat-settings.pug
@@ -12,6 +12,8 @@
     p: a.g18_gear-00000080.setBlacklistKeywords(href="#") Set Blacklist Keywords
     p: a.g18_gear-00000080.setHighlightKeywords(href="#") Set Highlight Keywords
     p: a.g18_gear-00000080.setScrollbackAmount(href="#") Set Scrollback Amount
+    p: a.g18_gear-00000080.setFontFamily(href="#") Set Font
+    p: a.g18_gear-00000080.setFontSize(href="#") Set Font Size
     p: a.g18_trash-00000080.clearChat(href="#") Clear My Chat
     p: a.button-simple.dark.openSettings(href="#" style="display: block;margin-top: 8px;text-align: center;")
         | BetterTTV Settings


### PR DESCRIPTION
Added "Set font" and "Set font size" to chat options. If default font family and size is used, no styles will be added or changed.

If accepted, it should solve [Font Settings #57](https://github.com/night/BetterTTV/issues/57).