### PR TITLE
add display: block to tooltip div for link preview

### DIFF
--- a/src/modules/chat_link_preview/index.js
+++ b/src/modules/chat_link_preview/index.js
@@ -9,7 +9,7 @@ const CHAT_LINK_SELECTOR = '.link-fragment';
 const IMAGE_REGEX = new RegExp('(https?:\/\/.)([a-z\-_0-9\/\:\.\%\+]*\.(jpg|jpeg|png|gif|gifv|webm|mp4))', 'i');
 
 function tooltip($url, body) {
-    const $tooltip = $('<div />');
+    const $tooltip = $('<div />').css('display', 'block');
     $tooltip.addClass('tw-tooltip-wrapper').addClass('inline');
     $tooltip.html(`
         <div class="tw-tooltip tw-tooltip--up tw-tooltip--align-center" data-a-target="tw-tooltip-label" style="width: 250px;


### PR DESCRIPTION
fixes #3473 

Adds a `display: block` to explicitly override the `display: inline-flex` in `.tw-tooltip-wrapper` class on the outer tooltip div for link preview.  Tested with both links and image preview.  Seems fine on both.