### PR TITLE
FIX: update command for modcard ignore hotkey

### DIFF
--- a/src/modules/chat_moderator_cards/moderator-card.js
+++ b/src/modules/chat_moderator_cards/moderator-card.js
@@ -13,7 +13,7 @@ const Commands = {
     UNMOD: '/unmod',
     TIMEOUT: '/timeout',
     PERMIT: '!permit',
-    IGNORE: '/ignore',
+    IGNORE: '/block',
     WHISPER: '/w'
 };
 


### PR DESCRIPTION
At some point, Twitch changed the chat slash commands from /ignore and /unignore, to /block and /unblock.  The modcard hotkey "i" sends the ignore command.  I have had this updated in my local repo for a while, and somehow never remembered to submit a PR for it...