### PR TITLE
Add RaidModule

### DIFF
--- a/src/modules/raid/index.js
+++ b/src/modules/raid/index.js
@@ -1,0 +1,30 @@
+const settings = require('../../settings');
+const watcher = require('../../watcher');
+
+class RaidModule {
+    constructor() {
+        settings.add({
+            id: 'replaceRaidUrl',
+            name: 'Replace URL after raid',
+            defaultValue: true,
+            description: 'Removes referrer=raid from the URL after raids'
+        });
+
+        watcher.on('load', () => this.reloadPage());
+    }
+
+    /* This function is called whenever something is loaded,
+    making sure that as soon as something loads, the module checks
+    to redirect from raids
+    */
+    reloadPage() {
+        if (settings.get('replaceRaidUrl')) {
+            if (window.location.href.includes('referrer=raid')) {
+                // Redirect to normal channel URL
+                window.location.href = window.location.href.replace('referrer=raid', '');
+            }
+        }
+    }
+}
+
+module.exports = new RaidModule();


### PR DESCRIPTION
## New Module
This add a new Module called `RaidModule`

### Functionality
The current functionality is to remove `referrer=raid` from the URL when the page loads, there's also the Setting to disable this in case the user wishes too

### Issues
This PR resolve issue: #4458 