### PR TITLE
Add eol to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
This will help contributors who are on windows (like myself) but who's git settings are for git to automatically handle line endings: `core.autocrlf` set to `true`.

Previously upon cloning, all my files were CRLF with prettier showing an error on every line complaining to remove 'CR'.  
Now when Window's users clone the repo, the endings will be LF. 

This was the recommended solution from here: https://prettier.io/docs/en/options.html#end-of-line