### PR TITLE
Add the ability to remove player gradient overlays.

### DIFF
--- a/src/css/betterttv-disable-player-overlay-gradient.css
+++ b/src/css/betterttv-disable-player-overlay-gradient.css
@@ -1,0 +1,4 @@
+.player-controls-top,
+.player-controls-bottom {
+    background-image: none !important;
+}

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -319,6 +319,22 @@ module.exports = [
         }
     },
     {
+        name: 'Disable Player Overlay Gradient',
+        description: 'Disables the gradient that shows over the player on mouse hover',
+        default: false,
+        storageKey: 'disablePlayerOverlayGradient',
+        toggle: function(value) {
+            if (value === true) {
+                cssLoader.load('disable-player-overlay-gradient', 'disablePlayerOverlayGradient');
+            } else {
+                cssLoader.unload('disablePlayerOverlayGradient');
+            }
+        },
+        load: function() {
+            cssLoader.load('disable-player-overlay-gradient', 'disablePlayerOverlayGradient');
+        }
+    },
+    {
         name: 'Disable Whispers',
         description: 'Disables the Twitch whisper feature and hides any whispers you receive',
         default: false,


### PR DESCRIPTION
When the mouse hovers over the player a gradient overlays the video at the bottom.  Depending on your player size this gradient can can actually overlay a large portion of the video and make it
particularly difficult to read any text the streamer has at the bottom of their screen.