### PR TITLE
getRouter fix

### DIFF
--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -190,7 +190,7 @@ module.exports = {
         try {
             const node = searchReactParents(
                 getReactInstance($(REACT_ROOT)[0]),
-                n => n.stateNode.props && n.stateNode.props.history && n.stateNode.props.history.listen && n.stateNode.props.history.location
+                n => n.stateNode && n.stateNode.props && n.stateNode.props.history && n.stateNode.props.history.listen && n.stateNode.props.history.location
             );
             router = node.stateNode.props;
         } catch (_) {}

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -188,11 +188,11 @@ module.exports = {
     getRouter() {
         let router;
         try {
-            const node = searchReactChildren(
+            const node = searchReactParents(
                 getReactInstance($(REACT_ROOT)[0]),
-                n => n.stateNode && n.stateNode.context && n.stateNode.context.router
+                n => n.stateNode.props && n.stateNode.props.history && n.stateNode.props.history.listen && n.stateNode.props.history.location
             );
-            router = node.stateNode.context.router;
+            router = node.stateNode.props;
         } catch (_) {}
 
         return router;


### PR DESCRIPTION
This works so far, however I don't know if this is the most efficient way of searching for it?
I figured since the 'history' prop is the only currently being used from the router in BTTV, I would scan for it directly.

fixes #3479 