### PR TITLE
renderSettings() in iFrame in TV-App

### DIFF
--- a/src/modules/chat_settings/index.js
+++ b/src/modules/chat_settings/index.js
@@ -80,7 +80,8 @@ class ChatSettingsModule {
   }
 
   renderSettings() {
-    if (inIFrame()) return;
+    // We want settings in iFrame when using a TV-App
+    if (inIFrame() && !window.parent.location.hostname.endsWith("lg.tv.twitch.tv")) return;
 
     let $settings = getSettings();
     // Hide the settings when in an iframe for now


### PR DESCRIPTION
Hey there, 

currently settings options aren't available when using BetterTTV on a embeded chat in an iFrame.
We embed the original Twitch chat using userscripts in our custom LG-App and want to include BetterTTV further. To let it show the settings, I have added a small check to the iFrame detection. 
Would be pretty cool if this can be pushed to public. 

If you are interested, you can take a look here: https://github.com/TBSniller/twitch-webos/blob/main/src/app/twitchchat.js

Coding isn't my main business, please excuse me if I made some mistakes.

Thanks in advance!