### PR TITLE
[new-twitch] Add optional reason box for custom timeouts

### DIFF
--- a/src/modules/chat_custom_timeouts/index.js
+++ b/src/modules/chat_custom_timeouts/index.js
@@ -2,7 +2,6 @@ const $ = require('jquery');
 const watcher = require('../../watcher');
 const keyCodes = require('../../utils/keycodes');
 const twitch = require('../../utils/twitch');
-const settings = require('../../settings');
 
 const CHAT_ROOM_SELECTOR = '.chat__pane';
 const CHAT_LINE_SELECTOR = '.chat-line__message';
@@ -40,7 +39,6 @@ function handleTimeoutClick(e) {
     if (!$customTimeout.length || e.which === keyCodes.DOMVKCancel) return;
 
     if ($customTimeout.is(':hover')) {
-        const reason = e.shiftKey ? setReason(action.type) : '';
         let command;
         if (action.type === ActionTypes.BAN) {
             command = '/ban';
@@ -48,6 +46,7 @@ function handleTimeoutClick(e) {
             command = '/timeout';
         }
         if (command) {
+            const reason = e.shiftKey ? setReason(action.type) : '';
             twitch.sendChatMessage(`${command} ${user}${reason ? ` ${reason}` : ''}`);
         }
     }

--- a/src/modules/chat_custom_timeouts/index.js
+++ b/src/modules/chat_custom_timeouts/index.js
@@ -23,7 +23,7 @@ const CUSTOM_TIMEOUT_TEMPLATE = `
 `;
 const ACTION_TYPES = {
     CANCEL: 'cancel',
-    TIMEOUT: 'time',
+    TIMEOUT: 'timeout',
     BAN: 'ban'
 };
 
@@ -31,16 +31,9 @@ let action;
 let user;
 
 function setReason(type) {
-    if (settings.get('customTimeoutReasons')) {
-        const reason = prompt(`Enter ${type === ACTION_TYPES.BAN ? 'ban' : 'timeout'} reason: (leave blank for none)`);
-        if (
-            reason === null ||
-            reason === ''
-        ) return '';
-        else return ` ${reason}`;
-    } else {
-        return '';
-    }
+    if (settings.get('customTimeoutReasons')) return '';
+    const reason = prompt(`Enter ${type} reason: (leave blank for none)`);
+    return reason ? ` ${reason}` : '';
 }
 
 function handleTimeoutClick(e) {
@@ -48,11 +41,10 @@ function handleTimeoutClick(e) {
     if (!$customTimeout.length || e.which === keyCodes.DOMVKCancel || e.shiftKey) return;
 
     if ($customTimeout.is(':hover')) {
+        const reason = setReason(action.type);
         if (action.type === ACTION_TYPES.BAN) {
-            const reason = setReason(action.type);
             twitch.sendChatMessage(`/ban ${user}${reason}`);
         } else if (action.type === ACTION_TYPES.TIMEOUT) {
-            const reason = setReason(action.type);
             twitch.sendChatMessage(`/timeout ${user} ${action.length}${reason}`);
         }
     }

--- a/src/modules/chat_custom_timeouts/index.js
+++ b/src/modules/chat_custom_timeouts/index.js
@@ -21,7 +21,7 @@ const CUSTOM_TIMEOUT_TEMPLATE = `
         <div class="cursor"></div>
     </div>
 `;
-const ACTION_TYPES = {
+const ActionTypes = {
     CANCEL: 'cancel',
     TIMEOUT: 'timeout',
     BAN: 'ban'
@@ -31,21 +31,24 @@ let action;
 let user;
 
 function setReason(type) {
-    if (settings.get('customTimeoutReasons')) return '';
     const reason = prompt(`Enter ${type} reason: (leave blank for none)`);
-    return reason ? ` ${reason}` : '';
+    return reason || '';
 }
 
 function handleTimeoutClick(e) {
     const $customTimeout = $(`#${CUSTOM_TIMEOUT_ID}`);
-    if (!$customTimeout.length || e.which === keyCodes.DOMVKCancel || e.shiftKey) return;
+    if (!$customTimeout.length || e.which === keyCodes.DOMVKCancel) return;
 
     if ($customTimeout.is(':hover')) {
-        const reason = setReason(action.type);
-        if (action.type === ACTION_TYPES.BAN) {
-            twitch.sendChatMessage(`/ban ${user}${reason}`);
-        } else if (action.type === ACTION_TYPES.TIMEOUT) {
-            twitch.sendChatMessage(`/timeout ${user} ${action.length}${reason}`);
+        const reason = e.shiftKey ? setReason(action.type) : '';
+        let command;
+        if (action.type === ActionTypes.BAN) {
+            command = '/ban';
+        } else if (action.type === ActionTypes.TIMEOUT) {
+            command = '/timeout';
+        }
+        if (command) {
+            twitch.sendChatMessage(`${command} ${user}${reason ? ` ${reason}` : ''}`);
         }
     }
 
@@ -72,25 +75,25 @@ function handleMouseMove(e) {
 
     if (amount > 200 || amount < 0 || offsetx > 80 || offsetx < 0) {
         action = {
-            type: ACTION_TYPES.CANCEL,
+            type: ActionTypes.CANCEL,
             length: 0,
             text: 'CANCEL'
         };
     } else if (amount > 20 && amount < 180) {
         action = {
-            type: ACTION_TYPES.TIMEOUT,
+            type: ActionTypes.TIMEOUT,
             length: time,
             text: humanTime
         };
     } else if (amount >= 180 && amount < 200) {
         action = {
-            type: ACTION_TYPES.BAN,
+            type: ActionTypes.BAN,
             length: 0,
             text: 'BAN'
         };
     } else if (amount > 0 && amount <= 20) {
         action = {
-            type: ACTION_TYPES.TIMEOUT,
+            type: ActionTypes.TIMEOUT,
             length: 2,
             text: 'PURGE'
         };
@@ -137,13 +140,6 @@ function handleClick(e) {
 class ChatCustomTimeoutsModule {
     constructor() {
         watcher.on('load.chat', () => this.loadClickHandler());
-
-        settings.add({
-            id: 'customTimeoutReasons',
-            name: 'Custom Timeout Reasons',
-            defaultValue: false,
-            description: 'Prompts for a reason when banning or timing out using the rightclick menu'
-        });
     }
 
     loadClickHandler() {


### PR DESCRIPTION
Add a setting that enables a prompt window to enter a reason for the custom timeout menu.
Useful for Twitch channels that require you to put a reason down on bans and timeouts.