### PR TITLE
[Feature] Display chat even if permanently banned from channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 dist
 .vscode
+.idea

--- a/src/modules/anon_chat/index.js
+++ b/src/modules/anon_chat/index.js
@@ -51,7 +51,7 @@ class AnonChatModule {
         this.enabled = false;
         if (forcedURL || settings.get('anonChat')) {
             this.part();
-        } else {
+        } else if (!settings.get('bannedChat')) { // If banned setting is on, user will join via event handler instead.
             this.join();
         }
     }

--- a/src/modules/banned_chat/index.js
+++ b/src/modules/banned_chat/index.js
@@ -1,0 +1,62 @@
+const settings = require('../../settings');
+const watcher = require('../../watcher');
+const twitch = require('../../utils/twitch');
+const anonChat = require('../anon_chat/index');
+
+class BannedChatModule {
+    constructor() {
+        settings.add({
+            id: 'bannedChat',
+            name: 'Display Chat if Banned',
+            defaultValue: false,
+            description: 'Show chat messages even if permanently banned from the channel'
+        });
+
+        watcher.on('load', () => this.attachBannedChatSocketListener());
+        watcher.on('load.chat', () => this.displayChatComponent());
+    }
+
+    displayChatComponent() {
+        if (settings.get('bannedChat')) {
+            const currentUserBannedNode = twitch.getCurrentUserBannedStateNode();
+            if (currentUserBannedNode) {
+                currentUserBannedNode.isCurrentUserBanned = () => false;
+            }
+
+            const userBannedNode = twitch.getUserBannedStateNode();
+            if (userBannedNode) {
+                userBannedNode.isUserBanned = () => false;
+            }
+        }
+    }
+
+    attachBannedChatSocketListener() {
+        // If Anon Chat is enabled, no need to listen for banned socket response as the user will always be anonymous.
+        if (settings.get('bannedChat') && !settings.get('anonChat')) {
+            const client = twitch.getChatServiceClient();
+            if (!client) return;
+
+            const socket = client.connection.ws;
+            if (!socket || socket.isBannedChatListenerAttached) return;
+
+            socket.isBannedChatListenerAttached = true;
+            socket.addEventListener('message', event => {
+                if (this.userBannedFromChannelMessage(event)) {
+                    anonChat.part();
+                } else if (this.leavingChannelMessage(event)) {
+                    anonChat.join();
+                }
+            });
+        }
+    }
+
+    userBannedFromChannelMessage(event) {
+        return event.data && event.data.startsWith('@msg-id=msg_banned');
+    }
+
+    leavingChannelMessage(event) {
+        return event.data && event.data.startsWith(':') && event.data.includes('PART');
+    }
+}
+
+module.exports = new BannedChatModule();

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -9,6 +9,7 @@ const CHAT_LIST = '.chat-list';
 const PLAYER = '.video-player__container';
 const CLIPS_BROADCASTER_INFO = '.clips-broadcaster-info';
 const CHAT_MESSAGE_SELECTOR = '.chat-line__message';
+const STREAM_CHAT = '.stream-chat';
 
 const TMIActionTypes = {
     MESSAGE: 0,
@@ -264,6 +265,32 @@ module.exports = {
         } catch (_) {}
 
         return chatClient;
+    },
+
+    getCurrentUserBannedStateNode() {
+        let currentUserBannedStateNode;
+        try {
+            const node = searchReactChildren(
+                getReactInstance($(STREAM_CHAT)[0]),
+                n => n.stateNode && n.stateNode.isCurrentUserBanned,
+                1000
+            );
+            currentUserBannedStateNode = node.stateNode;
+        } catch (_) {}
+        return currentUserBannedStateNode;
+    },
+
+    getUserBannedStateNode() {
+        let userBannedStateNode;
+        try {
+            const node = searchReactChildren(
+                getReactInstance($(STREAM_CHAT)[0]),
+                n => n.stateNode && n.stateNode.isUserBanned,
+                1000
+            );
+            userBannedStateNode = node.stateNode;
+        } catch (_) {}
+        return userBannedStateNode;
     },
 
     getChatServiceSocket() {


### PR DESCRIPTION
This PR includes a new setting `Display Chat if Banned` that shows chat messages even if the user's been permanently banned from the channel.

Before:
<img width="333" alt="banned" src="https://user-images.githubusercontent.com/9336586/85798826-924d7480-b714-11ea-8e0d-2a57a79b06c8.png">

After:
<img width="335" alt="unbanned" src="https://user-images.githubusercontent.com/9336586/85798830-94afce80-b714-11ea-9a74-3ab050d4c627.png">

The changes required were the following:
1. Show chat react component even if banned.
2. Use anonymous credentials for chat web socket in order to retrieve chat messages.
    * If **Anon Chat** setting is enabled nothing is required here as it takes care of it.
    * If **Anon Chat** setting is not enabled:
        1. Listen to web socket banned message and switch to anonymous user in that case.
        2. Listen to part (leaving channel) message and switch back to the original user if current user is anonymous.

Tested locally and seems to be working good on all cases.
