### PR TITLE
Fix Windows linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "webpack serve --mode development",
     "build": "webpack --mode development",
     "build:prod": "webpack --mode production",
-    "lint": "eslint '**/*.js' && prettier --check '**/*.js' && prettier --check '**/*.css'"
+    "lint": "eslint \"**/*.js\" && prettier --check \"**/*.js\" && prettier --check \"**/*.css\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes
- Allows lint command to run in Windows (requires `""`).