### PR TITLE
remove left margin on toggle descriptions

### DIFF
--- a/src/modules/settings/styles/header.module.css
+++ b/src/modules/settings/styles/header.module.css
@@ -64,5 +64,4 @@
   vertical-align: middle;
   align-items: center;
   justify-content: space-between;
-  margin-left: 4px;
 }


### PR DESCRIPTION
before
<img width="495" alt="Screenshot 2022-05-17 at 20 12 50" src="https://user-images.githubusercontent.com/43322006/168895176-66b95186-4afa-41b1-8350-adf0c43ae192.png">
after
<img width="508" alt="Screenshot 2022-05-17 at 20 32 48" src="https://user-images.githubusercontent.com/43322006/168895178-36ea15a0-f6c0-413d-a5c1-e7dc2735f7c3.png">
