### PR TITLE
extend dayjs with relativeTime and localizedFormat

### DIFF
--- a/src/modules/chat_commands/index.js
+++ b/src/modules/chat_commands/index.js
@@ -4,6 +4,11 @@ import twitchAPI from '../../utils/twitch-api.js';
 import chat from '../chat/index.js';
 import anonChat from '../anon_chat/index.js';
 
+import relativeTime from 'dayjs/plugin/relativeTime.js';
+import localizedFormat from 'dayjs/plugin/localizedFormat.js';
+dayjs.extend(relativeTime);
+dayjs.extend(localizedFormat);
+
 const CommandHelp = {
   b: 'Usage: "/b <login> [reason]" - Shortcut for /ban',
   chatters: 'Usage: "/chatters" - Retrieces the number of chatters in the chat',

--- a/src/modules/chat_commands/index.js
+++ b/src/modules/chat_commands/index.js
@@ -1,11 +1,11 @@
 import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime.js';
+import localizedFormat from 'dayjs/plugin/localizedFormat.js';
 import twitch from '../../utils/twitch.js';
 import twitchAPI from '../../utils/twitch-api.js';
 import chat from '../chat/index.js';
 import anonChat from '../anon_chat/index.js';
 
-import relativeTime from 'dayjs/plugin/relativeTime.js';
-import localizedFormat from 'dayjs/plugin/localizedFormat.js';
 dayjs.extend(relativeTime);
 dayjs.extend(localizedFormat);
 


### PR DESCRIPTION
fixes #4501

dayjs requires plugins to get .fromNow() and LLL localized specifier for .format().