### PR TITLE
Fixes click to play/pause bug not resuming on click

### DIFF
--- a/src/modules/video_player/index.js
+++ b/src/modules/video_player/index.js
@@ -24,7 +24,7 @@ function handleKeyEvent(keyup) {
 }
 
 let clicks = 0;
-function pausePlayer() {
+function handlePlayerClick() {
     clicks++;
     setTimeout(() => {
         if (clicks === 1) {
@@ -33,20 +33,7 @@ function pausePlayer() {
             const playerService = App.__container__.lookup('service:persistent-player');
             if (!playerService || !playerService.playerComponent || !playerService.playerComponent.player) return;
             if (isPaused === 'false') playerService.playerComponent.player.pause();
-        }
-        clicks = 0;
-    }, 250);
-}
-
-function playPlayer() {
-    clicks++;
-    setTimeout(() => {
-        if (clicks === 1) {
-            const $player = $('#player');
-            const isPaused = $player.attr('data-paused');
-            const playerService = App.__container__.lookup('service:persistent-player');
-            if (!playerService || !playerService.playerComponent || !playerService.playerComponent.player) return;
-            if (isPaused === 'true') playerService.playerComponent.player.play();
+            else playerService.playerComponent.player.play();
         }
         clicks = 0;
     }, 250);
@@ -71,12 +58,12 @@ class VideoPlayerModule {
     }
 
     clickToPause() {
-        $('#player').off('click', '.player-overlay.player-fullscreen-overlay', pausePlayer);
-        $('#player').off('click', '.player-overlay.player-play-overlay.js-paused-overlay', playPlayer);
+        $('#player').off('click', '.player-overlay.player-fullscreen-overlay', handlePlayerClick);
+        $('#player').off('click', '.player-overlay.player-play-overlay.js-paused-overlay', handlePlayerClick);
 
         if (settings.get('clickToPlay') === true) {
-            $('#player').on('click', '.player-overlay.player-fullscreen-overlay', pausePlayer);
-            $('#player').on('click', '.player-overlay.player-play-overlay.js-paused-overlay', playPlayer);
+            $('#player').on('click', '.player-overlay.player-fullscreen-overlay', handlePlayerClick);
+            $('#player').on('click', '.player-overlay.player-play-overlay.js-paused-overlay', handlePlayerClick);
         }
     }
 }

--- a/src/modules/video_player/index.js
+++ b/src/modules/video_player/index.js
@@ -24,15 +24,29 @@ function handleKeyEvent(keyup) {
 }
 
 let clicks = 0;
-function handlePlayerClick() {
+function pausePlayer() {
     clicks++;
     setTimeout(() => {
         if (clicks === 1) {
             const $player = $('#player');
-            const isPaused = $player.data('paused');
+            const isPaused = $player.attr('data-paused');
             const playerService = App.__container__.lookup('service:persistent-player');
             if (!playerService || !playerService.playerComponent || !playerService.playerComponent.player) return;
-            if (!isPaused) playerService.playerComponent.player.pause();
+            if (isPaused === 'false') playerService.playerComponent.player.pause();
+        }
+        clicks = 0;
+    }, 250);
+}
+
+function playPlayer() {
+    clicks++;
+    setTimeout(() => {
+        if (clicks === 1) {
+            const $player = $('#player');
+            const isPaused = $player.attr('data-paused');
+            const playerService = App.__container__.lookup('service:persistent-player');
+            if (!playerService || !playerService.playerComponent || !playerService.playerComponent.player) return;
+            if (isPaused === 'true') playerService.playerComponent.player.play();
         }
         clicks = 0;
     }, 250);
@@ -57,10 +71,12 @@ class VideoPlayerModule {
     }
 
     clickToPause() {
-        $('#player').off('click', '.player-overlay.player-fullscreen-overlay', handlePlayerClick);
+        $('#player').off('click', '.player-overlay.player-fullscreen-overlay', pausePlayer);
+        $('#player').off('click', '.player-overlay.player-play-overlay.js-paused-overlay', playPlayer);
 
         if (settings.get('clickToPlay') === true) {
-            $('#player').on('click', '.player-overlay.player-fullscreen-overlay', handlePlayerClick);
+            $('#player').on('click', '.player-overlay.player-fullscreen-overlay', pausePlayer);
+            $('#player').on('click', '.player-overlay.player-play-overlay.js-paused-overlay', playPlayer);
         }
     }
 }


### PR DESCRIPTION
-Clicking on screen would pause the player but clicking screen to resume would do nothing
-Added a second event handler for the paused overlay screen
-Replaced .data() with .attr() because .data() caches results, so when it checks if the player is paused, it will read result from cache instead of getting up to date value
-.attr() only returns strings so changed isPaused check to a string compare 
-Created two separate methods for playing and pausing because I ran into an issue where one method for both would cause pressing the play button in the middle of screen to immediately pause after resuming on the first click, but work as intended after that