### PR TITLE
Replies trigger pinned highlights

### DIFF
--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -147,7 +147,7 @@ function messageContainsKeyword(keywords, from, message) {
 }
 
 function isReply($message) {
-  return $message.parent().hasClass('chat-input-tray__open');
+  return $message.closest('.chat-input-tray__open').length > 0;
 }
 
 function messageTextFromAST(ast) {


### PR DESCRIPTION
Twitch added a blank div in the reply window, thus parent() didn't find the class.
Fixes #4485