### PR TITLE
[Feature] Add option to hide VOD chat header and text input

### DIFF
--- a/src/modules/vod_chat_hide_input/index.js
+++ b/src/modules/vod_chat_hide_input/index.js
@@ -1,0 +1,22 @@
+const $ = require('jquery');
+const settings = require('../../settings');
+
+class VodChatHideInputModule {
+    constructor() {
+        settings.add({
+            id: 'vodChatHideInput',
+            name: 'Hide VOD Chat Text Input',
+            defaultValue: false,
+            description: 'Hides the header and text input on VOD chat'
+        });
+
+        settings.on('changed.vodChatHideInput', () => this.load());
+        this.load();
+    }
+
+    load() {
+        $('body').toggleClass('bttv-vod-chat-hide-input', settings.get('vodChatHideInput'));
+    }
+}
+
+module.exports = new VodChatHideInputModule();

--- a/src/modules/vod_chat_hide_input/style.css
+++ b/src/modules/vod_chat_hide_input/style.css
@@ -1,0 +1,5 @@
+.bttv-vod-chat-hide-input {
+    .video-chat__header, .video-chat__input {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
I watch a decent amount of VODs in a tiny window and hated how much room the chat input and header took up since I never type in VOD chat anyway. Added an option to hide those so there's more room for chat replay. Based it off of `hide_room_selector` which seems like a pretty similar idea.