### PR TITLE
Fix badgecontainer selector

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -97,7 +97,7 @@ class ChatModule {
 
         let $badgesContainer = $element.find('.chat-badge').closest('span');
         if (!$badgesContainer.length) {
-            $badgesContainer = $element.find('button.chat-line__username').prev('span');
+            $badgesContainer = $element.find('span.chat-line__username').prev('span');
         }
 
         const badge = staff.get(user.name);


### PR DESCRIPTION
Was wondering why my badge didn't show up sometimes. If the user has no chat badges BTTV will look for `button.chat-line__username`, this most likely has changed recently since there is no button anymore, but a span (with role="button"). Changed the selector to the span (`span.chat-line__username`).