### PR TITLE
Added a few options for the sidebar

### DIFF
--- a/src/modules/hide_sidebar_elements/index.js
+++ b/src/modules/hide_sidebar_elements/index.js
@@ -11,15 +11,39 @@ class HideSidebarElementsModule {
             description: 'The left sidebar is too cluttered, so you can remove recommended channels'
         });
         settings.add({
+            id: 'autoExpandChannels',
+            name: 'Auto Expand Followed Channels List',
+            defaultValue: false,
+            description: 'Automatically clicks the "Load More" option for you'
+        });
+        settings.add({
+            id: 'hideRecommendedFriends',
+            name: 'Hide Recommended Friends',
+            defaultValue: true,
+            description: 'Hides the Recommended Friends section so you have more room for activities!'
+        });
+        settings.add({
+            id: 'hideOfflineFollowedChannels',
+            name: 'Hide Offline Followed Channels',
+            defaultValue: false,
+            description: 'Hides all offline followed channels for those who follow a ton of channels'
+        });
+        settings.add({
             id: 'hidePrimePromotion',
             name: 'Hide Prime Promotions',
             defaultValue: false,
             description: 'Hides the "Free With Prime" section of the sidebar'
         });
         settings.on('changed.hideFeaturedChannels', () => this.toggleFeaturedChannels());
+        settings.on('changed.autoExpandChannels', () => this.toggleAutoExpandChannels());
+        settings.on('changed.hideRecommendedFriends', () => this.toggleRecommendedFriends());
+        settings.on('changed.hideOfflineFollowedChannels', () => this.toggleOfflineFollowedChannels());
         settings.on('changed.hidePrimePromotion', () => this.togglePrimePromotions());
         watcher.on('load', () => {
             this.toggleFeaturedChannels();
+            this.toggleAutoExpandChannels();
+            this.toggleRecommendedFriends();
+            this.toggleOfflineFollowedChannels();
             this.togglePrimePromotions();
         });
     }
@@ -27,7 +51,34 @@ class HideSidebarElementsModule {
     toggleFeaturedChannels() {
         $('body').toggleClass('bttv-hide-featured-channels', settings.get('hideFeaturedChannels'));
     }
-
+    
+    toggleAutoExpandChannels() {
+        if (settings.get('autoExpandChannels') === true) {
+            $('.side-nav-load-more__button').trigger('click');
+        }
+    }
+    
+    toggleRecommendedFriends() { 
+        $('body').toggleClass('bttv-hide-recommended-friends', settings.get('hideRecommendedFriends'));
+    }
+    
+    toggleOfflineFollowedChannels() {
+        
+        var resizeTimer = null;
+        
+        function hideOfflineUser() {
+            if (settings.get('hideOfflineFollowedChannels') === true) {
+                $('.side-nav-card__avatar--offline').parent().css('cssText', 'display: none!important');
+            }
+        };
+        
+        $(window).bind('resize', function() {
+            if (resizeTimer) clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(hideOfflineUser, 100);
+        });
+        
+    }
+    
     togglePrimePromotions() {
         $('body').toggleClass('bttv-hide-prime-promotions', settings.get('hidePrimePromotion'));
     }

--- a/src/modules/hide_sidebar_elements/index.js
+++ b/src/modules/hide_sidebar_elements/index.js
@@ -51,34 +51,30 @@ class HideSidebarElementsModule {
     toggleFeaturedChannels() {
         $('body').toggleClass('bttv-hide-featured-channels', settings.get('hideFeaturedChannels'));
     }
-    
+
     toggleAutoExpandChannels() {
         if (settings.get('autoExpandChannels') === true) {
             $('.side-nav-load-more__button').trigger('click');
         }
     }
-    
-    toggleRecommendedFriends() { 
+
+    toggleRecommendedFriends() {
         $('body').toggleClass('bttv-hide-recommended-friends', settings.get('hideRecommendedFriends'));
     }
-    
+
     toggleOfflineFollowedChannels() {
-        
         var resizeTimer = null;
-        
         function hideOfflineUser() {
             if (settings.get('hideOfflineFollowedChannels') === true) {
                 $('.side-nav-card__avatar--offline').parent().css('cssText', 'display: none!important');
             }
         };
-        
         $(window).bind('resize', function() {
             if (resizeTimer) clearTimeout(resizeTimer);
             resizeTimer = setTimeout(hideOfflineUser, 100);
         });
-        
     }
-    
+
     togglePrimePromotions() {
         $('body').toggleClass('bttv-hide-prime-promotions', settings.get('hidePrimePromotion'));
     }

--- a/src/modules/hide_sidebar_elements/index.js
+++ b/src/modules/hide_sidebar_elements/index.js
@@ -63,16 +63,7 @@ class HideSidebarElementsModule {
     }
 
     toggleOfflineFollowedChannels() {
-        var resizeTimer = null;
-        function hideOfflineUser() {
-            if (settings.get('hideOfflineFollowedChannels') === true) {
-                $('.side-nav-card__avatar--offline').parent().css('cssText', 'display: none!important');
-            }
-        };
-        $(window).bind('resize', function() {
-            if (resizeTimer) clearTimeout(resizeTimer);
-            resizeTimer = setTimeout(hideOfflineUser, 100);
-        });
+        $('body').toggleClass('bttv-hide-followed-offlines', settings.get('hideOfflineFollowedChannels'));
     }
 
     togglePrimePromotions() {

--- a/src/modules/hide_sidebar_elements/style.css
+++ b/src/modules/hide_sidebar_elements/style.css
@@ -16,7 +16,7 @@
   }
 }
 
-.bttv-hide-prime-promotions {
+.bttv-hide-followed-offline {
   .side-nav-card[href*="/videos/all"], .side-nav-card__link[href*="/videos/all"] {
     display: none!important;
   }

--- a/src/modules/hide_sidebar_elements/style.css
+++ b/src/modules/hide_sidebar_elements/style.css
@@ -4,6 +4,12 @@
   }
 }
 
+.bttv-hide-recommended-friends {
+  .recommended-friends {
+    display: none;
+  }
+}
+
 .bttv-hide-prime-promotions {
   .top-nav__prime {
     display: none;

--- a/src/modules/hide_sidebar_elements/style.css
+++ b/src/modules/hide_sidebar_elements/style.css
@@ -18,6 +18,6 @@
 
 .bttv-hide-followed-offline {
   .side-nav-card[href*="/videos/all"], .side-nav-card__link[href*="/videos/all"] {
-    display: none!important;
+    display: none !important;
   }
 }

--- a/src/modules/hide_sidebar_elements/style.css
+++ b/src/modules/hide_sidebar_elements/style.css
@@ -15,3 +15,9 @@
     display: none;
   }
 }
+
+.bttv-hide-prime-promotions {
+  .side-nav-card[href*="/videos/all"], .side-nav-card__link[href*="/videos/all"] {
+    display: none!important;
+  }
+}


### PR DESCRIPTION
ported to new-twitch branch from
https://github.com/night/BetterTTV/pull/2647/files.

Also jquery is cool
and already imported so why not add an option to auto expand followed
channels as well.

The hiding of offline channels that are followed is
pretty annoying now though since you have to use javascript to get the
parent elements. I'm not a fan of the approach I used as it can bug out
when enabled before expanding the "Load More" option but will auto correct on frame resizes
(another thing I'm not a fan of).