### PR TITLE
[ Feature ] Mirror emotes & modules/chat/index.js rewrite

### DIFF
--- a/src/modules/emotes/emote.js
+++ b/src/modules/emotes/emote.js
@@ -15,29 +15,19 @@ module.exports = class Emote {
         return this.restrictionCallback ? this.restrictionCallback(channel, user) : true;
     }
 
-    toHTML() {
-        const srcset = [];
-        if (this.images['2x']) {
-            srcset.push(`${html.escape(this.images['2x'])} 2x`);
-        }
-        if (this.images['4x']) {
-            srcset.push(`${html.escape(this.images['4x'])} 4x`);
-        }
+    providerClass() {
+        return html.escape(this.provider.id);
+    }
 
-        const providerClass = html.escape(this.provider.id);
-        const idClass = `${html.escape(this.provider.id)}-emo-${html.escape(this.id)}`;
+    idClass() {
+        return `${html.escape(this.provider.id)}-emo-${html.escape(this.id)}`;
+    }
 
-        const balloon = `
+    balloon() {
+        return `
             ${html.escape(this.code)}<br>
             ${this.channel ? `Channel: ${html.escape(this.channel.displayName || this.channel.name)}<br>` : ''}
             ${html.escape(this.provider.displayName)}
-        `;
-
-        return `
-            <span class="balloon-wrapper bttv-emote ${providerClass} ${idClass}">
-                <img src="${html.escape(this.images['1x'])}" srcset="${srcset.join(', ')}" alt="${html.escape(this.code)}" class="chat-line__message--emote">
-                <div class="balloon balloon--tooltip balloon--up balloon--center mg-t-1" style="text-align: center;">${balloon}</div>
-            </span>
         `;
     }
 };

--- a/src/modules/emotes/style.css
+++ b/src/modules/emotes/style.css
@@ -2,6 +2,10 @@
     text-align: center;
 }
 
+.bttv-flip img {
+    transform: scaleX(-1);
+}
+
 /* Prevent stacking of IceCube, SoSnowy */
 .bttv-emo-5849c9a4f52be01a7ee5f79d + .bttv-emo-5849c9a4f52be01a7ee5f79d,
 .bttv-emo-567b5b520e984428652809b6 + .bttv-emo-567b5b520e984428652809b6 {

--- a/src/modules/emotes/style.css
+++ b/src/modules/emotes/style.css
@@ -1,3 +1,7 @@
+.tw-tooltip-wrapper[data-a-target="emote-name"] .tw-tooltip {
+    text-align: center;
+}
+
 /* Prevent stacking of IceCube, SoSnowy */
 .bttv-emo-5849c9a4f52be01a7ee5f79d + .bttv-emo-5849c9a4f52be01a7ee5f79d,
 .bttv-emo-567b5b520e984428652809b6 + .bttv-emo-567b5b520e984428652809b6 {
@@ -5,31 +9,31 @@
 }
 
 /* Ice Cube */
-div[data-a-target="emote-name"] + span .bttv-emo-5849c9a4f52be01a7ee5f79d img,
-span.bttv-emote + .bttv-emo-5849c9a4f52be01a7ee5f79d img {
+div[data-a-target="emote-name"] + .bttv-emo-5849c9a4f52be01a7ee5f79d img,
+div[data-a-target="emote-name"] + .bttv-emo-5849c9a4f52be01a7ee5f79d img {
   margin-left: -33px;
 }
 
 /* SoSnowy */
-div[data-a-target="emote-name"] + span .bttv-emo-567b5b520e984428652809b6 img,
-span.bttv-emote + .bttv-emo-567b5b520e984428652809b6 img {
+div[data-a-target="emote-name"] + .bttv-emo-567b5b520e984428652809b6 img,
+div[data-a-target="emote-name"] + .bttv-emo-567b5b520e984428652809b6 img {
   margin-left: -32px;
 }
 
 /* SantaHat */
-div[data-a-target="emote-name"] + span .bttv-emo-58487cc6f52be01a7ee5f205 img,
-span.bttv-emote + .bttv-emo-58487cc6f52be01a7ee5f205 img {
+div[data-a-target="emote-name"] + .bttv-emo-58487cc6f52be01a7ee5f205 img,
+div[data-a-target="emote-name"] + .bttv-emo-58487cc6f52be01a7ee5f205 img {
   margin-left: -34px;
   margin-top: -18px;
 }
 
 /* TopHat, CandyCane, ReinDeer */
-div[data-a-target="emote-name"] + span .bttv-emo-5849c9c8f52be01a7ee5f79e img,
-span.bttv-emote + .bttv-emo-5849c9c8f52be01a7ee5f79e img,
-div[data-a-target="emote-name"] + span .bttv-emo-567b5c080e984428652809ba img,
-span.bttv-emote + .bttv-emo-567b5c080e984428652809ba img,
-div[data-a-target="emote-name"] + span .bttv-emo-567b5dc00e984428652809bd img,
-span.bttv-emote + .bttv-emo-567b5dc00e984428652809bd img {
+div[data-a-target="emote-name"] + .bttv-emo-5849c9c8f52be01a7ee5f79e img,
+div[data-a-target="emote-name"] + .bttv-emo-5849c9c8f52be01a7ee5f79e img,
+div[data-a-target="emote-name"] + .bttv-emo-567b5c080e984428652809ba img,
+div[data-a-target="emote-name"] + .bttv-emo-567b5c080e984428652809ba img,
+div[data-a-target="emote-name"] + .bttv-emo-567b5dc00e984428652809bd img,
+div[data-a-target="emote-name"] + .bttv-emo-567b5dc00e984428652809bd img {
   margin-left: -31px;
   margin-top: -18px;
 }


### PR DESCRIPTION
This PR hooks up into the the tmi data from the chat service and replace the any bttv emotes it finds into twitch emotes format. Should be more robust, as there is less DOM manipulation.

Added emote mirroring for fun, but let me know if you want me to remove it.