### PR TITLE
Added feature to filter followed live channels by game.

### DIFF
--- a/src/modules/directory_filter_live/filter.css
+++ b/src/modules/directory_filter_live/filter.css
@@ -1,0 +1,12 @@
+#bttvLiveFilterPanel {
+  float: right;
+}
+
+#bttvLiveFilterPanel label {
+  font-size: 1.6rem;
+  padding-right: 10px;
+}
+
+#bttvLiveFilterPanel select {
+  font-size: 1.6rem;
+}

--- a/src/modules/directory_filter_live/index.js
+++ b/src/modules/directory_filter_live/index.js
@@ -1,0 +1,64 @@
+const settings = require('../../settings');
+const watcher = require('../../watcher');
+const $ = require('jquery');
+
+const filterPanelTemplate = () => `
+    <div id="liveFilterSelect">
+        <label class="tw-c-text-base tw-strong">Filter</label>
+        <select id="liveFilterSelectList">
+            <option value="All">All</option>
+        </select>
+    </div>
+`;
+
+class DirectoryFilterLiveModule {
+    constructor() {
+        settings.add({
+            id: 'showLiveFilter',
+            name: 'Filter Live Channels by Game',
+            defaultValue: false,
+            description: 'Allows for filtering followed live Channels by game.'
+        });
+        watcher.on('load.directory.following.live', () => this.load());
+    }
+
+    load(retries = 0) {
+        if (settings.get('showLiveFilter') === false || retries > 10) return;
+
+        const liveHeader = $('.tw-mg-b-2').find('h4:contains("Live channels")').css('display', 'inline').parent();
+        if (!liveHeader.length) {
+            return setTimeout(() => this.load(retries + 1), 250);
+        }
+
+        const panel = document.createElement('div');
+        panel.setAttribute('id', 'bttvLiveFilterPanel');
+        panel.innerHTML = filterPanelTemplate();
+        liveHeader.append(panel);
+
+        const games = [];
+
+        $('.live-channel-card a[href*="/game/"]').each(function() {
+            if (games.indexOf($(this).text()) === -1) {
+                games.push($(this).text());
+            }
+        });
+
+        games.sort().forEach(game => {
+            $('#liveFilterSelectList').append($('<option/>', {
+                value: game,
+                text: game
+            }));
+        });
+
+        $('#liveFilterSelectList').on('change', function() {
+            if (this.value === 'All') {
+                $('.live-channel-card').parent().show();
+            } else {
+                $('.live-channel-card').parent().hide();
+                $('.live-channel-card a[href*="/game/"]:contains("' + this.value + '")').closest('.live-channel-card').parent().show();
+            }
+        });
+    }
+}
+
+module.exports = new DirectoryFilterLiveModule();

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -204,6 +204,9 @@ class Watcher extends SafeEventEmitter {
                     if (lastRoute === routes.DIRECTORY_FOLLOWING_LIVE) break;
                     this.waitForLoad('following').then(() => this.emit('load.directory.following'));
                     break;
+                case routes.DIRECTORY_FOLLOWING_LIVE:
+                    this.waitForLoad('following').then(() => this.emit('load.directory.following.live'));
+                    break;
                 case routes.CHAT:
                     this.waitForLoad('chat').then(() => this.emit('load.chat'));
                     break;


### PR DESCRIPTION
If following a lot of channels that are streaming a variety of games the list of followed channels that are live gets quite cluttered. That can make it hard to discern which channels are streaming a specific game at that time. This remedies that by allowing filtering by game.

This feature has currently only been implemented on the live "Channels" tab for simplicity. 