### PR TITLE
[Feature] Add "Hide Channel Leaderboard" Option

### DIFF
--- a/src/modules/hide_channel_leaderboard/index.js
+++ b/src/modules/hide_channel_leaderboard/index.js
@@ -1,0 +1,21 @@
+const $ = require('jquery');
+const settings = require('../../settings');
+
+class HideChannelLeaderboardModule {
+    constructor() {
+        settings.add({
+            id: 'hideChannelLeaderboard',
+            name: 'Hide Channel Leaderboard',
+            defaultValue: false,
+            description: 'Hides channel leaderboard from the top of chat to reduce clutter'
+        });
+        settings.on('changed.hideChannelLeaderboard', () => this.load());
+        this.load();
+    }
+
+    load() {
+        $('body').toggleClass('bttv-hide-channel-leaderboard', settings.get('hideChannelLeaderboard'));
+    }
+}
+
+module.exports = new HideChannelLeaderboardModule();

--- a/src/modules/hide_channel_leaderboard/style.css
+++ b/src/modules/hide_channel_leaderboard/style.css
@@ -1,0 +1,5 @@
+.bttv-hide-channel-leaderboard {
+  .channel-leaderboard {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Annoyed by that channel leaderboard of top sub-gifters and bit-cheerers clogging up the top of yr chat ?

Here's a (tiny) PR for a BetterTTV setting for that !

<3