### PR TITLE
Add support for loading float settings

### DIFF
--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -16,7 +16,7 @@ Settings.prototype._parseSetting = function(value) {
     } else if (value === '') {
         return '';
     } else if (isNaN(value) === false) {
-        return parseInt(value, 10);
+        return parseFloat(value, 10);
     }
 
     return value;


### PR DESCRIPTION
Settings can now load floats. Ints are still loaded as ints. Tested with feature request [#1782](https://github.com/night/BetterTTV/pull/1782).