### PR TITLE
modcard currentUserCanModerate logic fix

### DIFF
--- a/src/modules/chat_moderator_cards/moderator-card.js
+++ b/src/modules/chat_moderator_cards/moderator-card.js
@@ -143,7 +143,7 @@ class ModeratorCard {
         const isCurrentUser = currentUser.name === this.user.name;
         const isModerator = this.user.isOwner || this.user.isModerator;
 
-        const currentUserCanModerate = !isCurrentUser && (currentUserIsOwner || (currentUserIsModerator && isModerator));
+        const currentUserCanModerate = !isCurrentUser && (currentUserIsOwner || (currentUserIsModerator && !isModerator));
         if (!currentUserCanModerate) return;
 
         const $modCards = $(MODERATOR_ACTIONS_TEMPLATE);


### PR DESCRIPTION
Minor logic fix to fix moderation actions being shown for moderator targets and not being shown for normal users.