### PR TITLE
Fix Twitch Message Types

### DIFF
--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -143,13 +143,15 @@ function messageContainsKeyword(keywords, from, message) {
 function messageTextFromAST(ast) {
     return ast.map(node => {
         switch (node.type) {
-            case 0:
+            case 0: // Text
                 return node.content.trim();
-            case 1:
+            case 1: // CurrentUserHighlight
+                return node.content;
+            case 2: // Mention
                 return node.content.recipient;
-            case 2:
+            case 3: // Link
                 return node.content.url;
-            case 3:
+            case 4: // Emote
                 return node.content.alt;
         }
     }).join(' ');


### PR DESCRIPTION
Now we can highlight names correctly, there are 3 more types such as clips and video links that should be fine to ignore.
Closes #3099