### PR TITLE
Re-enable panel list styling

### DIFF
--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -90,6 +90,10 @@ ul.tabs li.selected a {
     background: url(../assets/icons/logo_navbar_icons.png) no-repeat 0px -50px;
 }
 
+.panel-formatting .panel .description ul li {
+    list-style-position: inside;
+}
+
 /* Chat CSS */
 input.text:focus,select:focus,textarea:focus {
     outline: 0;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7132646/29341620-1c4a246a-81eb-11e7-80f9-e8decd4567b2.png)

After:
![image](https://user-images.githubusercontent.com/7132646/29341624-1fb82994-81eb-11e7-8372-7127afaa0ef5.png)

The selector is the same that Twitch uses which is fairly specific. An alternative may use "`#channel_panels`" instead of "`.panel-formatting`" but this allows for matching against other panels that may exist around the site.

This line from the official CSS is what disables it:
```
ol, ul, li {
	list-style: none;
}
```

despite this other styling they have that doesn't make it appear:
```
.panel-formatting .panel .description ul li {
	list-style-type: disc;
}
```