### PR TITLE
Fix auto theatre mode

### DIFF
--- a/src/modules/auto_theater_mode/index.js
+++ b/src/modules/auto_theater_mode/index.js
@@ -26,7 +26,13 @@ class AutoTheaterModeModule {
     try {
       player.setTheatre(true);
     } catch (_) {
-      $('button[data-a-target="player-theatre-mode-button"]').first().trigger('click');
+      const button = document.querySelector(
+        '.video-player__default-player button[data-a-target="player-theatre-mode-button"]'
+      );
+
+      if (button != null) {
+        button.click();
+      }
     }
 
     // hackfix: twitch's channel page experiment causes the player to load multiple times

--- a/src/modules/auto_theater_mode/index.js
+++ b/src/modules/auto_theater_mode/index.js
@@ -26,7 +26,7 @@ class AutoTheaterModeModule {
     try {
       player.setTheatre(true);
     } catch (_) {
-      $('button[data-a-target="player-theatre-mode-button"]').click();
+      $('button[data-a-target="player-theatre-mode-button"]').first().trigger('click');
     }
 
     // hackfix: twitch's channel page experiment causes the player to load multiple times


### PR DESCRIPTION
There are currently 2 sets of player controls (ad+normal), so only 'click' the theatre mode button in one of them.

Fixes #5361.