### PR TITLE
[new-twitch] Emote Menu fix

### DIFF
--- a/src/modules/emote_menu/index.js
+++ b/src/modules/emote_menu/index.js
@@ -29,9 +29,6 @@ class EmoteMenuModule {
         // Inject the emote menu if option is enabled.
         if (settings.get('clickTwitchEmotes') === false) return;
 
-        debug.log('Injecting Twitch Chat Emotes Script');
-        require('twitch-chat-emotes/script.min');
-
         debug.log('Hooking into Twitch Chat Emotes Script');
         try { // try/catch protects against re-registered emote getters
             window.emoteMenu.registerEmoteGetter('BetterTTV', () =>
@@ -45,6 +42,9 @@ class EmoteMenuModule {
                 })
             );
         } catch (e) {}
+
+        debug.log('Injecting Twitch Chat Emotes Script');
+        require('twitch-chat-emotes/script.min');
     }
 }
 


### PR DESCRIPTION
Fix for #2787

This worked for me on Chrome. Before this fix I would only get 3 BTTV emotes showing in the menu. All I did was move the injection below the emote registration code.

Note: opening the menu too fast will cause no emotes to appear. Closing and reopening the menu fixes that but maybe a delay should be added until the emote button appears?
