### PR TITLE
White VOD chat username theatre mode

### DIFF
--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -2250,7 +2250,7 @@ span.subscribe-text {
     box-shadow: 0 0 3px 1px #333;
 }
 
-.emoticon-selector .emoticon-selector-box input:focus, , .emote-picker-and-button .tw-input {
+.emoticon-selector .emoticon-selector-box input:focus, .emote-picker-and-button .tw-input {
     box-shadow: 0 0 3px 1px #333;
 }
 
@@ -3120,7 +3120,7 @@ ul.tabs li>a:hover, .directory_header .nav li>a:hover, ul.tabs li>button:hover, 
 .balloon div input, .balloon div input:focus {
     background: #3b3b3b;
     border: 1px solid rgba(0,0,0,0.35);
-    -webkit-box-shadow: 0 0 3px 1px rgba(0,0,0,0.35);
+    box-shadow: 0 0 3px 1px rgba(0,0,0,0.35);
     color: #d4d4d4;
 }
 

--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -3808,7 +3808,7 @@ button.follow-button, .subscription-modal__right button, .subscription-modal__le
 }
 
 .video-chat__message-author span {
-	color: inherit;
+    color: inherit;
 }
 
 .vod-message.vod-message--focused, .vod-message:hover {

--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -3803,6 +3803,14 @@ button.follow-button, .subscription-modal__right button, .subscription-modal__le
     border-left: none;
 }
 
+.vod-chat,.video-chat span, div[data-test-selector="video-chat-cta"] {
+    color: #d3d3d3;
+}
+
+.video-chat__message-author span {
+	color: inherit;
+}
+
 .vod-message.vod-message--focused, .vod-message:hover {
     background-color: transparent;
 }

--- a/src/css/betterttv-dark.css
+++ b/src/css/betterttv-dark.css
@@ -3803,10 +3803,6 @@ button.follow-button, .subscription-modal__right button, .subscription-modal__le
     border-left: none;
 }
 
-.vod-chat,.video-chat span, div[data-test-selector="video-chat-cta"] {
-    color: #d3d3d3;
-}
-
 .vod-message.vod-message--focused, .vod-message:hover {
     background-color: transparent;
 }


### PR DESCRIPTION
Fixes problem in VOD chat replay (theatre mode) where usernames are white instead of colour.

No good:
![chrome_2017-10-06_19-56-53](https://user-images.githubusercontent.com/16233822/31270614-c2395c5c-aad0-11e7-9d7e-23a0bee5e957.png)
