### PR TITLE
hide moderator card when a username is doubleclicked

### DIFF
--- a/src/modules/doubleclick_mention/index.js
+++ b/src/modules/doubleclick_mention/index.js
@@ -23,6 +23,9 @@ class DoubleClickMentionModule {
     load() {
         $(CHAT_ROOM_SELECTOR).off('dblclick.mention').on('dblclick.mention', USERNAME_SELECTORS, e => {
             if (e.shiftKey || e.ctrlKey) return;
+
+            $('.viewer-card__hide').find('button').click();
+
             clearSelection();
             let user = e.target.innerText ? e.target.innerText.replace('@', '') : '';
             const $target = $(e.target);


### PR DESCRIPTION
When you double click a username in chat in order to mention them, the moderator card still pops up.

I added a line to close that moderator card only on double click.

Signed-off-by: Matthew Roseman <mroseman95@gmail.com>