### PR TITLE
Increase maxDepth for twitch.getCurrentPlayer

### DIFF
--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -222,7 +222,8 @@ module.exports = {
         try {
             const node = searchReactParents(
                 getReactInstance($(PLAYER)[0]),
-                n => n.stateNode && (n.stateNode.player || n.stateNode.props.mediaPlayerInstance)
+                n => n.stateNode && (n.stateNode.player || n.stateNode.props.mediaPlayerInstance),
+                30
             );
             player = node.stateNode.player ? node.stateNode.player.player : node.stateNode.props.mediaPlayerInstance;
         } catch (e) {}


### PR DESCRIPTION
Updated `getCurrentPlayer` to a higher `maxDepth` setting to fetch the player instance.

Fixes: #3741, #3742, #3743, #3744

@night 