### PR TITLE
[Fix] Hide collapsed sidebar recommended channels

### DIFF
--- a/src/modules/hide_sidebar_elements/index.js
+++ b/src/modules/hide_sidebar_elements/index.js
@@ -48,7 +48,7 @@ class HideSidebarElementsModule {
         if (settings.get('hideFeaturedChannels')) {
             if (removeFeaturedChannelsListener) return;
 
-            removeFeaturedChannelsListener = domObserver.on('.side-nav-section a[data-test-selector="recommended-channel"], .side-nav-section a[data-test-selector="similarity-channel"], .side-nav-section .tw-svg__asset--navchannels', (node, isConnected) => {
+            removeFeaturedChannelsListener = domObserver.on('.side-nav-section a[data-test-selector="recommended-channel"], .side-nav-section a[data-test-selector="similarity-channel"], .side-nav-section .tw-svg__asset--navchannels, div[aria-label="Recommended Channels"]', (node, isConnected) => {
                 if (!isConnected) return;
                 $(node).addClass('bttv-hide-featured-channels');
             }, {useParentNode: true});


### PR DESCRIPTION
The issue I noticed was that the previously used "data-test-selector" was missing on the link element in a case where the user was logged out of Twitch and sidebar was collapsed. 
Added support for "aria-label" selector to overcome this.

Fixes #4183 