### PR TITLE
Implement Highlight by Role

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -10,6 +10,7 @@ import emotes from '../emotes/index.js';
 import nicknames from '../chat_nicknames/index.js';
 import legacySubscribers from '../legacy_subscribers/index.js';
 import splitChat from '../split_chat/index.js';
+import globalBots from '../../utils/bots.js';
 
 const EMOTE_STRIP_SYMBOLS_REGEX = /(^[~!@#$%^&*()]+|[~!@#$%^&*()]+$)/g;
 const MENTION_REGEX = /^@([a-zA-Z\d_]+)$/;
@@ -52,7 +53,6 @@ function formatChatUser(message) {
 }
 
 const staff = new Map();
-const globalBots = ['nightbot', 'moobot'];
 let channelBots = [];
 let asciiOnly = false;
 let subsOnly = false;

--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -268,7 +268,6 @@ class ChatHighlightBlacklistKeywordsModule {
     const date = new Date(timestamp);
     const fromBadges = Array.isArray(badges) ? badges.map((b) => b.id) : Object.keys(badges);
 
-    console.log(fromBadges);
     if (
       globalBots.includes(from) ||
       (channelBots.includes(from) && Object.prototype.hasOwnProperty.call(badges, 'moderator'))

--- a/src/utils/bots.js
+++ b/src/utils/bots.js
@@ -1,0 +1,1 @@
+export default ['nightbot', 'moobot', 'streamelements'];


### PR DESCRIPTION
Closes #4185 
Adds basic role highlighting by filtering roles based on user badges. The implementation requires the matching the **exact** badge keyword encased by brackets `[]`. Examples: `[broadcaster]`, `[moderator]`, `[partner]`, `[subscriber]`, Prime -> [premium], etc. Multiple badge keywords can be used at once. 

VODS will require additional work to locate badges using the badge image alt tags however doesn't seem like the most useful integration. For example, reducing a "6 Month Subscriber" tag to be "subscriber".

Edit: Added BetterTTV Bot filtering at `[bot]`.