### PR TITLE
[Fix] Hide Friends not hiding Online Friends sidebar section

### DIFF
--- a/src/modules/hide_friends/style.css
+++ b/src/modules/hide_friends/style.css
@@ -1,5 +1,5 @@
 .bttv-hide-friends {
   .online-friends, .recommended-friends {
-    display: none;
+    display: none !important;
   }
 }


### PR DESCRIPTION
Newly added css rule for **.tw-flex** has !important rule and made Online Friends sidebar element appear regardless of **Hide Friends** setting value. Added !important to override.
![image](https://user-images.githubusercontent.com/41855779/101337948-9c0b0480-387c-11eb-9e00-fdcc7707bb60.png)
