### PR TITLE
Menu link styling to BetterTTV Settings menu option

### DIFF
--- a/src/modules/settings/index.js
+++ b/src/modules/settings/index.js
@@ -205,7 +205,7 @@ class SettingsModule {
             </li>
         `);
         $('.top-nav-drawer__item a[data-tt_content="settings_profile"]').parent().after(`
-            <li class="top-nav-drawer__item">
+            <li class="top-nav-drawer__item top-nav-drawer__item--link">
                 <a title="BetterTTV Settings" href="#" class="flex ember-view">
                     <figure class="icon bttvSettingsIconDropDown"></figure>
                     <span class="top-nav-drawer__label">BetterTTV Settings</span>


### PR DESCRIPTION
Basically, this applies the hover effect to the BetterTTV Settings option in the menu, matching the styling of the other menu options.

Preview:
![hover](https://user-images.githubusercontent.com/6627739/28038466-eab8baec-65b6-11e7-8075-051487683bf8.png)
