### PR TITLE
Added column-toggle-hotkey module

### DIFF
--- a/src/modules/column_toggle_hotkey/index.js
+++ b/src/modules/column_toggle_hotkey/index.js
@@ -20,6 +20,11 @@ class ColumnToggleHotkeyModule {
             $(document).keydown(e => {
                 if (e.ctrlKey) {
                     if (e.which === 37) {
+                        // Check if you're in theater mode, don't click left one if you are
+                        // because it has no visual effect, but **is** clicking it in the background
+                        const container = App.__container__;
+                        if (container.lookup('service:persistentPlayer').playerComponent.player.theatre) return;
+
                         $('#left_close').click();
                     } else if (e.which === 39) {
                         $('#right_close').click();

--- a/src/modules/column_toggle_hotkey/index.js
+++ b/src/modules/column_toggle_hotkey/index.js
@@ -23,7 +23,10 @@ class ColumnToggleHotkeyModule {
                         // Check if you're in theater mode, don't click left one if you are
                         // because it has no visual effect, but **is** clicking it in the background
                         const container = App.__container__;
-                        if (container.lookup('service:persistentPlayer').playerComponent.player.theatre) return;
+                        if ((container.lookup('service:persistentPlayer').playerComponent) &&
+                            (container.lookup('service:persistentPlayer').playerComponent.player.theatre)) {
+                            return;
+                        }
 
                         $('#left_close').click();
                     } else if (e.which === 39) {

--- a/src/modules/column_toggle_hotkey/index.js
+++ b/src/modules/column_toggle_hotkey/index.js
@@ -1,0 +1,35 @@
+const debug = require('../../utils/debug');
+const settings = require('../../settings');
+const watcher = require('../../watcher');
+
+class ColumnToggleHotkeyModule {
+    constructor() {
+        settings.add({
+            id: 'columnToggleHotkey',
+            name: 'Column Toggle Hotkey',
+            defaultValue: false,
+            description: 'Enables CTRL+LEFT and CTRL+RIGHT hide / show left and right columns'
+        });
+        watcher.on('load', () => this.load());
+    }
+
+    load() {
+        if (settings.get('columnToggleHotkey') === false) return;
+
+        try {
+            $(document).keydown(e => {
+                if (e.ctrlKey) {
+                    if (e.which === 37) {
+                        $('#left_close').click();
+                    } else if (e.which === 39) {
+                        $('#right_close').click();
+                    }
+                }
+            });
+        } catch (e) {
+            debug.log('Error with column toggle hotkey: ', e);
+        }
+    }
+}
+
+module.exports = new ColumnToggleHotkeyModule();


### PR DESCRIPTION
This is a re-do of [this](https://github.com/night/BetterTTV/pull/2123) pull request I made yesterday, but now on the appropriate v7 branch - instead of master. Additionally, it uses JQuery to listen for keypress events instead of Twitch's Mousetrap.

Let me know what you think! I had some considerations to make this a generic "Add navigation hotkeys" toggle, as I don't notice there being a toggle to enable global twitch hotkeys for navigation (maybe in a future version this could just be a toggle that adds a slew of hotkeys?)