### PR TITLE
Replaces getCurrentEmotes() with chatService.selfEmotes - fixes #2908

### DIFF
--- a/src/modules/chat_tab_completion/index.js
+++ b/src/modules/chat_tab_completion/index.js
@@ -191,7 +191,7 @@ class ChatTabcompletionModule {
     }
 
     getTwitchEmotes() {
-        return Object.keys(twitch.getChatController().getCurrentEmotes());
+        return Object.keys(twitch.getChatController().chatService.selfEmotes);
     }
 }
 


### PR DESCRIPTION
Twitch apparently removed getCurrentEmotes() from the ChatController object.  ChatController.chatService.selfEmotes appears to be a suitable replacement.