### PR TITLE
[new-twitch] [Fix] Bttv Channel Emotes syncing when changing channel.

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -255,13 +255,18 @@ class Watcher extends SafeEventEmitter {
             const currentChannel = twitch.getCurrentChannel();
             if (!currentChannel) return;
 
-            if (currentChannel.id === channel.id) return;
+            if (currentChannel.name === channel.name) return;
             channel = currentChannel;
             api
                 .get(`channels/${channel.name}`)
-                .then(d => this.emit('channel.updated', d));
+                .catch(error => ({
+                    bots: [],
+                    emotes: [],
+                    status: error.status || 0
+                }))
+                .then(data => this.emit('channel.updated', data));
+            return true;
         };
-
 
         this.on('load.chat', updateChannel);
         this.on('load.vod', updateChannel);

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -255,7 +255,7 @@ class Watcher extends SafeEventEmitter {
             const currentChannel = twitch.getCurrentChannel();
             if (!currentChannel) return;
 
-            if (currentChannel.name === channel.name) return;
+            if (currentChannel.id === channel.id) return;
             channel = currentChannel;
             api
                 .get(`channels/${channel.name}`)

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -268,6 +268,7 @@ class Watcher extends SafeEventEmitter {
             return true;
         };
 
+        this.on('load.channel', updateChannel);
         this.on('load.chat', updateChannel);
         this.on('load.vod', updateChannel);
     }


### PR DESCRIPTION
Currently, changing channel doesn't always update the bttv channel emotes. A refresh is usually needed. This PR fixes this.