### PR TITLE
update mod icons selector - the second - fixes #3065 (#3067)

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -224,7 +224,7 @@ class ChatModule {
             $element.hide();
         }
 
-        const $modIcons = $element.find('.mod_icon');
+        const $modIcons = $element.find('.mod-icon').parent();
         if ($modIcons.length) {
             const userIsOwner = twitch.getUserIsOwnerFromTagsBadges(user.badges);
             const userIsMod = twitch.getUserIsModeratorFromTagsBadges(user.badges);


### PR DESCRIPTION
Yesterday @Nareese commited a fix for #3065 (#3067), but it seems that the selector is `.mod-icon` instead of `.mod_icon`.

Also this will remove the mentioned empty div