### PR TITLE
Fixing colon under username in chat

### DIFF
--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -2467,11 +2467,6 @@ body.channel_new.columns.ember-application {
     display: none;
 }
 
-.chat-line .colon,
-.conversation-chat-line .colon {
-    margin-left: -3px;
-}
-
 .chat-line .undelete a {
     text-decoration: none
 }


### PR DESCRIPTION
This is how it currently looks like:
![colonbug](https://cloud.githubusercontent.com/assets/6627739/25981303/5431442c-36cc-11e7-9591-46090ba2e410.png)
