### PR TITLE
Fix user highlights

### DIFF
--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -145,7 +145,7 @@ function messageTextFromAST(ast) {
         switch (node.type) {
             case 0: // Text
                 return node.content.trim();
-            case 1: // CurrentUserHighlight
+            case 2: // CurrentUserHighlight
                 return node.content;
             case 3: // Mention
                 return node.content.recipient;

--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -147,11 +147,11 @@ function messageTextFromAST(ast) {
                 return node.content.trim();
             case 1: // CurrentUserHighlight
                 return node.content;
-            case 2: // Mention
+            case 3: // Mention
                 return node.content.recipient;
-            case 3: // Link
+            case 4: // Link
                 return node.content.url;
-            case 4: // Emote
+            case 5: // Emote
                 return node.content.alt;
         }
     }).join(' ');


### PR DESCRIPTION
Found out what a `CurrentUserHighlight` is, it's when someone uses your username without the `@`. Updated that type to `2`. Not sure what is the type `1` yet, I'll keep looking out for it.

![self_highlight_no_at](https://user-images.githubusercontent.com/2277583/44315240-08754780-a3d7-11e8-8388-e71fd3e4541b.png)
![self_highlight_no_at _data](https://user-images.githubusercontent.com/2277583/44315241-09a67480-a3d7-11e8-827d-abe323d55c4f.png)
