### PR TITLE
fixes #3204 (#3203, #3205)

### DIFF
--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -147,11 +147,11 @@ function messageTextFromAST(ast) {
                 return node.content.trim();
             case 1: // CurrentUserHighlight
                 return node.content;
-            case 2: // Mention
+            case 3: // Mention
                 return node.content.recipient;
-            case 3: // Link
+            case 4: // Link
                 return node.content.url;
-            case 4: // Emote
+            case 5: // Emote
                 return node.content.alt;
         }
     }).join(' ');


### PR DESCRIPTION
fixes #3204 (#3203, #3205)

This is a fix for message highlighting, seems the message types have been updated. I tested Mentions, Links, Emotes, and self mentions and all seem to work again. I'm not sure what `CurrentUserHighlight` is, I was thinking it was self mentions, but those are type `3`.

I'm assuming these changes were created because something was added above them. Not sure if `CurrentUserHighlight` is still 1 or if that was also pushed down.