### PR TITLE
[Fix]: restrict icon size for youtube channel icon categories

### DIFF
--- a/src/modules/emote_menu/components/Icons.jsx
+++ b/src/modules/emote_menu/components/Icons.jsx
@@ -32,8 +32,8 @@ const twitchGamingLogo = {
 
 function BrandedImage({src, alt, brandSrc}) {
   return (
-    <div className={styles.icon}>
-      <img src={src} alt={alt} className={styles.iconBorderRadius} />
+    <div className={styles.brandedImage}>
+      <img src={src} alt={alt} className={styles.icon} />
       <img src={brandSrc} alt="" className={styles.brandIcon} />
     </div>
   );

--- a/src/modules/emote_menu/components/Icons.module.css
+++ b/src/modules/emote_menu/components/Icons.module.css
@@ -1,8 +1,13 @@
 .icon {
   object-fit: contain;
-  position: relative;
   width: 100%;
   height: 100%;
+  max-width: 20px;
+  max-height: 20px;
+}
+
+.brandedImage {
+  position: relative;
 }
 
 .iconBorderRadius {


### PR DESCRIPTION
This fixes an issue with the Youtube emote categories introduced during https://github.com/night/betterttv/pull/5227

The previous pull request changed some of the styles used by the `BrandedImage` component and removed the brand image icon's width/height restrictions.

This had the side effect of allowing the channel image size to be unbounded resulting in the following behavior for Ludwig's channel:
![image](https://user-images.githubusercontent.com/24517783/160908533-99b4968b-84e5-47fc-8380-8551a21af872.png)

Which is pulling the channel image avatar, a 300x300 image which causes the overflow, from here: https://api.betterttv.net/3/cached/users/youtube/UCrPseYLGpNygVi34QpGNqpA




Steps to Repro:
1. Install BetterTTV v7.4.24
2. Head to this scheduled Ludwig stream: https://www.youtube.com/watch?v=Xe5KJINZGRA
3. Enable the BetterTTV menu
4. Open the Emote menu


Here's a screenshot of the emote picker after the fix:
![image](https://user-images.githubusercontent.com/24517783/160909217-7de9bd53-1ce7-4ba0-aa80-08a443b1362f.png)
