### PR TITLE
[Feature] Add setting to hide native twitch emotes

### DIFF
--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -15,6 +15,9 @@ const REPEATING_SPACE_REGEX = /\s\s+/g;
 const BLACKLIST_KEYWORD_PROMPT = `Type some blacklist keywords. Messages containing keywords will be filtered from your chat.
 
 Use spaces in the field to specify multiple keywords. Place {} around a set of words to form a phrase, <> inside the {} to use exact search, and () around a single word to specify a username. Wildcards (*) are supported.`;
+const HIDE_EMOTE_PROMPT = `Type some native twitch emotes. These emotes will be hidden in your chat.
+
+Use spaces in the field to specify multiple keywords.`;
 const HIGHLIGHT_KEYWORD_PROMPT = `Type some highlight keywords. Messages containing keywords will turn red to get your attention.
 
 Use spaces in the field to specify multiple keywords. Place {} around a set of words to form a phrase, <> inside the {} to use exact search, and () around a single word to specify a username. Wildcards (*) are supported.`;
@@ -41,6 +44,8 @@ const pinnedHighlightTemplate = ({timestamp, from, message}) => `
         <span class="message">${html.escape(message)}</span>
     </div>
 `;
+
+const textFragmentTemplate = (emoteName) => `<span class="text-fragment" data-a-target="chat-message-text" style="background-color: rgba(255,255,0,0.2);">${emoteName}</span>`;
 
 function defaultHighlightKeywords(value) {
   if (typeof value === 'string') return value;
@@ -234,10 +239,26 @@ class ChatHighlightBlacklistKeywordsModule {
     changeKeywords(HIGHLIGHT_KEYWORD_PROMPT, 'highlightKeywords');
   }
 
+  setHiddenEmotes() {
+    changeKeywords(HIDE_EMOTE_PROMPT, 'hiddenEmotes');
+  }
+
+  nativeEmoteScrubber(ele, emotesToScrub) {
+    const emotes = $(ele[0]).find("[data-test-selector=chat-line-message-body]:first").find("[data-test-selector=emote-button]");
+    $(emotes).each(function(_, emote) {
+      const emoteName = $(emote).find("img")[0].alt;
+      if (emotesToScrub.includes(emote_name)) {
+        emote.replaceWith($(textFragmentTemplate(emoteName))[0]);
+      }
+    });
+  }
+
   onMessage($message, {user, timestamp, messageParts}) {
     const from = user.userLogin;
     const message = messageTextFromAST(messageParts);
     const date = new Date(timestamp);
+
+    this.nativeEmoteScrubber($message, (settings.get('hiddenEmotes') || '').split(' '));
 
     if (fromContainsKeyword(blacklistUsers, from) || messageContainsKeyword(blacklistKeywords, from, message)) {
       this.markBlacklisted($message);

--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -45,7 +45,11 @@ const pinnedHighlightTemplate = ({timestamp, from, message}) => `
     </div>
 `;
 
-const textFragmentTemplate = (emoteName) => `<span class="text-fragment" data-a-target="chat-message-text" style="background-color: rgba(255,255,0,0.2);">${emoteName}</span>`;
+const textFragmentTemplate = (emoteName) => `
+  <span class="text-fragment" data-a-target="chat-message-text" style="background-color: rgba(255,255,0,0.2);">
+    ${emoteName}
+  </span>
+`;
 
 function defaultHighlightKeywords(value) {
   if (typeof value === 'string') return value;
@@ -244,10 +248,12 @@ class ChatHighlightBlacklistKeywordsModule {
   }
 
   nativeEmoteScrubber(ele, emotesToScrub) {
-    const emotes = $(ele[0]).find("[data-test-selector=chat-line-message-body]:first").find("[data-test-selector=emote-button]");
-    $(emotes).each(function(_, emote) {
-      const emoteName = $(emote).find("img")[0].alt;
-      if (emotesToScrub.includes(emote_name)) {
+    const emotes = $(ele[0])
+      .find('[data-test-selector=chat-line-message-body]:first')
+      .find('[data-test-selector=emote-button]');
+    $(emotes).each((_, emote) => {
+      const emoteName = $(emote).find('img')[0].alt;
+      if (emotesToScrub.includes(emoteName)) {
         emote.replaceWith($(textFragmentTemplate(emoteName))[0]);
       }
     });

--- a/src/modules/chat_settings/index.js
+++ b/src/modules/chat_settings/index.js
@@ -23,6 +23,9 @@ const CHAT_SETTINGS_TEMPLATE = `
             <button class="setHighlightKeywords tw-pd-05 tw-block tw-border-radius-medium tw-full-width tw-interactable--default tw-interactable--hover-enabled tw-interactable tw-interactive">Set Highlight Keywords</button>
         </div>
         <div class="tw-full-width tw-relative">
+            <button class="setHiddenEmotes tw-pd-05 tw-block tw-border-radius-medium tw-full-width tw-interactable--default tw-interactable--hover-enabled tw-interactable tw-interactive">Set Hidden Emotes</button>
+        </div>
+        <div class="tw-full-width tw-relative">
             <button class="setFontFamily tw-pd-05 tw-block tw-border-radius-medium tw-full-width tw-interactable--default tw-interactable--hover-enabled tw-interactable tw-interactive">Set Font</button>
         </div>
         <div class="tw-full-width tw-relative">
@@ -113,6 +116,7 @@ class ChatSettingsModule {
 
     $settings.find('.setHighlightKeywords').click(highlightBlacklistKeywords.setHighlightKeywords);
     $settings.find('.setBlacklistKeywords').click(highlightBlacklistKeywords.setBlacklistKeywords);
+    $settings.find('.setHiddenEmotes').click(highlightBlacklistKeywords.setHiddenEmotes);
 
     $settings.find('.setFontFamily').click(chatFontSettings.setFontFamily);
     $settings.find('.setFontSize').click(chatFontSettings.setFontSize);


### PR DESCRIPTION
A friend recently mentioned to me that certain twitch native emotes bothered them to see, this patch would add a setting to show certain native twitch emotes as text instead of images. This felt like it fit well with the blacklist/highlight module, so I put it there. I'm happy to updating the module naming to include this feature or try to build it into a new module if needed. I tried my best to match the code style although I'm still very new to this codebase, and additionally I'm not super familiar with jQuery, here's my vanilla JS implimenation of `nativeEmoteScrubber`, in case that's preferred:

```javascript
  nativeEmoteScrubber(ele, emotesToScrub) {
    const emotes = ele[0].querySelector("[data-test-selector=chat-line-message-body]").querySelectorAll("[data-test-selector=emote-button]")
    Array.prototype.map.call(emotes, emote => {
      const emote_name = emote.getElementsByTagName("img")[0].alt
      if (emotesToScrub.includes(emote_name)) {
        const new_text_frag = document.createElement("span");
        new_text_frag.classList.add("text-fragment")
        new_text_frag.dataset.ATarget = "chat-message-text"
        new_text_frag.style.backgroundColor = "rgba(255,255,0,0.2)"
        new_text_frag.textContent = emote_name
        emote.parentElement.replaceChild(new_text_frag, emote)
      }
    })
  }
```