### PR TITLE
Fixing Modcards

### DIFF
--- a/src/modules/hide_sidebar_elements/index.js
+++ b/src/modules/hide_sidebar_elements/index.js
@@ -54,7 +54,7 @@ class HideSidebarElementsModule {
 
     toggleAutoExpandChannels() {
         if (settings.get('autoExpandChannels') === true) {
-            $('.side-nav-load-more__button').trigger('click');
+            $('.side-nav-show-more-toggle__button').trigger('click');
         }
     }
 

--- a/src/modules/hide_sidebar_elements/index.js
+++ b/src/modules/hide_sidebar_elements/index.js
@@ -54,7 +54,7 @@ class HideSidebarElementsModule {
 
     toggleAutoExpandChannels() {
         if (settings.get('autoExpandChannels') === true) {
-            $('.side-nav-show-more-toggle__button').trigger('click');
+            $('.side-nav-load-more__button').trigger('click');
         }
     }
 

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -256,7 +256,7 @@ class Watcher extends SafeEventEmitter {
                         emitMessage($el);
                     }
 
-                    if ($el.children('.viewer-card').length) {
+                    if ($el.find('.viewer-card').length) {
                         this.emit('chat.moderator_card.open', $el.closest('.viewer-card-layer'));
                     }
                 }


### PR DESCRIPTION
Reason why the modcard watcher is failing:


On the modcard initial open, first div class emits `chat.moderator_card.open` upon meeting `$el.children('.viewer-card').length`.
```html
<div class="tw-border-t tw-border-r tw-border-b tw-border-l tw-elevation-1  ">
     <div class="viewer-card" style="background-image:..>
```

On subsequent loads, the only addedNodes is `<div class="viewer-card-layer tw-relative">`, which is structured like so, failing to meet `$el.children('.viewer-card').length` as there is no child of selector `.viewer-card`
```html
<div class="viewer-card-layer tw-relative">
    <div class="">
        <div class="tw-border-t tw-border-r tw-border-b tw-border-l tw-elevation-1  ">
            <div class="viewer-card" style="background-image:...>
```

If you feel that `find()` is too much, it can also be when either of these occurrences happen. 

### Interesting Note

On the first load `<div class="viewer-card-layer tw-relative">` is also an addedNode, however it isn't yet a viewer card until the div listed above is created. Here is the structure before that happens. 

```html
<div class="viewer-card-layer tw-relative">
    <div class="viewer-card__hide tw-top-0 tw-right-0 tw-absolute tw-mg-t-05 tw-mg-r-05">
        <button aria-label="Hide" ...>
```