### PR TITLE
Tooltip css class change

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -18,7 +18,7 @@ const EMOTES_TO_CAP = ['567b5b520e984428652809b6'];
 const MAX_EMOTES_WHEN_CAPPED = 10;
 
 const badgeTemplate = (url, description) => `
-    <div class="tw-tooltip-wrapper tw-inline tw-relative">
+    <div class="tw-tooltip__container tw-inline tw-relative">
         <img alt="Moderator" class="chat-badge bttv-chat-badge" src="${url}" alt="" srcset="" data-a-target="chat-badge">
         <div class="tw-tooltip tw-tooltip--up tw-tooltip--align-left" data-a-target="tw-tooltip-label" style="margin-bottom: 0.9rem;">${description}</div>
     </div>
@@ -121,7 +121,7 @@ class ChatModule {
             const node = tokens[i];
             let $emote;
             // non-chat renders have a wrapper element
-            if (node.nodeType === window.Node.ELEMENT_NODE && node.classList.contains('tw-tooltip-wrapper')) {
+            if (node.nodeType === window.Node.ELEMENT_NODE && node.classList.contains('tw-tooltip__container')) {
                 const $emoteTooltip = $(node);
                 $emote = $emoteTooltip.find('.chat-line__message--emote');
                 if ($emote.length) {
@@ -210,7 +210,7 @@ class ChatModule {
             $element.css('color', color);
         }
 
-        const $message = $element.find('span[data-a-target="chat-message-text"],div.tw-tooltip-wrapper');
+        const $message = $element.find('span[data-a-target="chat-message-text"],div.tw-tooltip__container');
 
         if (
             (modsOnly === true && !user.mod) ||

--- a/src/modules/chat_moderator_cards/moderator-card.js
+++ b/src/modules/chat_moderator_cards/moderator-card.js
@@ -30,7 +30,7 @@ const MODERATOR_CARD_ACTIONS_SELECTOR = 'button[data-test-selector="ban-button"]
 const CHAT_INPUT_SELECTOR = 'textarea[data-a-target="chat-input"]';
 
 const moderatorActionButtonTemplate = (command, duration, tooltipText, buttonText) => `
-    <div class="tw-tooltip-wrapper tw-inline-flex">
+    <div class="tw-tooltip__container tw-inline-flex">
         <div class="bttv-moderator-card-action" data-command="${html.escape(command)}" data-duration="${html.escape(duration) || ''}">
             <button class="tw-button__text">
                 ${html.escape(buttonText)}

--- a/src/modules/video_player/index.js
+++ b/src/modules/video_player/index.js
@@ -10,7 +10,7 @@ const CANCEL_VOD_RECOMMENDATION_SELECTOR = '.recommendations-overlay .pl-rec__ca
 const BTTV_PICTURE_IN_PICTURE_SELECTOR = '#bttv-picture-in-picture';
 
 const getPictureInPictureTemplate = toggled => `
-    <div id="bttv-picture-in-picture" class="tw-inline-flex tw-relative tw-tooltip-wrapper">
+    <div id="bttv-picture-in-picture" class="tw-inline-flex tw-relative tw-tooltip__container">
         <button class="tw-align-items-center tw-align-middle tw-border-bottom-left-radius-medium tw-border-bottom-right-radius-medium tw-border-top-left-radius-medium tw-border-top-right-radius-medium tw-button-icon tw-button-icon--overlay tw-core-button tw-core-button--overlay tw-inline-flex tw-interactive tw-justify-content-center tw-overflow-hidden tw-relative" aria-label="Picture in Picture">
             <span class="tw-button-icon__icon">
                 <div style="width: 2rem; height: 2rem;">


### PR DESCRIPTION
Tooltip css class has changed from "tw-tooltip-wrapper" to "tw-tooltip__container",
causing issues with tooltip functionality and makes buttons appear with white background.

![image](https://user-images.githubusercontent.com/41855779/102551472-d5831180-40bf-11eb-98db-0239e519c731.png)

