### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/src/modules/chat_tab_completion/index.js
+++ b/src/modules/chat_tab_completion/index.js
@@ -67,8 +67,8 @@ class ChatTabcompletionModule {
         const caretPos = chatInputValue.length;
         const text = chatInputValue;
 
-        const start = (/[:()\w]+$/.exec(text.substr(0, caretPos)) || {index: caretPos}).index;
-        const end = caretPos + (/^\w+/.exec(text.substr(caretPos)) || [''])[0].length;
+        const start = (/[:()\w]+$/.exec(text.slice(0, caretPos)) || {index: caretPos}).index;
+        const end = caretPos + (/^\w+/.exec(text.slice(caretPos)) || [''])[0].length;
         this.textSplit = [text.substring(0, start), text.substring(start, end), text.substring(end + 1)];
 
         // If there are no words in front of the caret, exit

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -89,9 +89,9 @@ function calculateColorBackground(color) {
     color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
   }
 
-  const r = parseInt(color.substr(0, 2), 16);
-  const g = parseInt(color.substr(2, 2), 16);
-  const b = parseInt(color.substr(4, 2), 16);
+  const r = parseInt(color.slice(0, 2), 16);
+  const g = parseInt(color.slice(2, 4), 16);
+  const b = parseInt(color.slice(4, 6), 16);
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
   return yiq >= 128 ? 'dark' : 'light';
 }
@@ -108,9 +108,9 @@ function calculateColorReplacement(color, background) {
     color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
   }
 
-  let r = parseInt(color.substr(0, 2), 16);
-  let g = parseInt(color.substr(2, 2), 16);
-  let b = parseInt(color.substr(4, 2), 16);
+  let r = parseInt(color.slice(0, 2), 16);
+  let g = parseInt(color.slice(2, 4), 16);
+  let b = parseInt(color.slice(4, 6), 16);
   const hsl = rgbToHsl(r, g, b);
 
   // more thoroughly lightens dark colors, with no problems at black
@@ -123,7 +123,7 @@ function calculateColorReplacement(color, background) {
   b = rgb[2].toString(16);
 
   // note to self: .toString(16) does NOT zero-pad
-  return `#${`00${r}`.substr(r.length)}${`00${g}`.substr(g.length)}${`00${b}`.substr(b.length)}`;
+  return `#${`00${r}`.slice(r.length)}${`00${g}`.slice(g.length)}${`00${b}`.slice(b.length)}`;
 }
 
 const colorCache = new Map();


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.