### PR TITLE
Add option to show and highlight deleted messages

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -50,6 +50,7 @@ export const DeletedMessageTypes = {
   DEFAULT: 0,
   SHOW: 1,
   HIDE: 2,
+  HIGHLIGHT: 3,
 };
 
 export const SidebarFlags = {

--- a/src/modules/chat_deleted_messages/index.js
+++ b/src/modules/chat_deleted_messages/index.js
@@ -62,9 +62,11 @@ class ChatDeletedMessagesModule {
 
   handleDelete(name, targetMessageId) {
     const deletedMessages = settings.get(SettingIds.DELETED_MESSAGES);
-    if (deletedMessages !== DeletedMessageTypes.HIDE
-        && deletedMessages !== DeletedMessageTypes.SHOW
-        && deletedMessages !== DeletedMessageTypes.HIGHLIGHT) {
+    if (
+      deletedMessages !== DeletedMessageTypes.HIDE &&
+      deletedMessages !== DeletedMessageTypes.SHOW &&
+      deletedMessages !== DeletedMessageTypes.HIGHLIGHT
+    ) {
       return false;
     }
     const messages = findAllUserMessages(name, targetMessageId);
@@ -76,6 +78,7 @@ class ChatDeletedMessagesModule {
           break;
         case DeletedMessageTypes.HIGHLIGHT:
           $message.css('background-color', '#dc2626');
+        // eslint-disable-next-line no-fallthrough
         case DeletedMessageTypes.SHOW:
           $message.toggleClass(CHAT_LINE_DELETED_CLASS, true);
           /* eslint-disable-next-line func-names */
@@ -84,6 +87,7 @@ class ChatDeletedMessagesModule {
             $link.removeAttr('href');
           });
           $message.find(CHAT_LINE_CLIP_CARD_SELECTOR).remove();
+          break;
         default:
           break;
       }

--- a/src/modules/chat_deleted_messages/index.js
+++ b/src/modules/chat_deleted_messages/index.js
@@ -10,6 +10,7 @@ const CHAT_LINE_LINK_SELECTOR = 'a.link-fragment';
 const CHAT_LINE_CLIP_CARD_SELECTOR = '.chat-card';
 const CHAT_LINE_DELETED_CLASS = 'bttv-chat-line-deleted';
 
+
 function findAllUserMessages(name, targetMessageId) {
   return Array.from(document.querySelectorAll(CHAT_LINE_SELECTOR)).filter((node) => {
     const message = twitch.getChatMessageObject(node);
@@ -77,9 +78,10 @@ class ChatDeletedMessagesModule {
           $message.hide();
           break;
         case DeletedMessageTypes.HIGHLIGHT:
-          $message.css('background-color', '#dc2626');
-        // eslint-disable-next-line no-fallthrough
         case DeletedMessageTypes.SHOW:
+          if (deletedMessages === DeletedMessageTypes.HIGHLIGHT) {
+            $message.addClass('bttv-highlighted');
+          }
           $message.toggleClass(CHAT_LINE_DELETED_CLASS, true);
           /* eslint-disable-next-line func-names */
           $message.find(CHAT_LINE_LINK_SELECTOR).each(function () {

--- a/src/modules/chat_deleted_messages/index.js
+++ b/src/modules/chat_deleted_messages/index.js
@@ -63,9 +63,7 @@ class ChatDeletedMessagesModule {
   handleDelete(name, targetMessageId) {
     const deletedMessages = settings.get(SettingIds.DELETED_MESSAGES);
     if (
-      deletedMessages !== DeletedMessageTypes.HIDE &&
-      deletedMessages !== DeletedMessageTypes.SHOW &&
-      deletedMessages !== DeletedMessageTypes.HIGHLIGHT
+      ![DeletedMessageTypes.HIDE, DeletedMessageTypes.SHOW, DeletedMessageTypes.HIGHLIGHT].includes(deletedMessages)
     ) {
       return false;
     }
@@ -88,8 +86,6 @@ class ChatDeletedMessagesModule {
             $link.removeAttr('href');
           });
           $message.find(CHAT_LINE_CLIP_CARD_SELECTOR).remove();
-          break;
-        default:
           break;
       }
     });

--- a/src/modules/chat_deleted_messages/index.js
+++ b/src/modules/chat_deleted_messages/index.js
@@ -10,7 +10,6 @@ const CHAT_LINE_LINK_SELECTOR = 'a.link-fragment';
 const CHAT_LINE_CLIP_CARD_SELECTOR = '.chat-card';
 const CHAT_LINE_DELETED_CLASS = 'bttv-chat-line-deleted';
 
-
 function findAllUserMessages(name, targetMessageId) {
   return Array.from(document.querySelectorAll(CHAT_LINE_SELECTOR)).filter((node) => {
     const message = twitch.getChatMessageObject(node);

--- a/src/modules/chat_deleted_messages/index.js
+++ b/src/modules/chat_deleted_messages/index.js
@@ -62,24 +62,30 @@ class ChatDeletedMessagesModule {
 
   handleDelete(name, targetMessageId) {
     const deletedMessages = settings.get(SettingIds.DELETED_MESSAGES);
-    const showDeletedMessages = deletedMessages === DeletedMessageTypes.SHOW;
-    const hideDeletedMessages = deletedMessages === DeletedMessageTypes.HIDE;
-    if (!hideDeletedMessages && !showDeletedMessages) {
+    if (deletedMessages !== DeletedMessageTypes.HIDE
+        && deletedMessages !== DeletedMessageTypes.SHOW
+        && deletedMessages !== DeletedMessageTypes.HIGHLIGHT) {
       return false;
     }
     const messages = findAllUserMessages(name, targetMessageId);
     messages.forEach((message) => {
       const $message = $(message);
-      if (hideDeletedMessages) {
-        $message.hide();
-      } else if (showDeletedMessages) {
-        $message.toggleClass(CHAT_LINE_DELETED_CLASS, true);
-        /* eslint-disable-next-line func-names */
-        $message.find(CHAT_LINE_LINK_SELECTOR).each(function () {
-          const $link = $(this);
-          $link.removeAttr('href');
-        });
-        $message.find(CHAT_LINE_CLIP_CARD_SELECTOR).remove();
+      switch (deletedMessages) {
+        case DeletedMessageTypes.HIDE:
+          $message.hide();
+          break;
+        case DeletedMessageTypes.HIGHLIGHT:
+          $message.css('background-color', '#dc2626');
+        case DeletedMessageTypes.SHOW:
+          $message.toggleClass(CHAT_LINE_DELETED_CLASS, true);
+          /* eslint-disable-next-line func-names */
+          $message.find(CHAT_LINE_LINK_SELECTOR).each(function () {
+            const $link = $(this);
+            $link.removeAttr('href');
+          });
+          $message.find(CHAT_LINE_CLIP_CARD_SELECTOR).remove();
+        default:
+          break;
       }
     });
     return true;

--- a/src/modules/chat_deleted_messages/index.js
+++ b/src/modules/chat_deleted_messages/index.js
@@ -4,6 +4,7 @@ import twitch from '../../utils/twitch.js';
 import settings from '../../settings.js';
 import {DeletedMessageTypes, PlatformTypes, SettingIds} from '../../constants.js';
 import {loadModuleForPlatforms} from '../../utils/modules.js';
+import ChatHighlightBlacklistKeywords from '../chat_highlight_blacklist_keywords/index.js';
 
 const CHAT_LINE_SELECTOR = '.chat-line__message';
 const CHAT_LINE_LINK_SELECTOR = 'a.link-fragment';
@@ -70,6 +71,7 @@ class ChatDeletedMessagesModule {
     const messages = findAllUserMessages(name, targetMessageId);
     messages.forEach((message) => {
       const $message = $(message);
+      // eslint-disable-next-line default-case
       switch (deletedMessages) {
         case DeletedMessageTypes.HIDE:
           $message.hide();
@@ -77,7 +79,7 @@ class ChatDeletedMessagesModule {
         case DeletedMessageTypes.HIGHLIGHT:
         case DeletedMessageTypes.SHOW:
           if (deletedMessages === DeletedMessageTypes.HIGHLIGHT) {
-            $message.addClass('bttv-highlighted');
+            ChatHighlightBlacklistKeywords.markHighlighted($message);
           }
           $message.toggleClass(CHAT_LINE_DELETED_CLASS, true);
           /* eslint-disable-next-line func-names */

--- a/src/modules/settings/components/settings/twitch/DeletedMessages.jsx
+++ b/src/modules/settings/components/settings/twitch/DeletedMessages.jsx
@@ -40,7 +40,9 @@ function DeletedMessagesModule() {
             <Radio key="highlightDeletedMessages" value={DeletedMessageTypes.HIGHLIGHT}>
               <div>
                 <p className={styles.heading}>Highlight Deleted Messages</p>
-                <p className={styles.description}>{"Changes <message deleted> back to users' original messages and highlights them."}</p>
+                <p className={styles.description}>
+                  {"Changes <message deleted> back to users' original messages and highlights them."}
+                </p>
               </div>
             </Radio>
           </RadioGroup>

--- a/src/modules/settings/components/settings/twitch/DeletedMessages.jsx
+++ b/src/modules/settings/components/settings/twitch/DeletedMessages.jsx
@@ -37,6 +37,12 @@ function DeletedMessagesModule() {
                 </p>
               </div>
             </Radio>
+            <Radio key="highlightDeletedMessages" value={DeletedMessageTypes.HIGHLIGHT}>
+              <div>
+                <p className={styles.heading}>Highlight Deleted Messages</p>
+                <p className={styles.description}>{"Changes <message deleted> back to users' original messages and highlights them."}</p>
+              </div>
+            </Radio>
           </RadioGroup>
         </FormGroup>
       </div>


### PR DESCRIPTION
This is something I've been wanting for a while in BTTV. I think FFZ or some other extension had something similar to this a while ago and I always found it pretty useful.

Switched an `if` and `if else` block into a `switch` block with a fall-through to reduce code duplication with this change, but fine with reverting that and writing a little extra code.

Hoping this is something that could be added, but if not no sweat. Thanks!