### PR TITLE
Fixed getChatModeratorCardProps

### DIFF
--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -369,10 +369,10 @@ module.exports = {
                 n => n.stateNode && n.stateNode.props && n.stateNode.props.targetID,
                 20
             );
+            apolloComponent = node.stateNode.props;
             if (!apolloComponent.data) {
                 apolloComponent.data = {targetUser: {id: apolloComponent.targetID, login: apolloComponent.friendData.user.login}};
             }
-            apolloComponent = node.stateNode.props;
         } catch (_) {}
 
         return apolloComponent;

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -364,10 +364,14 @@ module.exports = {
     getChatModeratorCardProps(element) {
         let apolloComponent;
         try {
-            const node = searchReactParents(
+            const node = searchReactChildren(
                 getReactInstance(element),
-                n => n.stateNode && n.stateNode.props && n.stateNode.props.data
+                n => n.stateNode && n.stateNode.props && n.stateNode.props.targetID,
+                20
             );
+            if (!apolloComponent.data) {
+                apolloComponent.data = {targetUser: {id: apolloComponent.targetID, login: apolloComponent.friendData.user.login}};
+            }
             apolloComponent = node.stateNode.props;
         } catch (_) {}
 


### PR DESCRIPTION
Changed search to children nodes (20 depth) to find targetID as the "data" prop no longer exists here.

Modified the returned apolloComponent to add in compatible data with previous code in the chat_moderatior_card module.

#4402 