### PR TITLE
Fix purge action in moderator contextmenu

### DIFF
--- a/src/modules/chat_custom_timeouts/index.js
+++ b/src/modules/chat_custom_timeouts/index.js
@@ -66,7 +66,7 @@ function handleMouseMove(e) {
     const offset = e.pageY - $customTimeout.offset().top;
     const offsetx = e.pageX - $customTimeout.offset().left;
     const amount = 224 - offset;
-    const time = Math.floor(Math.pow(1.5, (amount - 20) / 7) * 60);
+    const time = Math.floor(Math.pow(1.5, (amount - 45) / 6) * 60);
 
     let humanTime;
     if (Math.floor(time / 60 / 60 / 24) > 0) {
@@ -83,19 +83,25 @@ function handleMouseMove(e) {
             length: 0,
             text: 'CANCEL'
         };
-    } else if (amount > 24 && amount < 200) {
+    } else if (amount > 45 && amount < 204) {
         action = {
             type: ActionTypes.TIMEOUT,
             length: time,
             text: humanTime
         };
-    } else if (amount >= 200 && amount < 224) {
+    } else if (amount >= 204 && amount < 224) {
         action = {
             type: ActionTypes.BAN,
             length: 0,
             text: 'BAN'
         };
-    } else if (amount > 0 && amount <= 24) {
+    } else if (amount > 22 && amount <= 45) {
+        action = {
+            type: ActionTypes.TIMEOUT,
+            length: 1,
+            text: 'PURGE'
+        };
+    } else if (amount > 0 && amount <= 22) {
         action = {
             type: ActionTypes.DELETE,
             length: 0,

--- a/src/modules/chat_custom_timeouts/index.js
+++ b/src/modules/chat_custom_timeouts/index.js
@@ -66,7 +66,7 @@ function handleMouseMove(e) {
     const offset = e.pageY - $customTimeout.offset().top;
     const offsetx = e.pageX - $customTimeout.offset().left;
     const amount = 224 - offset;
-    const time = Math.floor(Math.pow(1.5, (amount - 45) / 6) * 60);
+    const time = Math.floor(Math.pow(1.5, (amount - 45) / 6.5) * 60);
 
     let humanTime;
     if (Math.floor(time / 60 / 60 / 24) > 0) {
@@ -89,7 +89,7 @@ function handleMouseMove(e) {
             length: time,
             text: humanTime
         };
-    } else if (amount >= 204 && amount < 224) {
+    } else if (amount >= 204 && amount <= 224) {
         action = {
             type: ActionTypes.BAN,
             length: 0,


### PR DESCRIPTION
With the introduction of the delete button in the right-click mod action menu, the purge button lost it's functionality, and is acting like the timeout selector: https://imgur.com/iOOmbpq

Since the max-length of a /timeout is 2 weeks and the space to select the time is shorter, I slightly changed the time calculation. Time to select is between 1 minute and 2 weeks now.