### PR TITLE
Fix tooltip for our custom badges

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -81,10 +81,7 @@ class ChatModule {
 
     customBadges($element, user) {
         if ((globalBots.includes(user.name) || channelBots.includes(user.name)) && user.mod) {
-            $element.find('img.chat-badge[alt="Moderator"]')
-                .addClass('bttv-chat-badge')
-                .attr('srcset', '')
-                .attr('src', cdn.url('tags/bot.png'));
+            $element.find('img.chat-badge[alt="Moderator"]').replaceWith(badgeTemplate(cdn.url('tags/bot.png'), 'Bot'));
         }
 
         let $badgesContainer = $element.find('.chat-badge').closest('span');

--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -17,7 +17,7 @@ const EMOTES_TO_CAP = ['567b5b520e984428652809b6'];
 const MAX_EMOTES_WHEN_CAPPED = 10;
 
 const badgeTemplate = (url, description) => `
-    <div class="tw-tooltip-wrapper tw-inline">
+    <div class="tw-tooltip-wrapper tw-inline tw-relative">
         <img alt="Moderator" class="chat-badge bttv-chat-badge" src="${url}" alt="" srcset="" data-a-target="chat-badge">
         <div class="tw-tooltip tw-tooltip--up tw-tooltip--align-left" data-a-target="tw-tooltip-label" style="margin-bottom: 0.9rem;">${description}</div>
     </div>


### PR DESCRIPTION
Hiya,
Currently the tooltip for custom badges isn't showing:
![badges1](https://user-images.githubusercontent.com/13732765/75788904-2dd36780-5d69-11ea-8baf-ebe9df879727.gif)

The Twitch badges are getting replaced by a different div/with tooltip on hover. This broke the hover/tooltip on bot badges, since they are getting replaced by a mod badge on hover:
![badges2](https://user-images.githubusercontent.com/13732765/75789115-7d199800-5d69-11ea-8bd1-4c29a89e109c.gif)

Instead of editing the current mod badge, I replaced it using our badgeTemplate. This seems to fix the replacement on hover for the bot badge:
![badges3](https://user-images.githubusercontent.com/13732765/75789318-ccf85f00-5d69-11ea-8801-110cbb66f208.gif)

By adding the `tw-relative` class the tooltips are showing up again.
 
The order of badges is still a bit choppy, we could prepend them, so the order doesn't change on hover, untill there is better fix?
