### PR TITLE
[Bug Fix] Fix PIP button being large when page load

### DIFF
--- a/src/modules/video_player/style.css
+++ b/src/modules/video_player/style.css
@@ -16,6 +16,8 @@
 
 #bttv-picture-in-picture {
   display: inline-flex !important;
+  max-width:  30px;
+  max-height: 30px;
 
   button {
     position: relative;


### PR DESCRIPTION
Picture-in-Picture button is larger while page loads (image) and gets smaller after finish loading.
Added max width and height property to #bttv-picture-in-picture

![Screenshot_265](https://user-images.githubusercontent.com/28326534/128439727-41c31dc8-9dbc-4d32-accc-2c21122f5aea.png)
*Disclaimer: I only forked and changed the CSS as done with devTools, didn't actually downloaded and tested*