### PR TITLE
Dark mode fix described in #2616 and notif. center tweak

### DIFF
--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -3869,9 +3869,6 @@ button.follow-button, .subscription-modal__right button, .subscription-modal__le
 
 .notification-center__subheader-unread-count {
     background-color: #323232;
-}
-
-.notification-center__subheader-unread-count>span {
     color: #D3D3D3;
 }
 
@@ -3905,4 +3902,16 @@ button.follow-button, .subscription-modal__right button, .subscription-modal__le
 
 .header-announcement--net-neutrality {
     color: black;
+}
+
+.dashboard-page .card__body {
+    background-color: #282828;
+}
+
+.dashboard-page .card--bordered {
+    background-color: #282828;
+}
+
+.dashboard-page .card__title, .dashboard-page .card__info {
+    color: #D3D3D3;
 }


### PR DESCRIPTION
This is a small fix using the selectors mentioned in #2616.
Before:
![broadcasts_before](https://user-images.githubusercontent.com/14812986/29597786-d366c66a-8779-11e7-83a9-eafbd0e8a193.png)
![videos_before](https://user-images.githubusercontent.com/14812986/29597787-d36736e0-8779-11e7-83c7-d81588559138.png)
After:
![broadcasts_after](https://user-images.githubusercontent.com/14812986/29597792-d916932e-8779-11e7-8b10-8680ba4a871f.png)
![videos_after](https://user-images.githubusercontent.com/14812986/29597791-d914e27c-8779-11e7-8820-bd349e65ae10.png)

In addition, twitch changed the notification center a bit since #2491 from having a span within the notification-center__subheader-unread-count class div to just the class by itself. This broke one of the css changes I made so I cleaned it up.

Before:
![notif_before](https://user-images.githubusercontent.com/14812986/29597822-068eaa1c-877a-11e7-9cab-b208087f89f0.png)
After:
![notif_after](https://user-images.githubusercontent.com/14812986/29597825-0b8d5efa-877a-11e7-954c-c60ca23fde45.png)