### PR TITLE
fix theme-dark class name

### DIFF
--- a/src/modules/chat_moderator_cards/style.css
+++ b/src/modules/chat_moderator_cards/style.css
@@ -82,7 +82,7 @@
     }
 }
 
-.tw-theme--dark {
+.tw-root--theme-dark {
     .bttv-moderator-card-messages .triangle {
         border-left-color: white;
     }

--- a/src/modules/chat_state/style.css
+++ b/src/modules/chat_state/style.css
@@ -32,7 +32,7 @@
   }
 }
 
-.tw-theme--dark {
+.tw-root--theme-dark {
   #bttv-channel-state-contain {
     color: #b19dd8;
 

--- a/src/modules/emotes/style.css
+++ b/src/modules/emotes/style.css
@@ -108,7 +108,7 @@ div.bttv-emote + .bttv-emo-567b5dc00e984428652809bd img {
   }
 }
 
-.tw-theme--dark {
+.tw-root--theme-dark {
   .bttv-emote-tooltip {
     padding: 3px 6px;
     border-radius: 2px;

--- a/src/modules/host_button/style.css
+++ b/src/modules/host_button/style.css
@@ -3,6 +3,6 @@
   margin-bottom: 10px;
 }
 
-.tw-theme--dark .bttv-host-button {
+.tw-root--theme-dark .bttv-host-button {
   background: #433f4a !important;
 }

--- a/src/modules/split_chat/style.css
+++ b/src/modules/split_chat/style.css
@@ -2,7 +2,7 @@
   background-color: #dcdcdc;
 }
 
-.tw-theme--dark {
+.tw-root--theme-dark {
   .chat-line__message.bttv-split-chat-alt-bg, .vod-message.bttv-split-chat-alt-bg {
     background-color: #1f1925;
   }


### PR DESCRIPTION
fixes #3216 

The main fix here is changing `.tw-theme--dark` to `.tw-root--theme-dark` in modules/split_chat/style.css, but there were several other places in the code where that class occurred.  The only one I was able to immediately verify was effected was modules/chat_moderator_cards/style.css, which changes the message history expansion triangle from purple to white(ish) under dark theme, but I just updated them all anyway.