### PR TITLE
[new-twitch] Re-Add Left Side Chat

### DIFF
--- a/src/modules/chat_left_side/index.js
+++ b/src/modules/chat_left_side/index.js
@@ -1,0 +1,21 @@
+const $ = require('JQuery');
+const settings = require('../../settings');
+
+class ChatLeftSide {
+    constructor() {
+        settings.add({
+            id: 'leftSideChat',
+            name: 'Left Side Chat',
+            defaultValue: false,
+            description: 'Moves the chat to the left of the player'
+        });
+        settings.on('changed.leftSideChat', () => this.toggleLeftSideChat());
+        this.toggleLeftSideChat();
+    }
+
+    toggleLeftSideChat() {
+        $('body').toggleClass('swap-chat', settings.get('leftSideChat'));
+    }
+}
+
+module.exports = new ChatLeftSide();

--- a/src/modules/chat_left_side/style.css
+++ b/src/modules/chat_left_side/style.css
@@ -1,0 +1,44 @@
+.swap-chat {
+    .right-column {
+        order: 1;
+    }
+    
+    .twilight-main {
+        order: 2;
+    }
+
+    .side-nav {
+        order: 3;
+    }
+
+    /* Toggle Visibility Arrows */
+    .side-nav__toggle-visibility {
+        right: unset;
+        left: -2.5rem;
+        transform: rotate(-90deg);
+    }
+
+    .side-nav--collapsed .side-nav__toggle-visibility {
+        transform: rotate(90deg);
+    }
+    
+    .right-column__toggle-visibility {
+         right: -2.5rem;
+         left: unset;
+         transform: rotate(90deg);
+    }
+
+    .right-column--collapsed .right-column__toggle-visibility {
+        transform: rotate(-90deg);
+    }
+
+    /* Theatre Mode */
+    .channel-page__video-player--theatre-mode {
+        right: 0;
+        left: unset;
+    }
+
+    .right-column--theatre {
+        right: unset !important;
+    }
+}


### PR DESCRIPTION
Implements left side chat using Twitch's flex boxes. Theatre Mode being an exception due to implemented fixed positioning. 

Screenshots:
[Channel](https://i.aaron128l.com/BHshuh4.png)
[Theatre Mode](https://i.aaron128l.com/c1RxAes.png)
[Collapsed Side Bar](https://i.aaron128l.com/mnFY2yA.png)