### PR TITLE
Add ignoreClearChat setting default to false to allow chat clears

### DIFF
--- a/src/modules/chat_deleted_messages/index.js
+++ b/src/modules/chat_deleted_messages/index.js
@@ -38,6 +38,12 @@ class ChatDeletedMessagesModule {
             defaultValue: false,
             description: 'Completely removes timed out messages from view'
         });
+        settings.add({
+            id: 'ignoreClearChat',
+            name: 'Ignore Clear Chat',
+            defaultValue: false,
+            description: 'When a moderator uses /clear the chat will not clear'
+        });
 
         watcher.on('chat.message.handler', message => {
             this.handleMessage(message);
@@ -47,8 +53,11 @@ class ChatDeletedMessagesModule {
     handleMessage({message, preventDefault}) {
         switch (message.type) {
             case twitch.TMIActionTypes.CLEAR_CHAT:
-                twitch.sendChatAdminMessage('Chat was cleared by a moderator (Prevented by BetterTTV)');
-                preventDefault();
+                const ignoreClearChat = settings.get('ignoreClearChat');
+                if (ignoreClearChat) {
+                    twitch.sendChatAdminMessage('Chat was cleared by a moderator (Prevented by BetterTTV)');
+                    preventDefault();
+                }
                 break;
             case twitch.TMIActionTypes.MODERATION:
                 if (this.handleDelete(message.userLogin || message.user.userLogin)) {


### PR DESCRIPTION
This PR resolves the issue I opened on #4095 to allow moderators to clear chat even when we encourage users to use BTTV. This option defaults to false and can be turned on easily anytime in the BTTV settings. This change will give moderators back the power and not hesitate to recommend the use of BTTV without losing access to a useful and powerful command from Twitch. 