### PR TITLE
Fix for digit emojis

### DIFF
--- a/src/modules/emotes/emojis.js
+++ b/src/modules/emotes/emojis.js
@@ -50,6 +50,10 @@ class Emojis extends AbstractEmotes {
                 break;
             }
 
+            if (icon.length === 0) {
+              return false;
+            }
+
             url = ''.concat(options.base, options.size, '/', icon, options.ext);
 
             return false;

--- a/src/modules/emotes/emojis.js
+++ b/src/modules/emotes/emojis.js
@@ -41,6 +41,10 @@ class Emojis extends AbstractEmotes {
 
         twemoji.parse(emoji.char, {
           callback: (icon, options) => {
+            if (icon.length === 0) {
+              return false;
+            }
+
             switch (icon) {
               case 'a9': // ©
               case 'ae': // ®
@@ -48,10 +52,6 @@ class Emojis extends AbstractEmotes {
                 return false;
               default:
                 break;
-            }
-
-            if (icon.length === 0) {
-              return false;
             }
 
             url = ''.concat(options.base, options.size, '/', icon, options.ext);


### PR DESCRIPTION
pr adds fallback if twemoji fails to parse char

before:
![image](https://user-images.githubusercontent.com/43322006/131934927-dcc7185b-0e3a-4919-bfeb-7eeee6e83ce9.png)
after:
![image](https://user-images.githubusercontent.com/43322006/131935019-f7123804-e9fe-4a5e-a695-69ed4f4c4ffa.png)
