### PR TITLE
update mod icons selector - fixes #3065

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -224,7 +224,7 @@ class ChatModule {
             $element.hide();
         }
 
-        const $modIcons = $element.find('.chat-line__mod-icons');
+        const $modIcons = $element.find('.mod_icon');
         if ($modIcons.length) {
             const userIsOwner = twitch.getUserIsOwnerFromTagsBadges(user.badges);
             const userIsMod = twitch.getUserIsModeratorFromTagsBadges(user.badges);


### PR DESCRIPTION
Twitch removed the existing selector from the div that wrapped all the mod icons.  This PR changes the selector to `.mod_icon`, which appears on the individual icon button elements.  This leaves one empty div inside the now non-identifiable container, itself also not identifiable, that has a very minor spacing effect that is probably not desirable, but this at least gets rid of the icons as originally intended.