### PR TITLE
[Bug Fix] Fixes incorrect HTML character encoding in settings

### DIFF
--- a/src/modules/settings/components/settings/PlayerExtensions.jsx
+++ b/src/modules/settings/components/settings/PlayerExtensions.jsx
@@ -11,7 +11,7 @@ function HidePlayerExtensions() {
   return (
     <Panel header="Player Extensions">
       <div className={styles.toggle}>
-        <p className={styles.description}>Show the interactive overlays on top of Twitch&aposs video player</p>
+        <p className={styles.description}>Show the interactive overlays on top of Twitch&apos;s video player</p>
         <Toggle checked={value} onChange={(state) => setValue(state)} />
       </div>
     </Panel>


### PR DESCRIPTION
Currently it's incorrectly encoded:
![image](https://user-images.githubusercontent.com/12380876/127359124-a0fffd58-ec54-41c2-ac79-de1b8d622381.png)
