### PR TITLE
[Feature] Improve chat freeze

### DIFF
--- a/src/modules/chat_freeze/index.js
+++ b/src/modules/chat_freeze/index.js
@@ -1,4 +1,5 @@
 const $ = require('jquery');
+const watcher = require('../../watcher');
 const twitch = require('../../utils/twitch');
 const keycodes = require('../../utils/keycodes');
 
@@ -6,7 +7,37 @@ const CHAT_LIST_SELECTOR = '.chat-list';
 const MESSAGES_INDICATOR_SELECTOR = '.chat-list__more-messages';
 const FREEZE_KEYS = [keycodes.Ctrl, keycodes.Meta];
 
-let keysPressed = 0;
+const PATCHED_SYMBOL = Symbol();
+let twitchSetState;
+
+function setChatBufferDelay(delay) {
+    try {
+        twitch.getChatController().chatBuffer.setDelay(delay);
+    } catch (_) {}
+}
+
+function patchedSetState({isAutoScrolling}) {
+    if (isAutoScrolling !== undefined) {
+        setChatBufferDelay(isAutoScrolling ? 0 : Infinity);
+    }
+    return twitchSetState.apply(this, arguments);
+}
+
+function patchScroller() {
+    const scroller = twitch.getChatScroller();
+    if (!scroller) return;
+
+    const newScrollerSetState = scroller.setState;
+    if (
+        newScrollerSetState === patchedSetState ||
+        scroller._bttvSetStatePatched === PATCHED_SYMBOL
+    ) {
+        return;
+    }
+    scroller.setState = patchedSetState;
+    scroller._bttvSetStatePatched = PATCHED_SYMBOL;
+    twitchSetState = newScrollerSetState;
+}
 
 function setScrollState(enabled) {
     const scroller = twitch.getChatScroller();
@@ -22,6 +53,7 @@ function shouldFreeze(e) {
 
 class ChatFreezeModule {
     constructor() {
+        let keysPressed = 0;
         $('body')
             .on('keydown.chat-freeze', e => {
                 keysPressed++;
@@ -35,6 +67,8 @@ class ChatFreezeModule {
                 const indicator = $(MESSAGES_INDICATOR_SELECTOR).length > 0;
                 setScrollState(indicator);
             });
+
+        watcher.on('load.chat', patchScroller);
     }
 }
 


### PR DESCRIPTION
Currently, if the chatBuffer is full, messages will drop even if the chat is "frozen". 

This PR delays messages for ever, as long as the chat is frozen. Messages are queued back when autoscrolling resumes.