### PR TITLE
Update cheer badge css selector

### DIFF
--- a/src/modules/hide_bits/style.css
+++ b/src/modules/hide_bits/style.css
@@ -5,7 +5,7 @@
   div[data-a-target="bits-card"],
   img.chat-line__message--emote[src^="https://d3aqoihi2n8ty8.cloudfront.net/actions/"],
   img.chat-line__message--emote[src^="https://d3aqoihi2n8ty8.cloudfront.net/partner-actions/"],
-  .chat-badge[alt~="Cheer"] {
+  .chat-badge[alt~="cheer"] {
     display: none !important;
   }
 }


### PR DESCRIPTION
Twitch changed the alt text on the chat badge back to a lower-case C, breaking bits badge hiding