### PR TITLE
[Fix] Embeded usage on 3rd party sites

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 (() => {
     if (!String.prototype.includes || !Array.prototype.findIndex) return;
     if (window.location.pathname.endsWith('.html')) return;
-    if (!['www.twitch.tv', 'canary.twitch.tv', 'clips.twitch.tv', 'dashboard.twitch.tv'].includes(window.location.hostname)) return;
+    if (!new RegExp(['/twitch', 'twitch.tv'].join('|')).test(window.location)) return;
     if (window.Ember) return;
 
     const debug = require('./utils/debug');

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -68,7 +68,7 @@ function getReactInstance(element) {
     return null;
 }
 
-function searchReactParents(node, predicate, maxDepth = 15, depth = 0) {
+function searchReactParents(node, predicate, maxDepth = 25, depth = 0) {
     try {
         if (predicate(node)) {
             return node;

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -190,6 +190,7 @@ class Watcher extends SafeEventEmitter {
         }});
 
         debug.log('Watcher started');
+        this.forceReloadChat();
     }
 
     forceReloadChat() {


### PR DESCRIPTION
The [Twitch.tv embeded player](https://dev.twitch.tv/docs/embed/everything) was working fine with bttv  in the past for 3rd party sites, but it broke recently when I updated bttv.

Fixes: https://github.com/night/betterttv/issues/3874