### PR TITLE
[new-twitch] [Feat] Emotes autocompletion & tab completion & message history

### DIFF
--- a/src/modules/chat_autocompletion/chat-history-module.js
+++ b/src/modules/chat_autocompletion/chat-history-module.js
@@ -1,5 +1,6 @@
 const $ = require('jquery');
 const keyCodes = require('../../utils/keycodes');
+const watcher = require('../../watcher');
 
 function isSuggestionsShowing() {
     return !!$('[data-a-target="autocomplete-balloon"]')[0];
@@ -57,6 +58,7 @@ class ChatHistoryModule {
         if (message.trim().length === 0) return;
         this.messageHistory.unshift(message);
         this.historyPos = -1;
+        watcher.emit('input.onSendMessage', message);
     }
 
     onFocus() {

--- a/src/modules/chat_autocompletion/chat-history-module.js
+++ b/src/modules/chat_autocompletion/chat-history-module.js
@@ -1,0 +1,68 @@
+const $ = require('jquery');
+const keyCodes = require('../../utils/keycodes');
+
+function isSuggestionsShowing() {
+    return !!$('[data-a-target="autocomplete-balloon"]')[0];
+}
+
+class ChatHistoryModule {
+    load(resetHistory) {
+        if (resetHistory) {
+            this.messageHistory = [];
+        }
+        this.historyPos = -1;
+    }
+
+    onKeydown(e) {
+        const keyCode = e.keyCode || e.which;
+        if (e.ctrlKey) {
+            return;
+        }
+        const $inputField = $(e.target);
+        const setInputValue = value => {
+            e.target.customSetValue(value);
+        };
+
+        if (keyCode === keyCodes.Enter && !e.shiftKey) {
+            this.onSendMessage($inputField.val());
+        } else if (keyCode === keyCodes.UpArrow) {
+            if (isSuggestionsShowing()) return;
+            if ($inputField[0].selectionStart > 0) return;
+            if (this.historyPos + 1 === this.messageHistory.length) return;
+            const prevMsg = this.messageHistory[++this.historyPos];
+            setInputValue(prevMsg);
+            $inputField[0].setSelectionRange(0, 0);
+        } else if (keyCode === keyCodes.DownArrow) {
+            if (isSuggestionsShowing()) return;
+            if ($inputField[0].selectionStart < $inputField.val().length) return;
+            if (this.historyPos > 0) {
+                const prevMsg = this.messageHistory[--this.historyPos];
+                setInputValue(prevMsg);
+                $inputField[0].setSelectionRange(prevMsg.length, prevMsg.length);
+            } else {
+                const draft = $inputField.val().trim();
+                if (this.historyPos < 0 && draft.length > 0) {
+                    this.messageHistory.unshift(draft);
+                }
+                this.historyPos = -1;
+                $inputField.val('');
+                setInputValue('');
+            }
+        } else if (this.historyPos >= 0) {
+            this.messageHistory[this.historyPos] = $inputField.val();
+        }
+    }
+
+    onSendMessage(message) {
+        if (message.trim().length === 0) return;
+        this.messageHistory.unshift(message);
+        this.historyPos = -1;
+    }
+
+    onFocus() {
+        this.historyPos = -1;
+    }
+}
+
+module.exports = ChatHistoryModule;
+

--- a/src/modules/chat_autocompletion/custom-input-module.js
+++ b/src/modules/chat_autocompletion/custom-input-module.js
@@ -51,9 +51,19 @@ class CustomInputModule {
         });
 
         this.init();
-        watcher.on('input.onSendMessage', () => {
-            this.sendMessage();
-        });
+        watcher.on('input.onSendMessage', () => this.sendMessage());
+        watcher.on('chat.message', ($el, msg) => this.storeUser($el, msg));
+    }
+
+    init() {
+        this.userList = new Set();
+        this.tabTries = -1;
+        this.suggestions = null;
+        this.textSplit = ['', '', ''];
+    }
+
+    storeUser($el, message) {
+        this.userList.add(message.user.userDisplayName);
     }
 
     sendMessage() {
@@ -71,6 +81,7 @@ class CustomInputModule {
             const { $text, $oldText } = newTextArea();
             this.$text = $text;
             this.$oldText = $oldText;
+            this.userList = new Set();
         }
     }
 
