### PR TITLE
Fix the chat and ui when using chat on left side

### DIFF
--- a/src/modules/chat_left_side/style.css
+++ b/src/modules/chat_left_side/style.css
@@ -15,6 +15,20 @@
         }
     }
 
+    /* Restore channel content and player size */
+    .channel-root__right-column--expanded {
+        position: relative !important;
+        transform: none !important;
+    }
+
+    .channel-root__player--with-chat {
+        width: 100% !important;
+    }
+
+    .channel-info-content {
+        width: 100% !important;
+    }
+
     /* Header overlap with collapseable column */
     .channel-header .tw-sm-pd-r-4 .channel-header__left {
         margin-left: 3.5rem;


### PR DESCRIPTION
This fixes some of the weirdness the new twitch design introduced when using the chat on the left side. Mainly this means the chat is displayed again and the right part of the UI has the empty space removed.

Since I got fully switch over to the new design I could not test if any of these changes break the old design. I think most of the CSS classes are new ones so we should be good, but somebody that still has the old twitch design needs to verify this before merging.

Additionally I did try to verify that this does not break anything else but I can't guarantee anything because I probably did not test any possible scenario.

Fixes #3873
Fixes #3875 
Fixes #3878
Fixes #3891
Fixes #3895
Fixes #3898