### PR TITLE
[Fix] Front page autoplay

### DIFF
--- a/src/modules/disable_homepage_autoplay/index.js
+++ b/src/modules/disable_homepage_autoplay/index.js
@@ -15,9 +15,14 @@ class DisableHomepageAutoplayModule {
     const currentPlayer = twitch.getCurrentPlayer();
     if (!currentPlayer) return;
 
+    const prevMuted = currentPlayer.isMuted();
+
+    currentPlayer.setMuted(true);
+
     const stopAutoplay = () => {
       setTimeout(() => {
         currentPlayer.pause();
+        currentPlayer.setMuted(prevMuted);
       }, 0);
       if (currentPlayer.emitter) {
         currentPlayer.emitter.removeListener('Playing', stopAutoplay);


### PR DESCRIPTION
When disabling the `Enable auto play for homepage video player` setting you can hear the audio of the stream for a brief moment. This PR removes this behaviour by muting the stream and then setting the `mute` property back to its previous value.