### PR TITLE
modcard getChatMessages needs id instead of login

### DIFF
--- a/src/modules/chat_moderator_cards/index.js
+++ b/src/modules/chat_moderator_cards/index.js
@@ -26,7 +26,7 @@ class ChatModeratorCardsModule {
 
     let isOwner = false;
     let isModerator = false;
-    const userMessages = twitch.getChatMessages(targetUser.login);
+    const userMessages = twitch.getChatMessages(targetUser.id);
     if (userMessages.length) {
       const {message} = userMessages[userMessages.length - 1];
       isOwner = twitch.getUserIsOwnerFromTagsBadges(message.badges);


### PR DESCRIPTION
fixes #4950 

With the changes to support youtube, twitch.getChatMessages now takes an id as a filter parameter, but twitch modcard code sends the login name.