### PR TITLE
Calculate player position automatically

### DIFF
--- a/src/js/features/disable-channel-header.js
+++ b/src/js/features/disable-channel-header.js
@@ -13,15 +13,15 @@ function setHeaderHeight(height) {
 }
 
 function setPlayerHeight(height) {
-    var playerService = App.__container__.lookup('service:persistent-player');
-    if (!playerService || !playerService.fullSizePlayerLocation) return;
-
-    var top = playerService.get('fullSizePlayerLocation.top');
-    playerService.set('fullSizePlayerLocation', {top: top + height,
-        left: playerService.fullSizePlayerLocation.left});
-
-    if (playerService.playerComponent) {
-        playerService.playerComponent.ownerView.rerender();
+    var playerPlaceholder = $('.player-placeholder');
+    if (playerPlaceholder.length > 0) {
+        var playerPlaceholderParent = playerPlaceholder.scrollParent();
+        var offset = {
+            top: playerPlaceholder.offset().top + playerPlaceholderParent.scrollTop() + height,
+            left: playerPlaceholder.offset().left - playerPlaceholderParent.offset().left
+        };
+        var persistentPlayer = App.__container__.lookup('service:persistentPlayer');
+        persistentPlayer.set('fullSizePlayerLocation', offset);
     }
 }
 
@@ -33,9 +33,9 @@ module.exports = function(state) {
 
     if (bttv.settings.get('disableChannelHeader') === true) {
         setHeaderHeight(0);
-        setPlayerHeight(-380);
+        setPlayerHeight(0);
     } else if (state === false) {
         setHeaderHeight(380);
-        setPlayerHeight(380);
+        setPlayerHeight(0);
     }
 };


### PR DESCRIPTION
**TL;DR calculate player-position (top+left) automatically (using Twitch's own method), and use `setPlayerHeight` if you want to offset it from that position (otherwise, leave it at 0 for automatic positioning). Or if you don't care to be able to set player position (since Twitch's method sets it to the correct position regardless of what the header height is set to), scrap everything else in the function and just use `playerService.playerComponent.ownerView.rerender()` (just update `service:persistent-player` to `service:persistentPlayer`, since it appears to have changed to that).**

Twitch keeps changing things (one reason for the commit).

The other reason, is that Twitch's method for calculating player position seems to work regardless of what the header height is (tested in as many different scenarios as I could think up).

`setPlayerHeight` was replaced with the same method that Twitch uses; and its input is now a modifier to the player height, as opposed to the height itself. Which means `setPlayerHeight` can now be called with `0` and the correct position will automatically be calculated; unless future situations arise where it may be necessary to offset it from it's default position.

The player-height error (player loads higher than it should be, then auto-corrects the next time something causes Twitch's `updatePlayerPosition` to be called) appears to be something on Twitch's end, since it can happen even if I don't load BTTV. It could be fixed by calling `setPlayerHeight(0)` after the player is loaded (or Twitch's `updatePlayerPosition()`), but if it's not being caused by BTTV, then it might be wise to just wait for Twitch to fix whatever's causing it (after which, everything should work properly again; including the changes made in this commit).

Side node:
`service:persistent-player` now appears to be `service:persistentPlayer`. Also `playerService.playerComponent.ownerView.rerender()` seems to render it to the correct position, even if `fullSizePlayerLocation` is set beforehand. In which case, my player-calculations aren't really needed at all, they could just be replaced with `playerService.playerComponent.ownerView.rerender()` if there isn't a need to ever offset the default player height in the future (and could be smart to do, or at least be a quick replacement, if Twitch changes player-position calculations again).

And:
And manually setting player-heights will become a headache; as long as nothing fundamental changes about the page layout, the auto-height-calculations should prevent it from ever becoming an issue.