### PR TITLE
fixes #3576

### DIFF
--- a/src/modules/chat_state/index.js
+++ b/src/modules/chat_state/index.js
@@ -4,9 +4,7 @@ const twitch = require('../../utils/twitch');
 
 const CHAT_STATE_ID = 'bttv-channel-state-contain';
 const CHAT_STATE_TEMPLATE = require('./template')(CHAT_STATE_ID);
-const CHAT_HEADER_SELECTOR = '.rooms-header';
-const CHAT_HEADER_PRIVATE_ROOM_SELECTOR = 'svg.tw-svg__asset--unlock';
-const CHAT_SEND_BUTTON_SELECTOR = 'button[data-test-selector="chat-send-button"]';
+const CHAT_SETTINGS_BUTTON_SELECTOR = 'button[data-a-target="chat-settings"]';
 const PATCHED_SENTINEL = Symbol();
 
 let twitchOnRoomStateUpdated;
@@ -30,14 +28,9 @@ function displaySeconds(s) {
 
 function loadHTML() {
     const $stateContainer = $(`#${CHAT_STATE_ID}`);
-    const $headerSelector = $(CHAT_HEADER_SELECTOR);
-    const $chatSendButtonSelector = $(CHAT_SEND_BUTTON_SELECTOR);
-    if (!$headerSelector.length || $headerSelector.find(CHAT_HEADER_PRIVATE_ROOM_SELECTOR).length) {
-        $stateContainer.remove();
-        return;
-    }
+    const $chatSettingsButtonSelector = $(CHAT_SETTINGS_BUTTON_SELECTOR);
     if ($stateContainer.length) return;
-    $chatSendButtonSelector.before(CHAT_STATE_TEMPLATE);
+    $chatSettingsButtonSelector.before(CHAT_STATE_TEMPLATE);
 }
 
 function updateState(state, ...args) {

--- a/src/modules/chat_state/index.js
+++ b/src/modules/chat_state/index.js
@@ -4,6 +4,8 @@ const twitch = require('../../utils/twitch');
 
 const CHAT_STATE_ID = 'bttv-channel-state-contain';
 const CHAT_STATE_TEMPLATE = require('./template')(CHAT_STATE_ID);
+const CHAT_HEADER_SELECTOR = '.rooms-header';
+const CHAT_HEADER_PRIVATE_ROOM_SELECTOR = 'svg.tw-svg__asset--unlock';
 const CHAT_SETTINGS_BUTTON_SELECTOR = 'button[data-a-target="chat-settings"]';
 const PATCHED_SENTINEL = Symbol();
 
@@ -28,7 +30,12 @@ function displaySeconds(s) {
 
 function loadHTML() {
     const $stateContainer = $(`#${CHAT_STATE_ID}`);
+    const $headerSelector = $(CHAT_HEADER_SELECTOR);
     const $chatSettingsButtonSelector = $(CHAT_SETTINGS_BUTTON_SELECTOR);
+    if (!$headerSelector.length || $headerSelector.find(CHAT_HEADER_PRIVATE_ROOM_SELECTOR).length) {
+        $stateContainer.remove();
+        return;
+    }
     if ($stateContainer.length) return;
     $chatSettingsButtonSelector.before(CHAT_STATE_TEMPLATE);
 }

--- a/src/modules/chat_state/style.css
+++ b/src/modules/chat_state/style.css
@@ -3,6 +3,7 @@
   padding-top: 5px;
   margin-right: 10px;
   color: #6441a4;
+  float: left;
 
   svg path {
     fill: #6441a4;


### PR DESCRIPTION
fixes #3576 

Update the selectors to insert before the settings button instead of the chat send button, since twitch moved the settings button to the immediate left of the send button.  ~~Also clean up no longer used code for putting the container in the rooms header.~~