### PR TITLE
[ONHOLD] Refactor split chat

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -10,7 +10,6 @@ const emotes = require('../emotes');
 const nicknames = require('../chat_nicknames');
 const channelEmotesTip = require('../channel_emotes_tip');
 const legacySubscribers = require('../legacy_subscribers');
-const splitChat = require('../split_chat');
 
 const EMOTE_STRIP_SYMBOLS_REGEX = /(^[~!@#$%\^&\*\(\)]+|[~!@#$%\^&\*\(\)]+$)/g;
 const MENTION_REGEX = /^@([a-zA-Z\d_]+)$/;
@@ -191,8 +190,6 @@ class ChatModule {
 
     messageParser($element, messageObj) {
         if ($element[0].__bttvParsed) return;
-
-        splitChat.render($element);
 
         const user = formatChatUser(messageObj);
         if (!user) return;

--- a/src/modules/split_chat/index.js
+++ b/src/modules/split_chat/index.js
@@ -1,6 +1,6 @@
+const $ = require('jquery');
+const watcher = require('../../watcher');
 const settings = require('../../settings');
-
-let alternateBackground = false;
 
 class SplitChatModule {
     constructor() {
@@ -10,15 +10,13 @@ class SplitChatModule {
             defaultValue: false,
             description: 'Easily distinguish between messages from different users in chat'
         });
+
+        watcher.on('load.chat', () => this.load());
+        settings.on('changed.splitChat', () => this.load());
     }
 
-    render($el) {
-        if (settings.get('splitChat') === false) return;
-
-        if (alternateBackground) {
-            $el.toggleClass('bttv-split-chat-alt-bg');
-        }
-        alternateBackground = !alternateBackground;
+    load() {
+        $('body').toggleClass('bttv-split-chat-bg', settings.get('splitChat'));
     }
 }
 

--- a/src/modules/split_chat/style.css
+++ b/src/modules/split_chat/style.css
@@ -1,9 +1,11 @@
-.chat-line__message.bttv-split-chat-alt-bg, .vod-message.bttv-split-chat-alt-bg {
-  background-color: #dcdcdc;
+body.bttv-split-chat-bg {
+  .chat-line__message:nth-child(2n), .vod-message:nth-child(2n) {
+    background-color: #dcdcdc;
+  }
 }
 
-.tw-root--theme-dark {
-  .chat-line__message.bttv-split-chat-alt-bg, .vod-message.bttv-split-chat-alt-bg {
+.tw-root--theme-dark.bttv-split-chat-bg {
+  .chat-line__message:nth-child(2n), .vod-message:nth-child(2n) {
     background-color: #1f1925;
   }
 }


### PR DESCRIPTION
Hello @night ,

This PR resolves : #3359

* instead of toggling a class on each `message_line`, we're toggling one on the body
* `:nth-child(2n)` will alternate the background, this also works with messages that get removed, although the background of the messages that come after will change to the other (don't think that's an issue)

Thanks!