### PR TITLE
Shadow Ban Detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.js text eol=lf
+*.jsx text eol=lf

--- a/src/constants.js
+++ b/src/constants.js
@@ -26,6 +26,7 @@ export const SettingIds = {
   DELETED_MESSAGES: 'deletedMessages',
   BLACKLIST_KEYWORDS: 'blacklistKeywords',
   HIGHLIGHT_KEYWORDS: 'highlightKeywords',
+  SHADOW_BAN_DETECTOR: 'shadowBanDetector',
   SIDEBAR: 'sidebar',
   EMOTES: 'emotes',
   CHAT: 'chat',
@@ -183,6 +184,7 @@ export const SettingDefaultValues = {
   [SettingIds.EMOTE_AUTOCOMPLETE]: true,
   [SettingIds.BLACKLIST_KEYWORDS]: {},
   [SettingIds.HIGHLIGHT_KEYWORDS]: null,
+  [SettingIds.SHADOW_BAN_DETECTOR]: true,
   [SettingIds.SIDEBAR]: [
     SidebarFlags.FRIENDS |
       SidebarFlags.OFFLINE_FOLLOWED_CHANNELS |

--- a/src/constants.js
+++ b/src/constants.js
@@ -184,7 +184,7 @@ export const SettingDefaultValues = {
   [SettingIds.EMOTE_AUTOCOMPLETE]: true,
   [SettingIds.BLACKLIST_KEYWORDS]: {},
   [SettingIds.HIGHLIGHT_KEYWORDS]: null,
-  [SettingIds.SHADOW_BAN_DETECTOR]: true,
+  [SettingIds.SHADOW_BAN_DETECTOR]: false,
   [SettingIds.SIDEBAR]: [
     SidebarFlags.FRIENDS |
       SidebarFlags.OFFLINE_FOLLOWED_CHANNELS |

--- a/src/modules/settings/components/settings/twitch/ShadowBanDetector.jsx
+++ b/src/modules/settings/components/settings/twitch/ShadowBanDetector.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Panel from 'rsuite/Panel';
+import Toggle from 'rsuite/Toggle';
+import {registerComponent} from '../../Store.jsx';
+import {SettingIds, CategoryTypes} from '../../../../../constants.js';
+import styles from '../../../styles/header.module.css';
+import useStorageState from '../../../../../common/hooks/StorageState.jsx';
+
+function ShadowBanDetector() {
+  const [value, setValue] = useStorageState(SettingIds.SHADOW_BAN_DETECTOR);
+
+  return (
+    <Panel header="Shadow Ban Detection">
+      <div className={styles.toggle}>
+        <p className={styles.description}>Shows confirmations for messages being sent</p>
+        <Toggle checked={value} onChange={(state) => setValue(state)} />
+      </div>
+    </Panel>
+  );
+}
+
+registerComponent(ShadowBanDetector, {
+  settingId: SettingIds.SHADOW_BAN_DETECTOR,
+  name: 'Shadow Ban Detection',
+  category: CategoryTypes.CHAT,
+  keywords: ['twitch', 'ban', 'chat', 'shadow', 'message', 'confirmation'],
+});

--- a/src/modules/shadow_ban_detector/index.js
+++ b/src/modules/shadow_ban_detector/index.js
@@ -30,6 +30,7 @@ class ShadowBanDetector {
     if (message.isHistorical) return;
     if (message.user.userID !== getCurrentUser().id) return;
     if ($message[0].classList.contains('reply-list-item')) return;
+    if ($message[0].parentElement.parentElement.classList.contains('announcement-line')) return;
 
     this.messagesToCheck.push(new CachedMessage($message, message));
     $message.toggleClass(CHAT_LINE_DELETED_CLASS, true);

--- a/src/modules/shadow_ban_detector/index.js
+++ b/src/modules/shadow_ban_detector/index.js
@@ -1,0 +1,111 @@
+import settings from '../../settings.js';
+import watcher from '../../watcher.js';
+import {PlatformTypes, SettingIds} from '../../constants.js';
+import {loadModuleForPlatforms} from '../../utils/modules.js';
+import {getCurrentChannel} from '../../utils/channel.js';
+import {getCurrentUser} from '../../utils/user.js';
+
+const CHAT_LINE_DELETED_CLASS = 'bttv-chat-line-deleted';
+
+class ShadowBanDetector {
+  constructor() {
+    this.isLoaded = false;
+    watcher.on('load.chat', () => this.load());
+    watcher.on('chat.message', ($message, message) => this.handleMessage($message, message));
+    settings.on(`changed.${SettingIds.SHADOW_BAN_DETECTOR}`, () =>
+      settings.get(SettingIds.SHADOW_BAN_DETECTOR) ? this.load() : this.unload()
+    );
+  }
+
+  handleMessage($message, message) {
+    if (!this.isLoaded) {
+      return;
+    }
+
+    if (!message.isHistorical && message.user.userID === getCurrentUser().id) {
+      this.messagesToCheck.push([$message, message.messageBody.trim()]);
+      $message.toggleClass(CHAT_LINE_DELETED_CLASS, true);
+    }
+  }
+
+  updateChannel(channel) {
+    this.currChannelId = channel.id;
+    this.messagesToCheck.length = 0;
+    this.socket.send(`join #${channel.name}`);
+  }
+
+  connect() {
+    if (!this.isLoaded) {
+      return;
+    }
+
+    this.socket = new WebSocket('wss://irc-ws.chat.twitch.tv/');
+    this.socket.onclose = () => (this.isLoaded ? setTimeout(() => this.connect(), 1000) : null);
+    this.socket.onerror = () => this.socket.close();
+
+    this.socket.onmessage = ({type, data}) => {
+      if (type !== 'message') {
+        return;
+      }
+
+      // Extract actual message
+      const sub = data.substring(data.indexOf('tmi.twitch.tv'));
+      const msg = sub.substring(sub.indexOf(':') + 1).trim();
+
+      const id = data
+        .split(';')
+        .find((elem) => elem.startsWith('user-id='))
+        ?.split('=')[1];
+
+      if (getCurrentUser().id === id) {
+        for (let i = this.messagesToCheck.length - 1; i >= 0; i--) {
+          const [$message, message] = this.messagesToCheck[i];
+          if (msg === message) {
+            this.messagesToCheck.splice(i, 1);
+            $message.toggleClass(CHAT_LINE_DELETED_CLASS, false);
+            return;
+          }
+        }
+      }
+    };
+
+    this.socket.onopen = () => {
+      this.socket.send('CAP REQ :twitch.tv/tags twitch.tv/commands');
+      this.socket.send('PASS SCHMOOPIIE');
+      this.socket.send('NICK justinfan12345');
+      this.socket.send('USER justinfan12345 8 * :justinfan12345');
+      this.updateChannel(getCurrentChannel());
+    };
+  }
+
+  load() {
+    if (!settings.get(SettingIds.SHADOW_BAN_DETECTOR)) {
+      return;
+    }
+
+    const channel = getCurrentChannel();
+    if (channel === undefined) {
+      return;
+    }
+
+    if (!this.isLoaded) {
+      this.isLoaded = true;
+      this.messagesToCheck = [];
+      this.connect();
+    } else if (this.currChannelId !== channel.id) {
+      try {
+        this.updateChannel(channel);
+      } catch {} // Socket might've been in the process of restarting, will update in that case anyways.
+    }
+  }
+
+  unload() {
+    if (this.isLoaded) {
+      this.isLoaded = false;
+      delete this.messagesToCheck;
+      this.socket?.close();
+    }
+  }
+}
+
+export default loadModuleForPlatforms([PlatformTypes.TWITCH, () => new ShadowBanDetector()]);


### PR DESCRIPTION
Adds the ability to toggle message confirmations. Uses an additional, anonymous, `WebSocket` to this end.

I'm not entirely happy with how messages are being selected for confirmation (simply using the latest message with equal content). Using ids would be very greatly preferable, but on the react side of things the ids appear to be simple timestamps and it seems like I'm unable to get appropriate absolute timestamps from the `WebSocket`'s events. Should still be good enough.

Easy way to trigger a shadow ban for testing purposes: Spam two alternating messages quickly. Good idea to use a VPN + throwaway account though as shadow bans can affect IP and account (even then, they shouldn't stick around for too long though).

P.S.: The .gitattributes file makes sure that no CRLF line endings come into existence on Windows, because those make the linter go insane with errors.