### PR TITLE
Fix hide offline channels with collapsed sidebar

### DIFF
--- a/src/modules/hide_sidebar_elements/style.css
+++ b/src/modules/hide_sidebar_elements/style.css
@@ -11,7 +11,7 @@
 }
 
 .bttv-hide-followed-offline {
-  .side-nav-card__link[href*="/videos/"] {
+  .side-nav-card__link[href*="/videos/"], .side-nav-card[href*="/videos/"] {
     display: none !important;
   }
 }


### PR DESCRIPTION
Fixes: #3839

The markup differs between collapsed/expanded and the `<a/>` tag has either `side-nav-card__link` or `side-nav-card` classnames.