### PR TITLE
Disable automatic theatre mode when not online/hosting

### DIFF
--- a/src/modules/auto_theater_mode/index.js
+++ b/src/modules/auto_theater_mode/index.js
@@ -10,6 +10,12 @@ class AutoTheaterModeModule {
             defaultValue: false,
             description: 'Automatically enables theatre mode'
         });
+        settings.add({
+            id: 'offlineTheatreMode',
+            name: 'Offline Theatre Mode',
+            defaultValue: false,
+            description: 'Disables automatic theatre mode if the channel is offline'
+        });
         watcher.on('load.player', () => this.load());
     }
 
@@ -18,6 +24,9 @@ class AutoTheaterModeModule {
 
         const player = twitch.getCurrentPlayer();
         if (!player) return;
+
+        const isLive = !!player.player.ended;
+        if (settings.get('offlineTheatreMode') === true && isLive === false) return;
 
         player.player.setTheatre(true);
     }


### PR DESCRIPTION
This PR adds a new setting to allow the user to disable automatic theatre mode when a channel is offline/not hosting a user.

Each combination has been tested with the two theatre mode settings.