### PR TITLE
Update settings panel bug report link

### DIFF
--- a/src/modules/settings/index.js
+++ b/src/modules/settings/index.js
@@ -81,7 +81,7 @@ const settingsPanelTemplate = () => `
         <span style="float:right;">
             <a href="https://twitter.com/betterttv" target="_blank">Twitter</a> | 
             <a href="https://community.nightdev.com/c/betterttv" target="_blank">Forums</a> | 
-            <a href="https://github.com/night/BetterTTV/issues/new?labels=bug" target="_blank">Bug Report</a> | 
+            <a href="https://github.com/night/BetterTTV/issues" target="_blank">Bug Report</a> | 
             <a href="https://discord.gg/nightdev" target="_blank">Discord</a>
         </span>
     </div>


### PR DESCRIPTION
For quite a while now, we have been seeing an increasing number of duplicate reported issues, often seemingly oblivious to multiple copies of the same issue posted, often within the first few posts.  How could people possibly be missing this and reposting them?  They are almost certainly clicking directly into a new issue page from the "Bug Report" link at the bottom of the BTTV settings panel, without ever having a chance to see the index.  Let's get rid of that, and replace it with a link to the issues index.