### PR TITLE
Small CSS changes for dark mode

### DIFF
--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -3590,3 +3590,7 @@ circle#Oval {
 .notification-center__subheader-unread-count>span {
     color: #D3D3D3;
 }
+
+.notification__empty{
+    background-color: #1e1e1e;
+}

--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -3594,3 +3594,7 @@ circle#Oval {
 .notification__empty{
     background-color: #1e1e1e;
 }
+
+.notification-center__core--empty {
+    background-color: #1e1e1e;
+}

--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -3523,3 +3523,70 @@ button.follow-button, .subscription-modal__right button, .subscription-modal__le
 .vod-chat__scroll-wrapper::-webkit-scrollbar-thumb{
     border-color: #201c2b;
 }
+
+.offer-list__container>.ember-tether>.border-t {
+    border-top: .1rem solid #333;
+}
+
+.notification-center__header-text {
+    color: #D3D3D3;
+}
+
+.notification-center__header {
+    background-color: #1e1e1e;
+    border-bottom: .1rem solid #333;
+}
+
+.notification-center__subheader-text {
+    color: #D3D3D3;
+}
+
+.notification-center__subheader {
+    background-color: #1e1e1e;
+    border-bottom: .1rem solid #333;
+}
+
+.friend-requests__empty {
+    background-color: #1e1e1e;
+    border-bottom: .1rem solid #333;
+}
+
+.notification-center__empty {
+    background-color: #1e1e1e
+    border-bottom: .1rem solid #333;
+}
+
+.notification-center__footer {
+    background-color: #1e1e1e;
+    border-top: .1rem solid #333;
+}
+
+.notification__container.notification--read {
+    background-color: #1e1e1e;
+    border-bottom: .1rem solid #333;
+}
+
+.notification__container.notification--unread {
+    background-color: #323232;
+    border-bottom: .1rem solid #333;
+}
+
+.notification-center__core-end {
+    background-color: #1e1e1e;
+}
+
+.notification__container:hover {
+    background-color: #464646;
+}
+
+circle#Oval {
+    fill: #1e1e1e;
+}
+
+.notification-center__subheader-unread-count {
+    background-color: #323232;
+}
+
+.notification-center__subheader-unread-count>span {
+    color: #D3D3D3;
+}

--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -3602,3 +3602,12 @@ button.follow-button, .subscription-modal__right button, .subscription-modal__le
 .friend-request__action--icon > .icon > svg.svg-ban {
     fill: white;
 }
+
+.friend-request__action--icon {
+    background-color: inherit;
+    box-shadow: inset 0 0 0 1px #323232;
+}
+
+.notification-center__header .button:hover {
+    color:#D3D3D3
+}

--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -3571,7 +3571,7 @@ button.follow-button, .subscription-modal__right button, .subscription-modal__le
     border-bottom: .1rem solid #333;
 }
 
-.notification-center__core-end {
+.notification-center__core {
     background-color: #1e1e1e;
 }
 
@@ -3579,7 +3579,7 @@ button.follow-button, .subscription-modal__right button, .subscription-modal__le
     background-color: #464646;
 }
 
-circle#Oval {
+.notification__container #Oval {
     fill: #1e1e1e;
 }
 
@@ -3597,4 +3597,8 @@ circle#Oval {
 
 .notification-center__core--empty {
     background-color: #1e1e1e;
+}
+
+.friend-request__action--icon > .icon > svg.svg-ban {
+    fill: white;
 }


### PR DESCRIPTION
Really small changes to the dark mode CSS, since it looked like the notification panels didn't have many changes in dark mode while the text was changed to white by other parts of the CSS, making it really hard to read.

[Here are the visual changes in an imgur album](http://imgur.com/a/2EuyN)

I used the same color as the other panels (#1e1e1e) for the background of the notification panels, made the unread notifications to be slightly brighter (#323232) and set the hover color to be the brightest (#464646). 

The Prime tab had a grey line (#333) for the top and white line to separate elements, I thought that was weird so I changed it to all be (#333).