### PR TITLE
Fix click player to pause

### DIFF
--- a/src/modules/video_player/index.js
+++ b/src/modules/video_player/index.js
@@ -88,10 +88,10 @@ class VideoPlayerModule {
     }
 
     clickToPause() {
-        $(VIDEO_PLAYER_SELECTOR).off('click', '.player-overlay.player-fullscreen-overlay', handlePlayerClick);
+        $(VIDEO_PLAYER_SELECTOR).off('click', '.pl-overlay.pl-overlay__fullscreen', handlePlayerClick);
 
         if (settings.get('clickToPlay') === true) {
-            $(VIDEO_PLAYER_SELECTOR).on('click', '.player-overlay.player-fullscreen-overlay', handlePlayerClick);
+            $(VIDEO_PLAYER_SELECTOR).on('click', '.pl-overlay.pl-overlay__fullscreen', handlePlayerClick);
         }
     }
 }

--- a/src/modules/video_player/index.js
+++ b/src/modules/video_player/index.js
@@ -69,13 +69,13 @@ class VideoPlayerModule {
             description: 'Hides the interactive overlays on top of Twitch\'s video player'
         });
         settings.add({
-            id: 'clickToPlay',
-            name: 'Click to Play/Pause Stream',
+            id: 'clickToPause',
+            name: 'Click to Pause Stream',
             defaultValue: false,
-            description: 'Click on the twitch player to pause/resume playback'
+            description: 'Click on the twitch player to pause playback'
         });
         settings.on('changed.hidePlayerExtensions', () => this.toggleHidePlayerExtensions());
-        settings.on('changed.clickToPlay', () => this.clickToPause());
+        settings.on('changed.clickToPause', () => this.clickToPause());
         this.toggleHidePlayerExtensions();
     }
 
@@ -90,7 +90,7 @@ class VideoPlayerModule {
     clickToPause() {
         $(VIDEO_PLAYER_SELECTOR).off('click', '.pl-overlay.pl-overlay__fullscreen', handlePlayerClick);
 
-        if (settings.get('clickToPlay') === true) {
+        if (settings.get('clickToPause') === true) {
             $(VIDEO_PLAYER_SELECTOR).on('click', '.pl-overlay.pl-overlay__fullscreen', handlePlayerClick);
         }
     }

--- a/src/modules/video_player/index.js
+++ b/src/modules/video_player/index.js
@@ -69,13 +69,13 @@ class VideoPlayerModule {
             description: 'Hides the interactive overlays on top of Twitch\'s video player'
         });
         settings.add({
-            id: 'clickToPause',
-            name: 'Click to Pause Stream',
+            id: 'clickToPlay',
+            name: 'Click to Play/Pause Stream',
             defaultValue: false,
-            description: 'Click on the twitch player to pause playback'
+            description: 'Click on the twitch player to pause/resume playback'
         });
         settings.on('changed.hidePlayerExtensions', () => this.toggleHidePlayerExtensions());
-        settings.on('changed.clickToPause', () => this.clickToPause());
+        settings.on('changed.clickToPlay', () => this.clickToPause());
         this.toggleHidePlayerExtensions();
     }
 
@@ -90,7 +90,7 @@ class VideoPlayerModule {
     clickToPause() {
         $(VIDEO_PLAYER_SELECTOR).off('click', '.pl-overlay.pl-overlay__fullscreen', handlePlayerClick);
 
-        if (settings.get('clickToPause') === true) {
+        if (settings.get('clickToPlay') === true) {
             $(VIDEO_PLAYER_SELECTOR).on('click', '.pl-overlay.pl-overlay__fullscreen', handlePlayerClick);
         }
     }


### PR DESCRIPTION
Changed the class names for player overlay in video_player module to match those on twitch.

Also changed the setting name and description to match the functionality. Clicking on the player only pauses the stream, but clicking a paused player won't resume playback. This seems to be intentional, as mentioned in [here](https://github.com/night/BetterTTV/pull/2668#issuecomment-350600699).