### PR TITLE
fix: emotes selection with mouse

### DIFF
--- a/src/modules/emotes/style.css
+++ b/src/modules/emotes/style.css
@@ -45,7 +45,7 @@ div.bttv-emote + .bttv-emo-5e76d399d6581c3724c0f0b8 img {
 }
 
 .bttv-emote-tooltip-wrapper {
-  display: inline;
+  display: inline-block;
   position: relative;
 
   &:hover .bttv-emote-tooltip {


### PR DESCRIPTION
If a message ends with a BTTV/FFZ emote sometimes it's impossible to select and copy the full message with the mouse.

And it works fine if we change `display: inline` to `display: inline-block` in `.bttv-emote-tooltip-wrapper`. 
This fix should not affect how emotes will display.

In **Chrome** you can select twitch emotes but not BTTV/FFZ emotes. And this fix allows you to select them.

In **Firefox** you can't select even twitch emotes so this fix does nothing.

![](https://i.imgur.com/4hhhpk5.gif)