### PR TITLE
[new-twitch] Attempt to fix BTTV emote menu

### DIFF
--- a/src/modules/emote_menu/index.js
+++ b/src/modules/emote_menu/index.js
@@ -33,18 +33,23 @@ class EmoteMenuModule {
         require('twitch-chat-emotes/script.min');
 
         debug.log('Hooking into Twitch Chat Emotes Script');
-        try { // try/catch protects against re-registered emote getters
-            window.emoteMenu.registerEmoteGetter('BetterTTV', () =>
-                emotes.getEmotes(['bttv-emoji']).map(({code, images, provider}) => {
-                    return {
-                        text: code,
-                        channel: provider.displayName,
-                        badge: provider.badge,
-                        url: images['2x']
-                    };
-                })
-            );
-        } catch (e) {}
+        this.loadEmotes();
+    }
+    loadEmotes() {
+        window.emoteMenu.onLoad(() => {
+            try { // try/catch protects against re-registered emote getters
+                window.emoteMenu.registerEmoteGetter('BetterTTV', () =>
+                    emotes.getEmotes(['bttv-emoji']).map(({code, images, provider}) => {
+                        return {
+                            text: code,
+                            channel: provider.displayName,
+                            badge: provider.badge,
+                            url: images['2x']
+                        };
+                    })
+                );
+            } catch (e) {}
+        });
     }
 }
 


### PR DESCRIPTION
Attempting to fix the issues with BTTV and emotes not loading.

It seemed that if I waited awhile before opening the menu all icons would appear. The earlier I opened the menu the worse the result. Immediately would have no emotes, a second or so just 3 or so.

I added a callback that fires when emotes have been "loaded". Hopefully this works. It works for me. The side effect is the button doesn't appear as quickly but when you do (or at least during my testing) all the icons are there like before.

This fix requires an update to Userscript--Twitch-Chat-Emotes. The pull request for that is here: https://github.com/night/Userscript--Twitch-Chat-Emotes/pull/1

#2787