### PR TITLE
add user-select: none to settings switches

### DIFF
--- a/src/modules/settings/switch.css
+++ b/src/modules/settings/switch.css
@@ -20,6 +20,7 @@
   text-align: center;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
   cursor: pointer;
+  user-select: none;
 
   &:active {
     font-weight: bold;


### PR DESCRIPTION
Without `user-select: none`, (probably accidental) text selection on settings switches' text overrides switch clicking behaviour.

This change makes the switches more switch-y.

before | after
--- | ---
![before](https://user-images.githubusercontent.com/7574985/67064872-07e25900-f121-11e9-8f2b-c2c6c4f12794.gif) | ![after](https://user-images.githubusercontent.com/7574985/67064874-09138600-f121-11e9-91f2-c2e778be86a8.gif)

