### PR TITLE
[Feature] Add AlwaysSourceQuality Setting 

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,7 @@ export const SettingIds = {
   TAB_COMPLETION_EMOTE_PRIORITY: 'tabCompletionEmotePriority',
   WHISPERS: 'whispers',
   SHOW_DIRECTORY_LIVE_TAB: 'showDirectoryLiveTab',
+  ALWAYS_SOURCE_QUALITY: 'alwaysSourceQuality',
   CHANNEL_POINTS_MESSAGE_HIGHLIGHTS: 'channelPointsMessageHighlights',
   EMOTE_MENU: 'clickTwitchEmotes',
   DARKENED_MODE: 'darkenedMode',
@@ -182,6 +183,7 @@ export const SettingDefaultValues = {
   [SettingIds.CLICK_TO_PLAY]: false,
   [SettingIds.MUTE_INVISIBLE_PLAYER]: false,
   [SettingIds.SCROLL_VOLUME_CONTROL]: false,
+  [SettingIds.ALWAYS_SOURCE_QUALITY]: false,
   [SettingIds.BLACKLIST_KEYWORDS]: {},
   [SettingIds.HIGHLIGHT_KEYWORDS]: null,
   [SettingIds.SIDEBAR]: [

--- a/src/modules/settings/components/settings/AlwaysSourceQuality.jsx
+++ b/src/modules/settings/components/settings/AlwaysSourceQuality.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Panel from 'rsuite/lib/Panel/index.js';
+import Toggle from 'rsuite/lib/Toggle/index.js';
+import {registerComponent, useStorageState} from '../Store.jsx';
+import {CategoryTypes, SettingIds} from '../../../../constants.js';
+import styles from '../../styles/header.module.css';
+
+function AlwaysSourceQuality() {
+  const [value, setValue] = useStorageState(SettingIds.ALWAYS_SOURCE_QUALITY);
+
+  return (
+    <Panel header="Always Use Source Quality">
+      <div className={styles.toggle}>
+        <p className={styles.description}>Forces stream quality to use source quality</p>
+        <Toggle checked={value} onChange={(state) => setValue(state)} />
+      </div>
+    </Panel>
+  );
+}
+
+export default registerComponent(AlwaysSourceQuality, {
+  settingId: SettingIds.ALWAYS_SOURCE_QUALITY,
+  name: 'Always Use Source Quality',
+  category: CategoryTypes.CHANNEL,
+  keywords: ['source', 'quality', 'stream', 'player'],
+});


### PR DESCRIPTION
Hello,

I've implemented the setting mentioned in #5044. 

- It updates the localStorage with the twitch equivalent for the `source` quality. `{default: 'chunked'}`. Twitch will then use this value when opening a new page / navigating away.
- For the initial switch, if you're not navigating/refreshing, we retrieve the player qualities and search for the source (highest bitrate). We could assume it's always the first in the list or search by name, but I thought it would be safer this way.
- I'm also not entirely sure of the naming / description, suggestions are welcomed.

If this is something you want added, please provide feedback. @night 

Thanks!

Closes #5044 