### PR TITLE
Fix "hide-followed-offline" module

### DIFF
--- a/src/modules/hide_sidebar_elements/style.css
+++ b/src/modules/hide_sidebar_elements/style.css
@@ -17,7 +17,7 @@
 }
 
 .bttv-hide-followed-offline {
-  .side-nav-card[href*="/videos/all"], .side-nav-card__link[href*="/videos/all"] {
+  .side-nav-card__link[href*="/videos/"] {
     display: none !important;
   }
 }

--- a/src/modules/hide_sidebar_elements/style.css
+++ b/src/modules/hide_sidebar_elements/style.css
@@ -17,7 +17,7 @@
 }
 
 .bttv-hide-followed-offline {
-  .side-nav-card__link[href*="/videos/"] {
+  .side-nav-card__link[href^="/videos/"] {
     display: none !important;
   }
 }


### PR DESCRIPTION
Closes #2916

Some explanations:
- `.side-nav-card[href*="/videos/all"]` **removed**, since i couldn't find a single `.side-nav-card` with `href`
- in `.side-nav-card__link[href*="/videos/all"]`,  `/videos/all` was **replaced** with `/videos/`, since now even if user is offline, he could have `X new video(s)` with `href` containing specific video ID (i.e. `/videos/999999999`), so not only `/videos/all`

Notice, that this functionality **does not** handle `Reruns`
![image](https://user-images.githubusercontent.com/9695470/35228653-deb8d560-ff99-11e7-8b63-cf4abeff3c5b.png)

I am not even sure if it has to, since technically - stream is ON, but not the live.