### PR TITLE
Hide events panel

### DIFF
--- a/src/modules/hide_bits/style.css
+++ b/src/modules/hide_bits/style.css
@@ -3,6 +3,7 @@
   .pinned-cheer-v2,
   button[data-a-target="bits-button"],
   div[data-test-selector="channel-leaderboard-container"],
+  div[data-test-selector="last-x-events"],
   img.chat-line__message--emote[src^="https://d3aqoihi2n8ty8.cloudfront.net/actions/"],
   img.chat-line__message--emote[src^="https://d3aqoihi2n8ty8.cloudfront.net/partner-actions/"],
   .chat-badge[alt~="cheer"] {


### PR DESCRIPTION
I think `Chat > Bits` opiton should also hide this panel
![image](https://user-images.githubusercontent.com/37638480/175114111-3840106e-3fab-461d-b510-09aa62e313dd.png)
