### PR TITLE
Text only mode as a local chat filter

### DIFF
--- a/src/modules/chat_commands/index.js
+++ b/src/modules/chat_commands/index.js
@@ -15,6 +15,8 @@ const CommandHelp = {
     localasciioff: 'Usage "/localasciioff" - Turns off local ascii-only mode',
     localmod: 'Usage "/localmod" - Turns on local mod-only mode (only your chat is mod-only mode)',
     localmodoff: 'Usage "/localmodoff" - Turns off local mod-only mode',
+    localtextonly: 'Usage: "/localtextonly" - Turns on local text-only mode (only your chat is text only, no emotes)',
+    localtextonlyoff: 'Usage: "/localtextonlyoff" - Turns off local text-only mode',
     localsub: 'Usage "/localsub" - Turns on local sub-only mode (only your chat is sub-only mode)',
     localsuboff: 'Usage "/localsuboff" - Turns off local sub-only mode',
     massunban: 'Usage "/massunban" - Unbans all users in the channel (channel owner only)',
@@ -159,6 +161,12 @@ function handleCommands(message) {
             const modsOnly = !command.endsWith('off');
             chat.modsOnly(modsOnly);
             twitch.sendChatAdminMessage(`Local mods-only mode ${modsOnly ? 'enabled' : 'disabled'}.`);
+            break;
+        case 'localtextonly':
+        case 'localtextonlyoff':
+            const textOnly = !command.endsWith('off');
+            chat.textOnly(textOnly);
+            twitch.sendChatAdminMessage(`Local text-only mode ${textOnly ? 'enabled' : 'disabled'}.`);
             break;
         case 'localsub':
         case 'localsuboff':


### PR DESCRIPTION
Hi there! I took a stab at re-implementing #3649 as a local chat filter to fix #144 .

I'm a first time user and contributor to BetterTTV for the purpose of this feature though, so I'm not really sure how to go about identifying whether a message is a text-only message or not if we implement it as a local chat filter. I'm hoping this draft PR can serve as a conversation starter where I can show some progress on the feature and ask for help on how I could identify whether a message is text-only when implementing a local chat filter.

As of opening this, it's pretty poorly functional. Some emotes are allowed, but some are not, and those that are not are not so cleanly removed (the username remains but the message does not):
![image](https://user-images.githubusercontent.com/9123458/99158703-b0a41480-26a3-11eb-81c8-8b3b54e30ccb.png)



I'm not thrilled with putting the bulk of the work in the `messageReplacer` function either, because it feels out of place since similar filters are really implemented in `messageParser`. The trouble with this though is that I could not spot a way to determine if a message was text-only at that point, but I noticed some code dealing with emotes in `messageReplacer`, so I piggy-backed off that just for a starting point.

Would love any thoughts or advice on this while I explore more of the codebase to see if anything pops out at me.

 