### PR TITLE
[Feature] Add Show Homepage Carousel Setting

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,7 @@ export const SettingIds = {
   CHAT: 'chat',
   AUTO_PLAY: 'autoPlay',
   USERNAMES: 'usernames',
+  SHOW_HOMEPAGE_CAROUSEL: 'showHomepageCarousel'
 };
 
 export const CategoryTypes = {
@@ -184,6 +185,7 @@ export const SettingDefaultValues = {
   [SettingIds.SCROLL_VOLUME_CONTROL]: false,
   [SettingIds.BLACKLIST_KEYWORDS]: {},
   [SettingIds.HIGHLIGHT_KEYWORDS]: null,
+  [SettingIds.SHOW_HOMEPAGE_CAROUSEL]: true,
   [SettingIds.SIDEBAR]: [
     SidebarFlags.FRIENDS |
       SidebarFlags.OFFLINE_FOLLOWED_CHANNELS |

--- a/src/modules/homepage/index.js
+++ b/src/modules/homepage/index.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import settings from '../../settings.js';
 import watcher from '../../watcher.js';
 import twitch from '../../utils/twitch.js';
@@ -5,15 +6,26 @@ import {AutoPlayFlags, PlatformTypes, SettingIds} from '../../constants.js';
 import {hasFlag} from '../../utils/flags.js';
 import {loadModuleForPlatforms} from '../../utils/modules.js';
 
-class DisableHomepageAutoplayModule {
+class HomepageModule {
   constructor() {
-    watcher.on('load.homepage', () => this.load());
+    watcher.on('load.homepage', () => {
+      this.toggleAutoPlay();
+    });
+
+    settings.on(`changed.${SettingIds.SHOW_HOMEPAGE_CAROUSEL}`, () => this.toggleCarousel());
+    this.toggleCarousel();
   }
 
-  load() {
-    if (hasFlag(settings.get(SettingIds.AUTO_PLAY), AutoPlayFlags.FP_VIDEO)) return;
+  toggleCarousel() {
+    $('body').toggleClass('bttv-hide-homepage-carousel', !settings.get(SettingIds.SHOW_HOMEPAGE_CAROUSEL));
+  }
+
+  toggleAutoPlay() {
+    if (hasFlag(settings.get(SettingIds.AUTO_PLAY), AutoPlayFlags.FP_VIDEO) && settings.get(SettingIds.SHOW_HOMEPAGE_CAROUSEL)) return;
     const currentPlayer = twitch.getCurrentPlayer();
     if (!currentPlayer) return;
+
+    currentPlayer.setMuted(true);
 
     const stopAutoplay = () => {
       setTimeout(() => {
@@ -35,4 +47,4 @@ class DisableHomepageAutoplayModule {
   }
 }
 
-export default loadModuleForPlatforms([PlatformTypes.TWITCH, () => new DisableHomepageAutoplayModule()]);
+export default loadModuleForPlatforms([PlatformTypes.TWITCH, () => new HomepageModule()]);

--- a/src/modules/homepage/style.css
+++ b/src/modules/homepage/style.css
@@ -1,0 +1,5 @@
+.bttv-hide-homepage-carousel {
+  .front-page-carousel {
+    display: none;
+  }
+}

--- a/src/modules/settings/components/settings/HomepageCarousel.jsx
+++ b/src/modules/settings/components/settings/HomepageCarousel.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Panel from 'rsuite/lib/Panel/index.js';
+import Toggle from 'rsuite/lib/Toggle/index.js';
+import {registerComponent, useStorageState} from '../Store.jsx';
+import {SettingIds, CategoryTypes} from '../../../../constants.js';
+import styles from '../../styles/header.module.css';
+
+function HomepageCarousel() {
+  const [value, setValue] = useStorageState(SettingIds.SHOW_HOMEPAGE_CAROUSEL);
+
+  return (
+    <Panel header="Show Homepage Carousel">
+      <div className={styles.toggle}>
+        <p className={styles.description}>Show the Homepage carousel</p>
+        <Toggle checked={value} onChange={(state) => setValue(state)} />
+      </div>
+    </Panel>
+  );
+}
+
+export default registerComponent(HomepageCarousel, {
+  settingId: SettingIds.SHOW_HOMEPAGE_CAROUSEL,
+  name: 'Show Homepage Carousel',
+  category: CategoryTypes.DIRECTORY,
+  keywords: ['homepage', 'carousel'],
+});


### PR DESCRIPTION
Hello,

- Added a new setting `Show Homepage Carousel` (defaults true)
- Grouped together with the Auto Play setting for the homepage video player (same thing as the carousel) in a Homepage module
- Fixed an issue regarding the disabled Auto Play setting for the homepage video player (by muting it as well), you can hear the stream for a brief moment before it stops.

Closes #4987 

Thanks!