### PR TITLE
[Fix] Update twitch player selector

### DIFF
--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -7,7 +7,7 @@ const CHANNEL_CONTAINER = '.channel-page,.channel-root';
 const CHAT_CONTAINER = 'section[data-test-selector="chat-room-component-layout"]';
 const VOD_CHAT_CONTAINER = '.qa-vod-chat';
 const CHAT_LIST = '.chat-list';
-const PLAYER = '.player,.highwind-video-player__container';
+const PLAYER = '.player,.highwind-video-player__container,.video-player__container';
 const CLIPS_BROADCASTER_INFO = '.clips-broadcaster-info';
 
 const TMIActionTypes = {


### PR DESCRIPTION
@night 
Twitch removed `highwind-` prefix from their player. This breaks a few features.

Closes #3675 #3669 