### PR TITLE
Add changed Twitch name to highlighted words; fix #3040

### DIFF
--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -38,8 +38,19 @@ const pinnedHighlightTemplate = ({timestamp, from, message}) => `
 `;
 
 function defaultHighlightKeywords(value) {
-    if (typeof value === 'string') return value;
     const currentUser = twitch.getCurrentUser();
+    if (typeof value === 'string') {
+        if (currentUser) {
+            // Check for changed Twitch name, which isn't already in the string of highlights
+            if (!value.split(' ').some( w => {return w === currentUser.name;}) ) {
+                return value + ' ' + currentUser.name;
+            } else {
+                return value;
+            }
+        } else {
+            return value;
+        }
+    }
     return currentUser ? currentUser.name : '';
 }
 


### PR DESCRIPTION
In addition to first time additions of Twitch usernames to highlight
list, check for Twitch name being in highlight list in every call
to defaultHighlightKeywords and add if it isn't in it.

Please check for coding style, I went with the most explicit way, resulting in redundant `return value`s.