### PR TITLE
[Bug Fix] Hide Recommended Channels Again

### DIFF
--- a/src/modules/hide_sidebar_elements/index.js
+++ b/src/modules/hide_sidebar_elements/index.js
@@ -2,9 +2,11 @@ import $ from 'jquery';
 import watcher from '../../watcher.js';
 import settings from '../../settings.js';
 import domObserver from '../../observers/dom.js';
+import twitch from '../../utils/twitch.js';
 
 let removeFeaturedChannelsListener;
 let removeOfflineFollowedChannelsListener;
+let sidebarNode;
 
 class HideSidebarElementsModule {
   constructor() {
@@ -47,15 +49,14 @@ class HideSidebarElementsModule {
   toggleFeaturedChannels() {
     if (settings.get('hideFeaturedChannels')) {
       if (removeFeaturedChannelsListener) return;
+      removeFeaturedChannelsListener = domObserver.on('.side-nav-section', (_, isConnected) => {
+        if (!isConnected) return;
 
-      removeFeaturedChannelsListener = domObserver.on(
-        '.side-nav-section a[data-test-selector="recommended-channel"], .side-nav-section a[data-test-selector="similarity-channel"], .side-nav-section .tw-svg__asset--navchannels, .side-nav-section a[data-test-selector="popular-channel"]',
-        (node, isConnected) => {
-          if (!isConnected) return;
-          $(node).addClass('bttv-hide-featured-channels');
-        },
-        {useParentNode: true}
-      );
+        sidebarNode = sidebarNode || twitch.getRecommendedSidebar();
+        if (!sidebarNode) return;
+
+        $(sidebarNode).addClass('bttv-hide-featured-channels');
+      });
       return;
     }
 
@@ -63,6 +64,7 @@ class HideSidebarElementsModule {
 
     removeFeaturedChannelsListener();
     removeFeaturedChannelsListener = undefined;
+    sidebarNode = undefined;
     $('.side-nav-section').removeClass('bttv-hide-featured-channels');
   }
 

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -8,6 +8,7 @@ const CHAT_LIST = '.chat-list,.chat-list--default,.chat-list--other';
 const PLAYER = '.video-player__container';
 const CLIPS_BROADCASTER_INFO = '.clips-broadcaster-info';
 const CHAT_MESSAGE_SELECTOR = '.chat-line__message';
+const SIDEBAR_CONTENTS = '.side-bar-contents';
 
 const TMIActionTypes = {
   MESSAGE: 0,
@@ -186,6 +187,24 @@ export default {
     } catch (_) {}
 
     return store;
+  },
+
+  getRecommendedSidebar() {
+    let recommendedSidebar;
+    try {
+      const node = searchReactChildren(
+        getReactInstance($(SIDEBAR_CONTENTS)[0]),
+        (n) =>
+          n.stateNode &&
+          n.stateNode.DOMNode &&
+          n.stateNode.props &&
+          n.stateNode.props.section &&
+          n.stateNode.props.section.type === 'RECOMMENDED_SECTION',
+        30
+      );
+      recommendedSidebar = node.stateNode.DOMNode;
+    } catch (_) {}
+    return recommendedSidebar;
   },
 
   getClipsBroadcasterInfo() {


### PR DESCRIPTION
Changed the search to react rather than CSS as Twitch classes all three sections (Followed, Recommended, Friends) the same. This instead looks through all sidebar content for the `type: RECOMMENDED_SECTION` and marks that node to be hidden. Works on page load for both the full and collapsed sidebar and toggles correctly.

Fixes #4183