### PR TITLE
[Fix] Init of BTTV

### DIFF
--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -185,7 +185,7 @@ module.exports = {
     getRouter() {
         let router;
         try {
-            const node = searchReactParents(
+            const node = searchReactChildren(
                 getReactInstance($(REACT_ROOT)[0]),
                 n => n.stateNode && n.stateNode.context && n.stateNode.context.router
             );

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -109,13 +109,19 @@ class Watcher extends SafeEventEmitter {
             try {
                 router = twitch.getRouter();
                 const connectStore = twitch.getConnectStore();
-                if (!connectStore || !router) return;
+                if (!connectStore || !router) {
+                    debug.error('Initialization failed, missing : ', {connectStore, router});
+                    return;
+                }
                 user = connectStore.getState().session.user;
             } catch (_) {
                 return;
             }
 
-            if (!router || !user) return;
+            if (!router || !user) {
+                debug.error('Initialization failed, missing : ', {router, user});
+                return;
+            }
             clearInterval(loadInterval);
 
             twitch.setCurrentUser(user.authToken, user.id, user.login, user.displayName);


### PR DESCRIPTION
@night Related to #3412 

It seems `getRouter` isn't available since the new twitch update. Changed lookup direction for router context.