### PR TITLE
Fix chat colon (:) glitch

### DIFF
--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -2467,9 +2467,9 @@ body.channel_new.columns.ember-application {
     display: none;
 }
 
-.chat-line .colon,
+.chatReplay .chat-line .colon,
 .conversation-chat-line .colon {
-    margin-left: 3px;
+    margin-left: -3px;
 }
 
 .chat-line .undelete a {

--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -2469,7 +2469,7 @@ body.channel_new.columns.ember-application {
 
 .chat-line .colon,
 .conversation-chat-line .colon {
-    margin-left: -3px;
+    margin-left: 3px;
 }
 
 .chat-line .undelete a {


### PR DESCRIPTION
I just fixed the colon (:) glitch with the new twitch UI.

Before:
![b7e40f6f20f40ba53018684d4ff138f2](https://cloud.githubusercontent.com/assets/6990948/25977114/734c8bc2-36b9-11e7-83eb-06f54bac25ad.png)

After:
![fe66d52ea689c09f2db38e0aa234adb7](https://cloud.githubusercontent.com/assets/6990948/25977131/8434a8ac-36b9-11e7-9719-585193bcbf85.png)