@@ -82,12 +93,6 @@ class CustomInputModule {
     disable() {
         this.$text.hide();
         this.$oldText.show();
-    }
-
-    init() {
-        this.tabTries = -1;
-        this.suggestions = null;
-        this.textSplit = ['', '', ''];
     }
 
     getSuggestions(prefix, includeUsers = true, includeEmotes = true) {
@@ -186,17 +191,9 @@ class CustomInputModule {
     }
 
     getChatMembers() {
-        let chatMembers = this.chatInputCtrl.props.chatMembers;
         const broadcasterName = this.chatInputCtrl.props.channelDisplayName;
-        if (!chatMembers) {
-            return [];
-        }
-        chatMembers = chatMembers
-            .map(v => v.userDisplayName);
-        if (!chatMembers.find(v => v === broadcasterName)) {
-            chatMembers.push(broadcasterName);
-        }
-        return chatMembers;
+        this.userList.add(broadcasterName);
+        return Array.from(this.userList.values());
     }
 }
 

--- a/src/modules/chat_autocompletion/custom-input-module.js
+++ b/src/modules/chat_autocompletion/custom-input-module.js
@@ -1,0 +1,222 @@
+const $ = require('jquery');
+const watcher = require('../../watcher');
+const emotes = require('../emotes');
+const keyCodes = require('../../utils/keycodes');
+const twitch = require('../../utils/twitch');
+const settings = require('../../settings');
+
+const ORIGINAL_TEXTAREA = '.chat-input textarea';
+const CHAT_TEXTAREA = '#bttv-chat-input';
+
+// Replaces Twitch Text Input with our own
+function newTextArea() {
+    const text = document.createElement('textarea');
+    const $oldText = $(ORIGINAL_TEXTAREA);
+    $oldText[0].before(text);
+    const $text = $(text);
+
+    Array.from($oldText[0].attributes)
+        .map(attrEl => attrEl.name)
+        .forEach(attr => {
+            const v = $oldText.attr(attr);
+            $text.attr(attr, v);
+        });
+    $text.attr('id', 'bttv-chat-input');
+    $oldText.attr('id', 'twitch-chat-input');
+    $oldText.hide();
+    return { $text, $oldText};
+}
+
+class CustomInputModule {
+    constructor() {
+        settings.add({
+            id: 'tabCompletionEmotePriority',
+            name: 'Tab Completion Emote Priority',
+            description: 'Prioritize emotes over usernames when using tab completion',
+            default: false,
+        });
+
+        this.load();
+        watcher.on('load.chat', () => this.onChatLoad());
+    }
+
+    sendMessage() {
+        const message = this.$text.val();
+        if (message.trim().length === 0) {
+            return;
+        }
+        this.chatInputCtrl.props.onSendMessage(message);
+        this.$text.val('');
+        this.messageHistory.unshift(message);
+        this.historyPos = -1;
+    }
+
+    onChatLoad() {
+        this.chatInputCtrl = twitch.getChatInputController();
+        const { $text, $oldText } = newTextArea();
+        this.$text = $text;
+        this.$oldText = $oldText;
+    }
+
+    enable() {
+        this.$text.show();
+        this.$oldText.hide();
+        this.isEnabled = true;
+    }
+
+    disable() {
+        this.$text.hide();
+        this.$oldText.show();
+        this.isEnabled = false;
+    }
+
+    load() {
+        this.tabTries = -1;
+        this.suggestions = null;
+        this.textSplit = ['', '', ''];
+        this.messageHistory = [];
+        this.historyPos = -1;
+
+        $('body').off('click.tabComplete focus.tabComplete keydown.tabComplete')
+            .on('click.tabComplete focus.tabComplete', CHAT_TEXTAREA, () => this.onFocus())
+            .on('keydown.tabComplete', CHAT_TEXTAREA, e => this.onKeyDown(e));
+    }
+
+    getSuggestions(prefix, includeUsers = true, includeEmotes = true) {
+        let userList = [];
+        let emoteList = [];
+
+        if (includeEmotes) {
+            emoteList = emotes.getEmotes().map(emote => emote.code);
+            emoteList.push(...this.getTwitchEmotes());
+            emoteList = emoteList.filter(word => word.toLowerCase().indexOf(prefix.toLowerCase()) === 0);
+            emoteList = Array.from(new Set(emoteList).values());
+            emoteList.sort();
+        }
+
+        if (includeUsers) {
+            userList = this.getChatMembers().filter(word => word.toLowerCase().indexOf(prefix.toLowerCase()) === 0);
+            userList.sort();
+        }
+
+        if (settings.get('tabCompletionEmotePriority') === true) {
+            return [ ...emoteList, ...userList];
+        } else {
+            return [...userList, ...emoteList];
+        }
+    }
+
+    onKeyDown(e, includeUsers) {
+        if (!this.isEnabled) return;
+        const keyCode = e.keyCode || e.which;
+        if (e.ctrlKey) {
+            return;
+        }
+        const $inputField = this.$text;
+
+        if (keyCode === keyCodes.Enter && !e.shiftKey) {
+            e.preventDefault();
+            this.sendMessage();
+        } else if (keyCode === keyCodes.Tab) {
+            e.preventDefault();
+            this.onAutoComplete(includeUsers, e.shiftKey);
+        } else if (keyCode === keyCodes.Escape && this.tabTries >= 0) {
+            $inputField.val(this.textSplit.join(''));
+        } else if (keyCode !== keyCodes.Shift) {
+            this.tabTries = -1;
+        }
+
+        // Message history
+        if (keyCode === keyCodes.UpArrow) {
+            if ($inputField[0].selectionStart > 0) return;
+            if (this.historyPos + 1 === this.messageHistory.length) return;
+            const prevMsg = this.messageHistory[++this.historyPos];
+            $inputField.val(prevMsg);
+            $inputField[0].setSelectionRange(0, 0);
+        } else if (keyCode === keyCodes.DownArrow) {
+            if ($inputField[0].selectionStart < $inputField.val().length) return;
+            if (this.historyPos > 0) {
+                const prevMsg = this.messageHistory[--this.historyPos];
+                $inputField.val(prevMsg);
+                $inputField[0].setSelectionRange(prevMsg.length, prevMsg.length);
+            } else {
+                const draft = $inputField.val().trim();
+                if (this.historyPos < 0 && draft.length > 0) {
+                    this.messageHistory.unshift(draft);
+                }
+                this.historyPos = -1;
+                $inputField.val('');
+            }
+        } else if (this.historyPos >= 0) {
+            this.messageHistory[this.historyPos] = $inputField.val();
+        }
+    }
+
+    onFocus() {
+        this.tabTries = -1;
+    }
+
+    onAutoComplete(includeUsers, shiftKey) {
+        const $inputField = this.$text;
+
+        // First time pressing tab, split before and after the word
+        if (this.tabTries === -1) {
+            const caretPos = $inputField[0].selectionStart;
+            const text = $inputField.val();
+
+            const start = (/[\:\(\)\w]+$/.exec(text.substr(0, caretPos)) || {index: caretPos}).index;
+            const end = caretPos + (/^\w+/.exec(text.substr(caretPos)) || [''])[0].length;
+            this.textSplit = [text.substring(0, start), text.substring(start, end), text.substring(end + 1)];
+
+            // If there are no words in front of the caret, exit
+            if (this.textSplit[1] === '') return;
+
+            // Get all matching completions
+            const includeEmotes = this.textSplit[0].slice(-1) !== '@';
+            this.suggestions = this.getSuggestions(this.textSplit[1], includeUsers, includeEmotes);
+        }
+
+        if (this.suggestions.length > 0) {
+            this.tabTries += shiftKey ? -1 : 1; // shift key iterates backwards
+            if (this.tabTries >= this.suggestions.length) this.tabTries = 0;
+            if (this.tabTries < 0) this.tabTries = this.suggestions.length - 1;
+            if (!this.suggestions[this.tabTries]) return;
+
+            let cursorOffset = 0;
+            if (this.textSplit[2].trim() === '') {
+                this.textSplit[2] = ' ';
+                cursorOffset = 1;
+            }
+
+            const cursorPos = this.textSplit[0].length + this.suggestions[this.tabTries].length + cursorOffset;
+            $inputField.val(this.textSplit[0] + this.suggestions[this.tabTries] + this.textSplit[2]);
+            $inputField[0].setSelectionRange(cursorPos, cursorPos);
+        }
+    }
+
+    getTwitchEmotes() {
+        const twEmotes = this.chatInputCtrl.props.emotes;
+        if (!twEmotes) {
+            return [];
+        }
+        return twEmotes
+            .reduce((accum, v) => accum.concat(v.emotes), [])
+            .map(emote => emote.displayName);
+    }
+
+    getChatMembers() {
+        let chatMembers = this.chatInputCtrl.props.chatMembers;
+        const broadcasterName = this.chatInputCtrl.props.channelDisplayName;
+        if (!chatMembers) {
+            return [];
+        }
+        chatMembers = chatMembers
+            .map(v => v.userDisplayName);
+        if (!chatMembers.find(v => v === broadcasterName)) {
+            chatMembers.push(broadcasterName);
+        }
+        return chatMembers;
+    }
+}
+
+module.exports = CustomInputModule;

--- a/src/modules/chat_autocompletion/custom-input-module.js
+++ b/src/modules/chat_autocompletion/custom-input-module.js
@@ -3,6 +3,7 @@ const emotes = require('../emotes');
 const keyCodes = require('../../utils/keycodes');
 const twitch = require('../../utils/twitch');
 const settings = require('../../settings');
+const watcher = require('../../watcher');
 
 const ORIGINAL_TEXTAREA = '.chat-input textarea';
 
@@ -12,8 +13,8 @@ function setReactTextareaValue(txt, msg) {
     txt.dispatchEvent(ev);
 }
 
-// Replaces Twitch Text Input with our own
 function newTextArea() {
+    // Replaces Twitch Text Input with our own
     const text = document.createElement('textarea');
     const $oldText = $(ORIGINAL_TEXTAREA);
     $oldText[0].before(text);
@@ -41,7 +42,7 @@ function newTextArea() {
 }
 
 class CustomInputModule {
-    constructor(onMessage) {
+    constructor() {
         settings.add({
             id: 'tabCompletionEmotePriority',
             name: 'Tab Completion Emote Priority',
@@ -49,8 +50,10 @@ class CustomInputModule {
             default: false,
         });
 
-        this.onMessage = onMessage; // this callback notifies the ChatHistoryModule of a new message
         this.init();
+        watcher.on('input.onSendMessage', () => {
+            this.sendMessage();
+        });
     }
 
     sendMessage() {
@@ -60,7 +63,6 @@ class CustomInputModule {
         }
         this.chatInputCtrl.props.onSendMessage(message);
         this.$text.val('');
-        this.onMessage(message);
     }
 
     load(createTextarea = true) {
@@ -121,7 +123,6 @@ class CustomInputModule {
 
         if (keyCode === keyCodes.Enter && !e.shiftKey) {
             e.preventDefault();
-            this.sendMessage();
         } else if (keyCode === keyCodes.Tab) {
             e.preventDefault();
             this.onAutoComplete(includeUsers, e.shiftKey);

--- a/src/modules/chat_autocompletion/index.js
+++ b/src/modules/chat_autocompletion/index.js
@@ -1,0 +1,112 @@
+const $ = require('jquery');
+const watcher = require('../../watcher');
+const emotes = require('../emotes');
+const keyCodes = require('../../utils/keycodes');
+const twitch = require('../../utils/twitch');
+const debounce = require('lodash.debounce');
+
+const BTTV_EMOTES_ID = 'bttv-emotes';
+const INPUT_FIELD_SELECTOR = '.chat-input textarea';
+
+function bttvEmToTwitch(bttvEm) {
+    return {
+        displayName: bttvEm.code,
+        srcSet: Object.values(bttvEm.images).join(', '),
+        id: `${bttvEm.id}`,
+        token: bttvEm.code,
+        __typename: 'Emote'
+    };
+}
+
+function isSuggestionsShowing() {
+    return !!$('[data-a-target="autocomplete-balloon"]')[0];
+}
+
+function setTextareaValue(txt, msg) {
+    txt.value = msg;
+    // setting the value of an input with react need an 'input' event
+    const ev = new Event('input', { target: txt, bubbles: true });
+    txt.dispatchEvent(ev);
+}
+
+class ChatAutocompletionModule {
+    constructor() {
+        watcher.on('load.chat', () => {
+            this.load();
+        });
+
+        this.debounceLoadEmotes = debounce(() => {
+            this.loadEmotes();
+        }, 4000, { leading: true, trailing: false });
+
+        $('body').on('keydown', INPUT_FIELD_SELECTOR, e => this.onKeydown(e));
+    }
+
+    load() {
+        this.messageHistory = [];
+        this.historyPos = -1;
+    }
+
+    loadEmotes() {
+        const controller = twitch.getChatInputController();
+        const emotesFormatted = emotes.getEmotes()
+            .filter(em => !em.code.startsWith(':')) // emojis or any emote using special char break the chat.
+            .map(bttvEmToTwitch);
+
+        const emotesEntry = Object.values(controller.props.emotes)
+            .find(v => v.id === BTTV_EMOTES_ID);
+
+        if (emotesEntry) {
+            emotesEntry.emotes = emotesFormatted;
+        } else {
+            controller.props.emotes.push({
+                id: BTTV_EMOTES_ID,
+                emotes: emotesFormatted
+            });
+        }
+    }
+
+    onSendMessage(message) {
+        if (message.trim().length === 0) return;
+        this.messageHistory.unshift(message);
+        this.historyPos = -1;
+    }
+
+    onKeydown(e) {
+        this.debounceLoadEmotes();
+        const keyCode = e.keyCode || e.which;
+        if (e.ctrlKey) return;
+        const $inputField = $(e.target);
+
+        // Message history
+        if (keyCode === keyCodes.Enter && !e.shiftKey) {
+            this.onSendMessage($inputField.val());
+        } else if (keyCode === keyCodes.UpArrow) {
+            if (isSuggestionsShowing()) return;
+            if ($inputField[0].selectionStart > 0) return;
+            if (this.historyPos + 1 === this.messageHistory.length) return;
+            const prevMsg = this.messageHistory[++this.historyPos];
+            setTextareaValue($inputField[0], prevMsg);
+            $inputField[0].setSelectionRange(0, 0);
+        } else if (keyCode === keyCodes.DownArrow) {
+            if (isSuggestionsShowing()) return;
+            if ($inputField[0].selectionStart < $inputField.val().length) return;
+            if (this.historyPos > 0) {
+                const prevMsg = this.messageHistory[--this.historyPos];
+                setTextareaValue($inputField[0], prevMsg);
+                $inputField[0].setSelectionRange(prevMsg.length, prevMsg.length);
+            } else {
+                const draft = $inputField.val().trim();
+                if (this.historyPos < 0 && draft.length > 0) {
+                    this.messageHistory.unshift(draft);
+                }
+                this.historyPos = -1;
+                setTextareaValue($inputField[0], '');
+            }
+        } else if (this.historyPos >= 0) {
+            this.messageHistory[this.historyPos] = $inputField.val();
+        }
+    }
+}
+
+module.exports = new ChatAutocompletionModule();

--- a/src/modules/chat_autocompletion/index.js
+++ b/src/modules/chat_autocompletion/index.js
@@ -1,33 +1,61 @@
-// const watcher = require('../../watcher');
-// const settings = require('../../settings');
+const watcher = require('../../watcher');
+const settings = require('../../settings');
 
-// const CustomInputModule = require('./custom-input-module');
-// const InputPatcherModule = require('./input-patcher-module');
+const CustomInputModule = require('./custom-input-module');
+const InputPatcherModule = require('./input-patcher-module');
+const ChatHistoryModule = require('./chat-history-module');
+
+const CHAT_INPUT = '.chat-input';
 
 class ChatAutocompletionModule {
     constructor() {
-        // settings.add({
-        //     id: 'tabAutocomplete',
-        //     name: 'Tab Based Autocompletion',
-        //     defaultValue: false,
-        //     description: 'Autocomplete with Tab key'
-        // });
+        settings.add({
+            id: 'tabAutocomplete',
+            name: 'Tab Based Autocompletion',
+            defaultValue: false,
+            description: 'Autocomplete with Tab key'
+        });
 
-        // this.customInput = new CustomInputModule();
-        // this.patchedInput = new InputPatcherModule();
+        this.customInput = new CustomInputModule(message => {
+            this.chatHistory.onSendMessage(message);
+        });
+        this.patchedInput = new InputPatcherModule();
+        this.chatHistory = new ChatHistoryModule();
+        this.currentInput = null;
 
-        // watcher.on('load.chat', () => this.load());
-        // settings.on('changed.tabAutocomplete', () => this.load());
+        watcher.on('load.chat', () => this.load());
+        settings.on('changed.tabAutocomplete', () => this.load(false));
+
+        $('body').off('click.tabComplete focus.tabComplete keydown.tabComplete')
+            .on('click.tabComplete focus.tabComplete', CHAT_INPUT, () => this.onFocus())
+            .on('keydown.tabComplete', CHAT_INPUT, e => this.onKeydown(e));
     }
 
-    load() {
+    load(chatLoad = true) {
+        this.customInput.load(chatLoad);
+        this.patchedInput.load(chatLoad);
+        this.chatHistory.load(chatLoad);
         if (settings.get('tabAutocomplete')) {
             this.customInput.enable();
-            this.patchedInput.disable();
+            this.currentInput = this.customInput;
         } else {
             this.customInput.disable();
-            this.patchedInput.enable();
+            this.currentInput = this.patchedInput;
         }
+    }
+
+    onKeydown(e) {
+        if (this.currentInput) {
+            this.currentInput.onKeydown(e);
+        }
+        this.chatHistory.onKeydown(e);
+    }
+
+    onFocus() {
+        if (this.currentInput) {
+            this.currentInput.onFocus();
+        }
+        this.chatHistory.onFocus();
     }
 }
 

--- a/src/modules/chat_autocompletion/index.js
+++ b/src/modules/chat_autocompletion/index.js
@@ -16,9 +16,7 @@ class ChatAutocompletionModule {
             description: 'Autocomplete with Tab key'
         });
 
-        this.customInput = new CustomInputModule(message => {
-            this.chatHistory.onSendMessage(message);
-        });
+        this.customInput = new CustomInputModule();
         this.patchedInput = new InputPatcherModule();
         this.chatHistory = new ChatHistoryModule();
         this.currentInput = null;

--- a/src/modules/chat_autocompletion/index.js
+++ b/src/modules/chat_autocompletion/index.js
@@ -1,110 +1,32 @@
-const $ = require('jquery');
-const watcher = require('../../watcher');
-const emotes = require('../emotes');
-const keyCodes = require('../../utils/keycodes');
-const twitch = require('../../utils/twitch');
-const debounce = require('lodash.debounce');
+// const watcher = require('../../watcher');
+// const settings = require('../../settings');
 
-const BTTV_EMOTES_ID = 'bttv-emotes';
-const INPUT_FIELD_SELECTOR = '.chat-input textarea';
-
-function bttvEmToTwitch(bttvEm) {
-    return {
-        displayName: bttvEm.code,
-        srcSet: Object.values(bttvEm.images).join(', '),
-        id: `${bttvEm.id}`,
-        token: bttvEm.code,
-        __typename: 'Emote'
-    };
-}
-
-function isSuggestionsShowing() {
-    return !!$('[data-a-target="autocomplete-balloon"]')[0];
-}
-
-function setTextareaValue(txt, msg) {
-    txt.value = msg;
-    // setting the value of an input with react need an 'input' event
-    const ev = new Event('input', { target: txt, bubbles: true });
-    txt.dispatchEvent(ev);
-}
+// const CustomInputModule = require('./custom-input-module');
+// const InputPatcherModule = require('./input-patcher-module');
 
 class ChatAutocompletionModule {
     constructor() {
-        watcher.on('load.chat', () => {
-            this.load();
-        });
+        // settings.add({
+        //     id: 'tabAutocomplete',
+        //     name: 'Tab Based Autocompletion',
+        //     defaultValue: false,
+        //     description: 'Autocomplete with Tab key'
+        // });
 
-        this.debounceLoadEmotes = debounce(() => {
-            this.loadEmotes();
-        }, 4000, { leading: true, trailing: false });
+        // this.customInput = new CustomInputModule();
+        // this.patchedInput = new InputPatcherModule();
 
-        $('body').on('keydown', INPUT_FIELD_SELECTOR, e => this.onKeydown(e));
+        // watcher.on('load.chat', () => this.load());
+        // settings.on('changed.tabAutocomplete', () => this.load());
     }
 
     load() {
-        this.messageHistory = [];
-        this.historyPos = -1;
-    }
-
-    loadEmotes() {
-        const controller = twitch.getChatInputController();
-        const emotesFormatted = emotes.getEmotes()
-            .filter(em => !em.code.startsWith(':')) // emojis or any emote using special char break the chat.
-            .map(bttvEmToTwitch);
-
-        const emotesEntry = Object.values(controller.props.emotes)
-            .find(v => v.id === BTTV_EMOTES_ID);
-
-        if (emotesEntry) {
-            emotesEntry.emotes = emotesFormatted;
+        if (settings.get('tabAutocomplete')) {
+            this.customInput.enable();
+            this.patchedInput.disable();
         } else {
-            controller.props.emotes.push({
-                id: BTTV_EMOTES_ID,
-                emotes: emotesFormatted
-            });
-        }
-    }
-
-    onSendMessage(message) {
-        if (message.trim().length === 0) return;
-        this.messageHistory.unshift(message);
-        this.historyPos = -1;
-    }
-
-    onKeydown(e) {
-        this.debounceLoadEmotes();
-        const keyCode = e.keyCode || e.which;
-        if (e.ctrlKey) return;
-        const $inputField = $(e.target);
-
-        // Message history
-        if (keyCode === keyCodes.Enter && !e.shiftKey) {
-            this.onSendMessage($inputField.val());
-        } else if (keyCode === keyCodes.UpArrow) {
-            if (isSuggestionsShowing()) return;
-            if ($inputField[0].selectionStart > 0) return;
-            if (this.historyPos + 1 === this.messageHistory.length) return;
-            const prevMsg = this.messageHistory[++this.historyPos];
-            setTextareaValue($inputField[0], prevMsg);
-            $inputField[0].setSelectionRange(0, 0);
-        } else if (keyCode === keyCodes.DownArrow) {
-            if (isSuggestionsShowing()) return;
-            if ($inputField[0].selectionStart < $inputField.val().length) return;
-            if (this.historyPos > 0) {
-                const prevMsg = this.messageHistory[--this.historyPos];
-                setTextareaValue($inputField[0], prevMsg);
-                $inputField[0].setSelectionRange(prevMsg.length, prevMsg.length);
-            } else {
-                const draft = $inputField.val().trim();
-                if (this.historyPos < 0 && draft.length > 0) {
-                    this.messageHistory.unshift(draft);
-                }
-                this.historyPos = -1;
-                setTextareaValue($inputField[0], '');
-            }
-        } else if (this.historyPos >= 0) {
-            this.messageHistory[this.historyPos] = $inputField.val();
+            this.customInput.disable();
+            this.patchedInput.enable();
         }
     }
 }

--- a/src/modules/chat_autocompletion/input-patcher-module.js
+++ b/src/modules/chat_autocompletion/input-patcher-module.js
@@ -1,0 +1,125 @@
+const $ = require('jquery');
+const watcher = require('../../watcher');
+const emotes = require('../emotes');
+const keyCodes = require('../../utils/keycodes');
+const twitch = require('../../utils/twitch');
+const debounce = require('lodash.debounce');
+
+
+const BTTV_EMOTES_ID = 'bttv-emotes';
+const INPUT_FIELD_SELECTOR = '#twitch-chat-input';
+
+function bttvEmToTwitch(bttvEm) {
+    return {
+        displayName: bttvEm.code,
+        srcSet: Object.values(bttvEm.images).join(', '),
+        id: `${bttvEm.id}`,
+        token: bttvEm.code,
+        __typename: 'Emote'
+    };
+}
+
+function isSuggestionsShowing() {
+    return !!$('[data-a-target="autocomplete-balloon"]')[0];
+}
+
+function setTextareaValue(txt, msg) {
+    txt.value = msg;
+    // setting the value of an input with react need an 'input' event
+    const ev = new Event('input', { target: txt, bubbles: true });
+    txt.dispatchEvent(ev);
+}
+
+class InputPatcherModule {
+    constructor() {
+        watcher.on('load.chat', () => {
+            this.load();
+        });
+
+        this.debounceLoadEmotes = debounce(() => {
+            this.loadEmotes();
+        }, 4000, { leading: true, trailing: false });
+
+        this.isEnabled = false;
+        $('body').on('keydown', INPUT_FIELD_SELECTOR, e => this.onKeydown(e));
+    }
+
+    load() {
+        this.messageHistory = [];
+        this.historyPos = -1;
+    }
+
+    disable() {
+        this.isEnabled = false;
+    }
+
+    enable() {
+        this.isEnabled = true;
+    }
+
+    loadEmotes() {
+        if (!this.isEnabled) return;
+        const controller = twitch.getChatInputController();
+
+        const emotesFormatted = emotes.getEmotes()
+            .filter(em => !em.code.startsWith(':')) // emojis or any emote using special char break the chat.
+            .map(bttvEmToTwitch);
+
+        const emotesEntry = Object.values(controller.props.emotes)
+            .find(v => v.id === BTTV_EMOTES_ID);
+
+        if (emotesEntry) {
+            emotesEntry.emotes = emotesFormatted;
+        } else {
+            controller.props.emotes.push({
+                id: BTTV_EMOTES_ID,
+                emotes: emotesFormatted
+            });
+        }
+    }
+
+    onSendMessage(message) {
+        if (message.trim().length === 0) return;
+        this.messageHistory.unshift(message);
+        this.historyPos = -1;
+    }
+
+    onKeydown(e) {
+        if (!this.isEnabled) return;
+        this.debounceLoadEmotes();
+        const keyCode = e.keyCode || e.which;
+        if (e.ctrlKey) return;
+        const $inputField = $(INPUT_FIELD_SELECTOR);
+
+        // Message history
+        if (keyCode === keyCodes.Enter && !e.shiftKey) {
+            this.onSendMessage($inputField.val());
+        } else if (keyCode === keyCodes.UpArrow) {
+            if (isSuggestionsShowing()) return;
+            if ($inputField[0].selectionStart > 0) return;
+            if (this.historyPos + 1 === this.messageHistory.length) return;
+            const prevMsg = this.messageHistory[++this.historyPos];
+            setTextareaValue($inputField[0], prevMsg);
+            $inputField[0].setSelectionRange(0, 0);
+        } else if (keyCode === keyCodes.DownArrow) {
+            if (isSuggestionsShowing()) return;
+            if ($inputField[0].selectionStart < $inputField.val().length) return;
+            if (this.historyPos > 0) {
+                const prevMsg = this.messageHistory[--this.historyPos];
+                setTextareaValue($inputField[0], prevMsg);
+                $inputField[0].setSelectionRange(prevMsg.length, prevMsg.length);
+            } else {
+                const draft = $inputField.val().trim();
+                if (this.historyPos < 0 && draft.length > 0) {
+                    this.messageHistory.unshift(draft);
+                }
+                this.historyPos = -1;
+                setTextareaValue($inputField[0], '');
+            }
+        } else if (this.historyPos >= 0) {
+            this.messageHistory[this.historyPos] = $inputField.val();
+        }
+    }
+}
+
+module.exports = InputPatcherModule;

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -46,12 +46,14 @@ function getReactInstance(element) {
             return element[key];
         }
     }
+
     return null;
 }
 
 function getReactElement(element) {
     const instance = getReactInstance(element);
     if (!instance) return null;
+
     return instance._currentElement;
 }
 

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -6,6 +6,7 @@ const REACT_ROOT = '#root div[data-reactroot]';
 const CHAT_CONTAINER = '.chat-room__container';
 const VOD_CHAT_CONTAINER = '.video-watch-page__right-column';
 const CHAT_LIST = '.chat-list';
+const CHAT_INPUT = '.chat-input';
 const PLAYER = '.player';
 
 const TMIActionTypes = {
@@ -45,14 +46,12 @@ function getReactInstance(element) {
             return element[key];
         }
     }
-
     return null;
 }
 
 function getReactElement(element) {
     const instance = getReactInstance(element);
     if (!instance) return null;
-
     return instance._currentElement;
 }
 
@@ -75,7 +74,7 @@ function searchReactChildren(node, predicate, maxDepth = 15, depth = 0) {
         return null;
     }
 
-    const {_renderedChildren: children, _renderedComponent: componenet} = node;
+    const {_renderedChildren: children, _renderedComponent: component} = node;
 
     if (children) {
         for (const key of Object.keys(children)) {
@@ -86,8 +85,8 @@ function searchReactChildren(node, predicate, maxDepth = 15, depth = 0) {
         }
     }
 
-    if (componenet) {
-        return searchReactChildren(componenet, predicate, maxDepth, depth + 1);
+    if (component) {
+        return searchReactChildren(component, predicate, maxDepth, depth + 1);
     }
 
     return null;
@@ -196,6 +195,18 @@ module.exports = {
         if (controller) {
             controller = controller._instance;
         }
+
+        return controller;
+    },
+
+    getChatInputController() {
+        const container = $(CHAT_INPUT)[0];
+        if (!container) return null;
+
+        let controller;
+        try {
+            controller = getParentNode(getReactElement(container))._instance;
+        } catch (_) {}
 
         return controller;
     },


### PR DESCRIPTION
Using the new twitch emote auto completion (ie prefixing by ':'), this PR add Bttv emotes support (except emojis).

EDIT: added Tab Completion, user can enable it with settings. It will disable twitch completion (':') and suggestion box.

It also add message history like the master branch did.
