### PR TITLE
[new-twitch] Fix js error in watcher.js when logged out

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -76,7 +76,7 @@ class Watcher extends SafeEventEmitter {
                 return;
             }
 
-            if (!router) return;
+            if (!router || !user) return;
             clearInterval(loadInterval);
 
             twitch.setCurrentUser(user.authToken, user.id, user.login, user.displayName);


### PR DESCRIPTION
When logged out and visiting a channel (it's all I tested it on) I would get this error:

```Uncaught TypeError: Cannot read property 'authToken' of undefined at build\watcher.js:82```

