### PR TITLE
Name mismatch for highlight sound feedback

### DIFF
--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -233,7 +233,7 @@ class ChatHighlightBlacklistKeywordsModule {
 
         if (fromContainsKeyword(highlightUsers, from) || messageContainsKeyword(highlightKeywords, from, message)) {
             this.markHighlighted($message);
-            if (settings.get('playHighlightSound')) {
+            if (settings.get('highlightFeedback')) {
                 this.handleHighlightSound();
             }
             if (timestamp > loadTime) this.pinHighlight({from, message, date});


### PR DESCRIPTION
fixes #3546

Mismatch between the name used in the setting define and the name that is later checked to see if the sound should be played.