### PR TITLE
Fix highlighted keywords not showing 3-digit hex colors

### DIFF
--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -159,6 +159,15 @@ function getRgb(color) {
     };
   }
 
+  const hex3Regex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i.exec(color);
+  if (hex3Regex != null) {
+    return {
+      r: parseInt(hex3Regex[1], 16) * 17,
+      g: parseInt(hex3Regex[2], 16) * 17,
+      b: parseInt(hex3Regex[3], 16) * 17,
+    };
+  }
+
   const rgbRegex = /^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/i.exec(color);
   if (rgbRegex != null) {
     return {

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -162,9 +162,9 @@ function getRgb(color) {
   const hex3Regex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i.exec(color);
   if (hex3Regex != null) {
     return {
-      r: parseInt(hex3Regex[1], 16) * 17,
-      g: parseInt(hex3Regex[2], 16) * 17,
-      b: parseInt(hex3Regex[3], 16) * 17,
+      r: parseInt(hex3Regex[1] + hex3Regex[1], 16),
+      g: parseInt(hex3Regex[2] + hex3Regex[2], 16),
+      b: parseInt(hex3Regex[3] + hex3Regex[3], 16),
     };
   }
 


### PR DESCRIPTION
Fixes #5871.

I've just added a check for 3-digit hex colors in `getRgb(color)` similar to the check for 6-digit hex colors.