### PR TITLE
Enable GIF Emotes by default

### DIFF
--- a/src/modules/emotes/index.js
+++ b/src/modules/emotes/index.js
@@ -28,7 +28,7 @@ class EmotesModule {
         settings.add({
             id: 'bttvGIFEmotes',
             name: 'BetterTTV GIF Emotes',
-            defaultValue: false,
+            defaultValue: true,
             description: 'Adds animated emotes (not everyone likes GIFs, but some people do)'
         });
     }


### PR DESCRIPTION
It is common to see chatters in Twitch Chats, the NightDev Discord and GitHub issues complaining about not being able to see some emotes. The onboarding of users to BTTV is a step in itself, having to describe how to further their experience that is engraved in the culture of Twitch and BTTV by enabling another option creates for a lengthy discussion. We should break this barrier by enabling this setting by default. Thank you for your consideration in merging this PR.