### PR TITLE
Fix multiple viewer counters

### DIFF
--- a/src/js/features/player-viewer-count.js
+++ b/src/js/features/player-viewer-count.js
@@ -2,7 +2,9 @@ module.exports = function() {
     var controller = window.App && App.__container__.lookup('controller:channel');
     if (!controller || !controller.channelModel) return;
 
-    $('div.player-livestatus').append('<span class="player-viewer-count"></span>');
+    if ($('div.player-livestatus .player-viewer-count').length === 0) {
+        $('div.player-livestatus').append('<span class="player-viewer-count"></span>');
+    }
     var updateViewerCount = function(model, key) {
         var label = Twitch.display.commatize(model.get(key)) + ' viewers';
         $('.player-viewer-count').text(label);


### PR DESCRIPTION
A new viewer counter was created every time I opened a new live channel without reloading the page (whenever the application route was set to 'channel.index.index', whatever that means). Now it checks if there already is one before inserting one.

Fixes this:
![live](https://cloud.githubusercontent.com/assets/456392/21005839/bfaf0226-bd36-11e6-9975-879506841d41.png)
