### PR TITLE
Fix "Hide New Viewer Greeting" module

### DIFF
--- a/src/modules/hide_new_viewer_greeting/style.css
+++ b/src/modules/hide_new_viewer_greeting/style.css
@@ -1,5 +1,5 @@
 .bttv-hide-new-viewer-greeting {
-  .chat-line__ritual {
+  .user-notice-line {
     display: none;
   }
 }


### PR DESCRIPTION
Closes #3060 

Twitch decided to change class name from `.chat-line__ritual` to `.user-notice-line` for greeting messages.
