### PR TITLE
[Feature] Add "chat in fullscreen" setting

### DIFF
--- a/src/modules/chat_in_fullscreen/index.js
+++ b/src/modules/chat_in_fullscreen/index.js
@@ -32,9 +32,11 @@ class ChatInFullscreen {
         if (fsElement && this.chatFsActive) {
             $('body').addClass('fullscreen-active');
             $('.right-column .channel-root__right-column').appendTo(fsElement);
+            $('#emote-menu-for-twitch').appendTo(fsElement);
         } else {
             $('body').removeClass('fullscreen-active');
             $('.channel-root__right-column').appendTo('.right-column > .tw-block');
+            $('#emote-menu-for-twitch').appendTo('body');
         }
     }
 }

--- a/src/modules/chat_in_fullscreen/index.js
+++ b/src/modules/chat_in_fullscreen/index.js
@@ -1,0 +1,42 @@
+const $ = require('jquery');
+const settings = require('../../settings');
+
+class ChatInFullscreen {
+    constructor() {
+        settings.add({
+            id: 'chatInFullscreen',
+            name: 'Chat in Fullscreen',
+            defaultValue: false,
+            description: 'Shows chat section while in fullscreen mode.'
+        });
+        this.chatFsActive = false;
+        settings.on('changed.chatInFullscreen', () => this.toggleChatInFullscreen());
+        $(document).on('fullscreenchange mozfullscreenchange MSFullscreenChange webkitfullscreenchange', () => this.onFullScreenMoveChat());
+        this.toggleChatInFullscreen();
+    }
+
+    toggleChatInFullscreen() {
+        this.chatFsActive = settings.get('chatInFullscreen');
+        if (this.chatFsActive) {
+            $('body').addClass('bttv-chat-in-fullscreen');
+            $('.video-player__container').wrapInner('<div class="chat-in-fs-wrap" />');
+        } else {
+            $('body').removeClass('bttv-chat-in-fullscreen');
+            $('.video-player__container > .chat-in-fs-wrap').contents().unwrap();
+        }
+    }
+
+    onFullScreenMoveChat() {
+        const fsElement = document.fullscreenElement || document.mozFullScreenElement || document.msFullscreenElement || document.webkitFullscreenElement;
+
+        if (fsElement && this.chatFsActive) {
+            $('body').addClass('fullscreen-active');
+            $('.right-column .channel-root__right-column').appendTo(fsElement);
+        } else {
+            $('body').removeClass('fullscreen-active');
+            $('.channel-root__right-column').appendTo('.right-column > .tw-block');
+        }
+    }
+}
+
+module.exports = new ChatInFullscreen();

--- a/src/modules/chat_in_fullscreen/style.css
+++ b/src/modules/chat_in_fullscreen/style.css
@@ -1,0 +1,46 @@
+
+/* re-applying styles, because they get overwritten */
+.bttv-chat-in-fullscreen .player .chat-line__message,
+.bttv-chat-in-fullscreen .player .chat-line__moderation,
+.bttv-chat-in-fullscreen .player .chat-line__status {
+  padding: .5rem 2rem;
+}
+
+.bttv-chat-in-fullscreen .video-player__container .chat-line__timestamp {
+  margin-right: .5rem;
+}
+
+.bttv-chat-in-fullscreen .video-player__container .bits-leaderboard-header-first-entry {
+  padding-left: 1.4rem;
+  padding-right: 1.4rem;
+}
+
+.bttv-chat-in-fullscreen .pinned-cheer-v2-header__runner-up-entries {
+  margin: .4rem 0;
+}
+
+/* new styles */
+.bttv-chat-in-fullscreen .video-player__container .channel-root__right-column {
+  flex: 1 !important;
+  font-size: inherit;
+}
+
+.bttv-chat-in-fullscreen.fullscreen-active .video-player__container .chat-in-fs-wrap {
+  position: relative;
+}
+
+.bttv-chat-in-fullscreen.fullscreen-active .video-player__container {
+  display: flex;
+  font-size: inherit;
+}
+
+.bttv-chat-in-fullscreen.fullscreen-active .video-player__container .player-video {
+  display: flex;
+}
+
+.bttv-chat-in-fullscreen.fullscreen-active .video-player__container .player-video > video {
+  width: auto;
+  height: 100vh;
+  position: relative;
+  max-width: calc(100vw - 340px);
+}


### PR DESCRIPTION
Mainly for users with wide and ultra-wide monitors. Streams are almost always 16:9, which leaves black space on monitors with 21:9 for example. On 16:9 monitors it also has its uses.
![Screenshot from 2019-08-04 20-26-17](https://user-images.githubusercontent.com/18082688/62427097-4f4a7300-b6f6-11e9-90c1-7dc8c1cbed71.png)
![Screenshot from 2019-08-04 20-26-50](https://user-images.githubusercontent.com/18082688/62427099-51accd00-b6f6-11e9-8657-f0b4a223ddcb.png)
