### PR TITLE
Remove unnecessary negative margin in whispers. Fixes #2628

### DIFF
--- a/src/css/betterttv.css
+++ b/src/css/betterttv.css
@@ -2469,8 +2469,7 @@ body.channel_new.columns.ember-application {
     display: none;
 }
 
-.chatReplay .chat-line .colon,
-.conversation-chat-line .colon {
+.chatReplay .chat-line .colon {
     margin-left: -3px;
 }
 


### PR DESCRIPTION
Without BTTV:

![image](https://user-images.githubusercontent.com/7132646/29433733-01a4e4a2-8366-11e7-8cbc-1fa45da33a58.png)

With BTTV:

![image](https://user-images.githubusercontent.com/7132646/29433720-f481c600-8365-11e7-9ce3-68f2c0f2ce81.png)

With this change:

![image](https://user-images.githubusercontent.com/7132646/29433814-4ebb71c0-8366-11e7-9ac6-b79e98106a96.png)
