### PR TITLE
[Feature] Add option to permanently toggle chat auto-scrolling

### DIFF
--- a/src/modules/chat_no_auto_scroll/index.js
+++ b/src/modules/chat_no_auto_scroll/index.js
@@ -1,0 +1,21 @@
+const $ = require('jquery');
+const settings = require('../../settings');
+
+class ChatNoAutoScroll {
+    constructor() {
+        settings.add({
+            id: 'chatNoAutoScroll',
+            name: 'Disable Chat Auto Scroll',
+            defaultValue: false,
+            description: 'Disables the auto-scroll when scrolling up the chat.'
+        });
+        settings.on('changed.chatNoAutoScroll', () => this.toggleAutoScroll());
+        this.toggleAutoScroll();
+    }
+
+    toggleAutoScroll() {
+        $('.chat-list__lines > div:nth-child(3) > div:nth-child(1)').off();
+    }
+}
+
+module.exports = new ChatNoAutoScroll();

--- a/src/modules/chat_no_auto_scroll/index.js
+++ b/src/modules/chat_no_auto_scroll/index.js
@@ -14,7 +14,7 @@ class ChatNoAutoScroll {
     }
 
     toggleAutoScroll() {
-        freeze.setScrollState(settings.get('changed.chatNoAutoScroll'));
+        freeze.setScrollState(!settings.get('chatNoAutoScroll'));
     }
 }
 

--- a/src/modules/chat_no_auto_scroll/index.js
+++ b/src/modules/chat_no_auto_scroll/index.js
@@ -1,4 +1,4 @@
-const $ = require('jquery');
+const freeze = require('../chat_freeze/index.js');
 const settings = require('../../settings');
 
 class ChatNoAutoScroll {
@@ -14,7 +14,7 @@ class ChatNoAutoScroll {
     }
 
     toggleAutoScroll() {
-        $('.chat-list__lines > div:nth-child(3) > div:nth-child(1)').off();
+        freeze.setScrollState(settings.get('changed.chatNoAutoScroll'));
     }
 }
 


### PR DESCRIPTION
On Firefox (Linux), I can't use Ctrl or Meta to control the scrolling (Ctrl+Wheel zooms in/out; Meta shows the "File, View" menu).

This provides a workaround by permanently disabling the scroller.