### PR TITLE
Add "uses-select: none" for emote tooltips

### DIFF
--- a/src/modules/emotes/style.css
+++ b/src/modules/emotes/style.css
@@ -59,6 +59,10 @@ div.bttv-emote + .bttv-emo-567b5dc00e984428652809bd img {
   z-index: 2000;
   pointer-events: none;
   text-align: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
   &.bttv-emote-tooltip--up {
     top: auto;


### PR DESCRIPTION
Sometimes if you want to copy some message with emotes, it's copied with tooltip text.

For example if you copy
```
gachiBASS Clap gachiBASS Clap gachiBASS Clap
```
you get this
```
gachiBASS Clap Clap
Channel: turtlemaw
BetterTTV Channel Emotes gachiBASS Clap gachiBASS Clap
```
![alt text](https://i.imgur.com/cbyFGta.png)

So I added `user-select: none` for this tooltips, and it solves the problem.

https://caniuse.com/#search=user-select