### PR TITLE
Remove margin from pinned cheers

### DIFF
--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -2153,6 +2153,7 @@ body.channel_new.columns.ember-application {
 .pinned-cheers {
     padding-bottom: 10px;
     padding-left: 5px;
+    margin: 0;
 }
 
 .pinned-cheers:before {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7132646/20778706/3247c762-b735-11e6-81a7-ad7759115502.png)

Mentions under the recent cheer become visible around the edges. Removing the margin set by Twitch in the `.sticky-message--pinned-cheers` rule will resolve this issue.