### PR TITLE
V7 patch

### DIFF
--- a/src/modules/emotes/channel-emotes.js
+++ b/src/modules/emotes/channel-emotes.js
@@ -18,7 +18,7 @@ class ChannelEmotes extends AbstractEmotes {
     constructor() {
         super();
 
-        watcher.on('load.channel', () => {
+        watcher.on('load.chat', () => {
             const currentChannel = twitch.getCurrentChannel();
             if (!currentChannel) return;
 

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -67,7 +67,7 @@ class Watcher extends SafeEventEmitter {
                     case 'chat':
                         this.emit('load.chat');
                         break;
-                    case 'dashboard.index':
+                    case 'dashboards.index':
                         this.emit('load.dashboard');
                         this.emit('load.chat');
                         break;


### PR DESCRIPTION
Load channel emotes on `load.chat` rather than `load.channel`. Fixes all cases when channel isn't emitted, such as /chat and /dashboard. 

Also fixes the dashboard route.