### PR TITLE
[new-twitch] Hide Extensions

### DIFF
--- a/src/modules/hide_extensions/index.js
+++ b/src/modules/hide_extensions/index.js
@@ -1,6 +1,8 @@
-const $ = require('JQuery');
+const $ = require('jquery');
 const settings = require('../../settings');
 const watcher = require('../../watcher');
+
+const EXTENSION_CONTAINER = '#js-player-extension-root';
 
 class HideExtensionsModule {
     constructor() {
@@ -8,14 +10,14 @@ class HideExtensionsModule {
             id: 'hideExtensions',
             name: 'Hide Extensions',
             defaultValue: false,
-            description: 'Hide Twitch Extensions'
+            description: 'Hides Twitch extensions that are displayed over the video player'
         });
         watcher.on('load.player', () => this.load());
     }
 
     load() {
         if (settings.get('hideExtensions') === false) return;
-        $('#js-player-extension-root').hide();
+        $(EXTENSION_CONTAINER).hide();
     }
 }
 

--- a/src/modules/hide_extensions/index.js
+++ b/src/modules/hide_extensions/index.js
@@ -8,9 +8,9 @@ class HideExtensionsModule {
     constructor() {
         settings.add({
             id: 'hideExtensions',
-            name: 'Hide Extensions',
+            name: 'Hide Twitch Extensions',
             defaultValue: false,
-            description: 'Hides Twitch extensions that are displayed over the video player'
+            description: 'Hides the interactive overlays on top of Twitch\'s video player'
         });
         watcher.on('load.player', () => this.load());
     }

--- a/src/modules/hide_extensions/index.js
+++ b/src/modules/hide_extensions/index.js
@@ -1,0 +1,22 @@
+const $ = require('JQuery');
+const settings = require('../../settings');
+const watcher = require('../../watcher');
+
+class HideExtensionsModule {
+    constructor() {
+        settings.add({
+            id: 'hideExtensions',
+            name: 'Hide Extensions',
+            defaultValue: false,
+            description: 'Hide Twitch Extensions'
+        });
+        watcher.on('load.player', () => this.load());
+    }
+
+    load() {
+        if (settings.get('hideExtensions') === false) return;
+        $('#js-player-extension-root').hide();
+    }
+}
+
+module.exports = new HideExtensionsModule();


### PR DESCRIPTION
Hides the container that contains extensions that are over the player.

I don't know many channels that have them so I was only able to test it on one and it worked.

#2671