### PR TITLE
Add exact matching option for highlight/blacklist keywords

### DIFF
--- a/src/js/features/chat-load-settings.js
+++ b/src/js/features/chat-load-settings.js
@@ -57,7 +57,7 @@ module.exports = function() {
 
     $('.setBlacklistKeywords').click(function(e) {
         e.preventDefault();
-        var keywords = prompt('Type some blacklist keywords. Messages containing keywords will be filtered from your chat. Use spaces in the field to specify multiple keywords. Place {} around a set of words to form a phrase, and () around a word to specify a username. Wildcards are supported.', bttv.settings.get('blacklistKeywords'));
+        var keywords = prompt('Type some blacklist keywords. Messages containing keywords will be filtered from your chat. Use spaces in the field to specify multiple keywords. Place {} around a set of words to form a phrase, <> inside the {} to use exact search, and () around a single word to specify a username. Wildcards (*) are supported.', bttv.settings.get('blacklistKeywords'));
         if (keywords !== null) {
             keywords = keywords.trim().replace(/\s\s+/g, ' ');
             bttv.settings.save('blacklistKeywords', keywords);
@@ -66,7 +66,7 @@ module.exports = function() {
 
     $('.setHighlightKeywords').click(function(e) {
         e.preventDefault();
-        var keywords = prompt('Type some highlight keywords. Messages containing keywords will turn red to get your attention. Use spaces in the field to specify multiple keywords. Place {} around a set of words to form a phrase, and () around a word to specify a username. Wildcards are supported.', bttv.settings.get('highlightKeywords'));
+        var keywords = prompt('Type some highlight keywords. Messages containing keywords will turn red to get your attention. Use spaces in the field to specify multiple keywords. Place {} around a set of words to form a phrase, <> inside {} to use exact search, and () around a single word to specify a username. Wildcards (*) are supported.', bttv.settings.get('highlightKeywords'));
         if (keywords !== null) {
             keywords = keywords.trim().replace(/\s\s+/g, ' ');
             bttv.settings.save('highlightKeywords', keywords);

--- a/src/js/features/keywords-lists.js
+++ b/src/js/features/keywords-lists.js
@@ -37,7 +37,7 @@ exports.blacklistFilter = function(data) {
     }
 
     for (i = 0; i < blacklistKeywords.length; i++) {
-        var keyword = escapeRegExp(blacklistKeywords[i]).replace(/\*/g, '[^ ]*');
+        var keyword = escapeRegExp(blacklistKeywords[i]).replace(/\*/g, '[^ ]*').replace(/^<(.*)>$/g, '^$1$$');
         var blacklistRegex = new RegExp(keyword, 'i');
         if (blacklistRegex.test(data.message) && vars.userData.name !== data.from) {
             return true;
@@ -92,7 +92,7 @@ exports.highlighting = function(data) {
     }
 
     for (i = 0; i < highlightKeywords.length; i++) {
-        var hlKeyword = escapeRegExp(highlightKeywords[i]).replace(/\*/g, '[^ ]*');
+        var hlKeyword = escapeRegExp(highlightKeywords[i]).replace(/\*/g, '[^ ]*').replace(/^<(.*)>$/g, '^$1$$');
         var wordRegex = new RegExp('(\\s|^|@)' + hlKeyword + '([!.,:\';?/]|\\s|$)', 'i');
         if (vars.userData.isLoggedIn && vars.userData.name !== data.from && wordRegex.test(data.message)) {
             if (bttv.chat.store.activeView === false) {


### PR DESCRIPTION
Adds ability to force a highlight or blacklist keyword group to be an "exact match" set. It still allows the wildcard * to be used, allowing for effective "starts-with" and "ends-with". 

Example (keyword entry -> relevant regex):
```
{test} -> /test/
<test> -> /^test$/
{<test>} -> /^test$/
{<test*>} -> /^test[^ ]*$/
{<test *>} -> /^test [^ ]*$/
```

This functionality is useful for blacklisting bot commands that start with a keyword which is followed by parameters when the parameters can change from call to call. If accepted, it would close #67  