### PR TITLE
Expand global bots list with StreamElements

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -53,7 +53,7 @@ function formatChatUser(message) {
 }
 
 const staff = new Map();
-const globalBots = ['nightbot', 'moobot'];
+const globalBots = ['nightbot', 'moobot', 'streamelements'];
 let channelBots = [];
 let asciiOnly = false;
 let subsOnly = false;

--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -53,7 +53,7 @@ function formatChatUser(message) {
 }
 
 const staff = new Map();
-const globalBots = ['nightbot', 'moobot', 'streamelements'];
+const globalBots = ['nightbot', 'moobot', 'streamelements', 'streamlabs'];
 let channelBots = [];
 let asciiOnly = false;
 let subsOnly = false;


### PR DESCRIPTION
Closes #5483

According to the site Streams Charts (`streamscharts.com`), today:
| Bot | Mod in channels last 24h |
| --- | --- |
| nightbot | 8549 |
| streamelements | 8426 |
| moobot | 2602 |
| streamlabs | 1461 |
| wizebot | 921 |
| sery_bot | 450 |
| fossabot | 441 |

Obviously that's extremely inaccurate, and you, Night, should be able to verify how far off the Nightbot number is. But it should still be able to give a small hint on what chatbots are the most common.

Obviously, any streamer can add their own bots to their channel list on `betterttv.com`, but this PR would still be helpful. 😊