### PR TITLE
Potential fix for mod-cards

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -314,11 +314,8 @@ class Watcher extends SafeEventEmitter {
 
                     if ($el.hasClass('viewer-card')) {
                         this.emit('chat.moderator_card.open', $el);
-                    } else if ($el.hasClass('viewer-card-layer__draggable') && $el.find('.viewer-card').length) {
-                        const $viewerCard = $el.find('.viewer-card');
-                        if ($viewerCard.length) {
-                            this.emit('chat.moderator_card.open', $viewerCard);
-                        }
+                    } else if ($el.attr('class') === '' && $el.children('div:first').hasClass('viewer-card')) {
+                        this.emit('chat.moderator_card.open', $el.children('div:first'));
                     }
 
                     if ($el.hasClass('chat-input')) {


### PR DESCRIPTION
Hi Night, played around with the watcher for a bit to see what nodes were added/removed regarding the modcards/viewercards:

The surrounding html structure of the viewercard:
```html
<div data-a-target="viewer-card-positioner" class="tw-absolute viewer-card-layer__draggable" style="top: 52px;">
    <div class="">
        <div data-a-target="viewer-card" class="tw-border-b tw-border-l tw-border-r tw-border-t tw-elevation-1 tw-flex tw-flex-column viewer-card">
            ...
        </div>
    </div>
    <div data-a-target="viewer-card-close-button" class="tw-absolute tw-mg-r-05 tw-mg-t-05 tw-right-0 tw-top-0">
        ...
    </div>
</div>
```

On the first time opening a viewercard, an added node is detected with the following content:
```html
<div data-a-target="viewer-card" class="tw-border-b tw-border-l tw-border-r tw-border-t tw-elevation-1 tw-flex tw-flex-column viewer-card">...</div>
```
Which is catched by the `$el.hasClass('viewer-card')` [check](https://github.com/night/BetterTTV/blob/master/src/watcher.js#L315).

However the second time the mod card opens the watcher detects this viewer-card div but one layer deeper:
```html
<div class="">
    <div data-a-target="viewer-card" class="tw-border-b tw-border-l tw-border-r tw-border-t tw-elevation-1 tw-flex tw-flex-column viewer-card">
        ...
    </div>
</div>
```
The full structure above is also detected as new node, right before the one above, however [the old check](https://github.com/night/BetterTTV/blob/master/src/watcher.js#L317) `$el.hasClass('viewer-card-layer__draggable') && $el.find('.viewer-card').length` somehow seems to not search through the div with the empty class, not sure why..
Tried searching from the inside, first .find() the cancel button `.viewer-card-drag-cancel`, then searching for the closest `.viewer-card`, but no results..

So I added a check for elements with an empty class, with a check only on the first child div class, so BTTV doesn't have to crawl through a bunch of elements in case Twitch decides to add more elements with empty class names.
While I was browsing through Twitch, I couldn't find a lot of elements without a class name, max 2 on first page load load.