### PR TITLE
Changes for Collapse Channel Header (different issue; not a duplicate of the previous PR)

### DIFF
--- a/src/js/features/disable-channel-header.js
+++ b/src/js/features/disable-channel-header.js
@@ -17,16 +17,9 @@ module.exports = function(state) {
     var routeName = App.__container__.lookup('controller:application').get('currentRouteName');
     if (routeName.substr(0, 8) !== 'channel.') return;
 
-    var playerService = App.__container__.lookup('service:player');
     if (bttv.settings.get('disableChannelHeader') === true) {
-        playerService.fullSizePlayerLocation.top = 75;
         setHeaderHeight(0);
     } else if (state === false) {
-        playerService.fullSizePlayerLocation.top = 455;
         setHeaderHeight(380);
     }
-
-    try {
-        playerService.playerComponent.ownerView.rerender();
-    } catch (e) {}
 };


### PR DESCRIPTION
I cleared some of it up.
`playerService.playerComponent.ownerView.rerender()` didn't exist because `playerService.playerComponent` is `null` when you're not logged in (also, `.set('fullSizePlayerLocation', {top: x, left: y})` doesn't work if you're not logged in).
Also, `playerService.playerComponent.ownerView.rerender()` resets `playerService.fullSizePlayerLocation` back to `{top: 85, left: 30}` (for me), regardless of what it's set to before `rerender()` is called.

So it seems that unless I've missed something, neither are needed any more. When not logged in, `playerService.playerComponent.ownerView.rerender()` fails but the player still falls into the correct position when the channel header is collapsed (and `playerService.fullSizePlayerLocation` stays at `{top: 85, left: 30}` both before and after).
And when you're logged in, the same applies; so actually moving the player (with `.set('fullSizePlayerLocation', {top: x, left: y})`) would break the layout anyway.

One last note: on one Chrome instance (logged into one account) the channel header is gone to begin with, while in another Chrome instance (logged into a different account) it's still there, and toggles on/off with the Disable Channel Header setting (even with all of the `fullSizePlayerLocation` related lines removed).
In Firefox, it also works properly with those portions removed (and shows the channel header for both accounts, as well as when it's not logged in).
(I haven't been able to duplicate why the channel header is already missing, on its own, in that one particular Chrome instance; but it's still that way now, and it's missing for all channels)

Unless anyone sees something that I'm not seeing, my final conclusion is that Twitch changed stuff once again, and that the player location no longer needs to be set when collapsing/un-collapsing the channel header.