### PR TITLE
Addition of setting to enable column toggling

### DIFF
--- a/src/js/features/column-toggle-hotkey.js
+++ b/src/js/features/column-toggle-hotkey.js
@@ -1,0 +1,17 @@
+var debug = require('../helpers/debug');
+
+module.exports = function() {
+    if (!bttv.settings.get('columnToggleHotkey')) return;
+    if (!window.Ember || !window.App) return;
+
+    try {
+        window.Mousetrap.bind('ctrl+left', function() {
+            $('#left_close').click();
+        });
+        window.Mousetrap.bind('ctrl+right', function() {
+            $('#right_close').click();
+        });
+    } catch (e) {
+        debug.log('Error with column-toggle-hotkey: ', e);
+    }
+};

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -143,6 +143,7 @@ var betterViewerList = require('./features/better-viewer-list'),
     directoryFunctions = require('./features/directory-functions'),
     enableImagePreview = require('./features/image-preview').enablePreview,
     enableTheatreMode = require('./features/auto-theatre-mode'),
+    addColumnToggleHotkey = require('./features/column-toggle-hotkey'),
     disableChannelHeader = require('./features/disable-channel-header'),
     flipDashboard = require('./features/flip-dashboard'),
     formatDashboard = require('./features/format-dashboard'),
@@ -315,6 +316,7 @@ var main = function() {
         disableChannelHeader();
         freeSubReminder();
         enableTheatreMode();
+        addColumnToggleHotkey();
 
         // Loads global BTTV emotes (if not loaded)
         overrideEmotes();

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -109,6 +109,12 @@ module.exports = [
         storageKey: 'clickToPlay',
     },
     {
+        name: 'Column Toggle Hotkey',
+        description: 'Enables use of a Hotkey to toggle hiding/showing left and right columns (CTRL+LEFT and CTRL+RIGHT)',
+        default: false,
+        storageKey: 'columnToggleHotkey'
+    },
+    {
         name: 'Completion Tooltip',
         description: 'Shows a tooltip with suggested names when typing @ or using tab completion',
         default: true,

--- a/src/js/settings-list.js
+++ b/src/js/settings-list.js
@@ -110,7 +110,7 @@ module.exports = [
     },
     {
         name: 'Column Toggle Hotkey',
-        description: 'Enables use of a Hotkey to toggle hiding/showing left and right columns (CTRL+LEFT and CTRL+RIGHT)',
+        description: 'Enables CTRL+LEFT and CTRL+RIGHT hide / show left and right columns',
         default: false,
         storageKey: 'columnToggleHotkey'
     },


### PR DESCRIPTION
This toggle allows users to toggle the visibility of the left and right columns of various twitch.tv pages

When in a stream, the right column is where chat is displayed, so toggling that column hides and shows the chat. On other pages that have a right column, this is where your followed streamers are listed.

The left column is where most settings and navigation links are held (like Games, Channels, BTTV Settings, etc.)

The reason I made this little tweak was I found myself constantly wanting to be able to hide the chat when I moved a stream to a different sized monitor or resized the window. This would make chat take up a little too much space, and I would hide it for more stream real estate. I'm lazy and like to use my keyboard, so why the heck not.