### PR TITLE
Fix twitch.getChatModeratorCardProps

### DIFF
--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -364,9 +364,10 @@ module.exports = {
     getChatModeratorCardProps(element) {
         let apolloComponent;
         try {
-            const node = searchReactParents(
+            const node = searchReactChildren(
                 getReactInstance(element),
-                n => n.stateNode && n.stateNode.props && n.stateNode.props.data
+                n => n.stateNode && n.stateNode.props && n.stateNode.props.data,
+                30
             );
             apolloComponent = node.stateNode.props;
         } catch (_) {}


### PR DESCRIPTION
fixes #4400, fixes #4402

Twitch changed their modcard layout, and it broke twitch.getChatModeratorCardProps.  Fix searches Children instead of Parents, and overrides maxDepth = 30 (node is currently located at depth 23).