### PR TITLE
set root eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,8 @@
   
   "globals": {},
 
+  "root": true,
+
   "rules": {
     "strict": 0,
 


### PR DESCRIPTION
When trying to `gulp watch`, I was getting this error:

```sh
> gulp watch
[23:00:04] Using gulpfile ~\help\js\BetterTTV\gulpfile.js
[23:00:04] Starting 'watch'...
[23:00:04] Starting 'devServer'...
[23:00:04] Starting 'cleanup'...
[23:00:04] Starting 'lint'...
[23:00:04] Finished 'cleanup' after 45 ms
[23:00:05] 'lint' errored after 1.01 s
[23:00:05] ESLintError in plugin "gulp-eslint"
Message:
    Unnecessarily quoted property 'LeftClick' found.
Details:
    fileName: C:\Users\Thth\help\js\BetterTTV\src\constants.js
    lineNumber: 8
    domainEmitter: [object Object]
    domainThrown: false

[23:00:05] 'watch' errored after 1.03 s
[23:00:05] The following tasks did not complete: devServer
[23:00:05] Did you forget to signal async completion?
```
The issue turned out to be a stray `.eslintrc` in an ancestor directory. The [eslint docs](https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy) seem to indicate that the nearest configuration file should take priority, so I have no idea why a config file further up causes me issues. (Maybe it has something to do with gulp?)

Regardless, setting `"root": true` on `.eslintrc` at the project's base level, as the eslint docs recommends for remedying "unexpected results", is the explicit fix for this issue.