### PR TITLE
Emote Menu Button Placement

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -204,16 +204,7 @@ export const SettingDefaultValues = {
   [SettingIds.WHISPERS]: true,
   [SettingIds.SHOW_DIRECTORY_LIVE_TAB]: false,
   [SettingIds.CHANNEL_POINTS_MESSAGE_HIGHLIGHTS]: true,
-  [SettingIds.EMOTE_MENU]: (settings) => {
-    if (settings == null) {
-      return EmoteMenuTypes.NONE;
-    }
-    const emoteMenu = settings[SettingIds.LEGACY_EMOTE_MENU];
-    if (emoteMenu != null && emoteMenu === true) {
-      return EmoteMenuTypes.LEGACY;
-    }
-    return EmoteMenuTypes.NONE;
-  },
+  [SettingIds.EMOTE_MENU]: EmoteMenuTypes.NONE,
   [SettingIds.AUTO_THEME_MODE]: false,
   [SettingIds.DARKENED_MODE]: false,
   [SettingIds.PRIME_PROMOTIONS]: true,

--- a/src/constants.js
+++ b/src/constants.js
@@ -61,7 +61,7 @@ export const DeletedMessageTypes = {
 
 export const EmoteMenuTypes = {
   NONE: 0,
-  LEGACY: 1,
+  LEGACY_ENABLED: 1,
   ENABLED: 2,
 };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,7 +19,8 @@ export const SettingIds = {
   WHISPERS: 'whispers',
   SHOW_DIRECTORY_LIVE_TAB: 'showDirectoryLiveTab',
   CHANNEL_POINTS_MESSAGE_HIGHLIGHTS: 'channelPointsMessageHighlights',
-  EMOTE_MENU: 'clickTwitchEmotes',
+  LEGACY_EMOTE_MENU: 'clickTwitchEmotes', // legacy
+  EMOTE_MENU: 'emoteMenu',
   AUTO_THEME_MODE: 'autoThemeMode',
   DARKENED_MODE: 'darkenedMode',
   PRIME_PROMOTIONS: 'primePromotions',
@@ -56,6 +57,12 @@ export const DeletedMessageTypes = {
   SHOW: 1,
   HIDE: 2,
   HIGHLIGHT: 3,
+};
+
+export const EmoteMenuTypes = {
+  NONE: 0,
+  DEFAULT: 1,
+  REPLACE_NATIVE: 2,
 };
 
 export const SidebarFlags = {
@@ -196,7 +203,16 @@ export const SettingDefaultValues = {
   [SettingIds.WHISPERS]: true,
   [SettingIds.SHOW_DIRECTORY_LIVE_TAB]: false,
   [SettingIds.CHANNEL_POINTS_MESSAGE_HIGHLIGHTS]: true,
-  [SettingIds.EMOTE_MENU]: false,
+  [SettingIds.EMOTE_MENU]: (settings) => {
+    if (settings == null) {
+      return EmoteMenuTypes.DEFAULT;
+    }
+    const emoteMenu = settings[SettingIds.LEGACY_EMOTE_MENU];
+    if (emoteMenu != null && emoteMenu === false) {
+      return EmoteMenuTypes.NONE;
+    }
+    return EmoteMenuTypes.DEFAULT;
+  },
   [SettingIds.AUTO_THEME_MODE]: false,
   [SettingIds.DARKENED_MODE]: false,
   [SettingIds.PRIME_PROMOTIONS]: true,

--- a/src/constants.js
+++ b/src/constants.js
@@ -61,8 +61,8 @@ export const DeletedMessageTypes = {
 
 export const EmoteMenuTypes = {
   NONE: 0,
-  DEFAULT: 1,
-  REPLACE_NATIVE: 2,
+  LEGACY: 1,
+  ENABLED: 2,
 };
 
 export const SidebarFlags = {
@@ -206,13 +206,13 @@ export const SettingDefaultValues = {
   [SettingIds.CHANNEL_POINTS_MESSAGE_HIGHLIGHTS]: true,
   [SettingIds.EMOTE_MENU]: (settings) => {
     if (settings == null) {
-      return EmoteMenuTypes.DEFAULT;
-    }
-    const emoteMenu = settings[SettingIds.LEGACY_EMOTE_MENU];
-    if (emoteMenu != null && emoteMenu === false) {
       return EmoteMenuTypes.NONE;
     }
-    return EmoteMenuTypes.DEFAULT;
+    const emoteMenu = settings[SettingIds.LEGACY_EMOTE_MENU];
+    if (emoteMenu != null && emoteMenu === true) {
+      return EmoteMenuTypes.LEGACY;
+    }
+    return EmoteMenuTypes.NONE;
   },
   [SettingIds.AUTO_THEME_MODE]: false,
   [SettingIds.DARKENED_MODE]: false,

--- a/src/constants.js
+++ b/src/constants.js
@@ -182,6 +182,7 @@ export const EmoteMenuTips = {
   EMOTE_MENU_FAVORITE_EMOTE: 'emoteMenuTipClosedFavoriteEmote',
   EMOTE_MENU_PREVENT_CLOSE: 'emoteMenuTipClosedPreventClose',
   EMOTE_MENU_HOTKEY: 'emoteMenuTipClosedHotkey',
+  EMOTE_MENU_REPLACE_DEFAULT: 'emoteMenuTipClosedReplaceDefault',
 };
 
 export const SettingDefaultValues = {

--- a/src/modules/emote_menu/components/Button.jsx
+++ b/src/modules/emote_menu/components/Button.jsx
@@ -8,9 +8,10 @@ import {EmoteMenuTips} from '../../../constants.js';
 import emoteMenuViewStore from '../../../common/stores/emote-menu-view-store.js';
 import keyCodes from '../../../utils/keycodes.js';
 import {isMac} from '../../../utils/window.js';
-import styles from './LegacyButton.module.css';
+import styles from './Button.module.css';
+import LogoIcon from '../../../common/components/LogoIcon.jsx';
 
-export default function LegacyButton({appendToChat, className, boundingQuerySelector}) {
+export default function Button({isLegacy = false, appendToChat, className, boundingQuerySelector}) {
   const [loaded, setLoaded] = useState(false);
   const [whisperOpen, setWhisperOpen] = useState(false);
   const whisperRef = useRef(null);
@@ -67,7 +68,13 @@ export default function LegacyButton({appendToChat, className, boundingQuerySele
           boundingQuerySelector={boundingQuerySelector}
         />
       }>
-      <button type="button" className={classNames(styles.button, className)} />
+      {isLegacy ? (
+        <button type="button" className={classNames(styles.legacyButton, className)} />
+      ) : (
+        <button type="button" className={classNames(styles.button, className)}>
+          <LogoIcon />
+        </button>
+      )}
     </Whisper>
   );
 }

--- a/src/modules/emote_menu/components/Button.module.css
+++ b/src/modules/emote_menu/components/Button.module.css
@@ -18,6 +18,8 @@
   align-items: center;
   height: var(--button-size-default, 30px);
   width: var(--button-size-default, 30px);
+  color: var(--bttv-rs-text-primary);
+  cursor: pointer;
   svg {
     height: 16px;
     width: 16px;

--- a/src/modules/emote_menu/components/Button.module.css
+++ b/src/modules/emote_menu/components/Button.module.css
@@ -1,4 +1,4 @@
-.button {
+.legacyButton {
   background-size: 18px;
   background-position: center;
   background-repeat: no-repeat;
@@ -10,4 +10,16 @@
   float: left;
   padding: 15px;
   background-image: url(assets/icons/legacy_smile.svg) !important;
+}
+
+.button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  padding: 7px;
+  svg {
+    height: 16px;
+    width: 16px;
+  }
 }

--- a/src/modules/emote_menu/components/Button.module.css
+++ b/src/modules/emote_menu/components/Button.module.css
@@ -16,8 +16,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  cursor: pointer;
-  padding: 7px;
+  height: var(--button-size-default, 30px);
+  width: var(--button-size-default, 30px);
   svg {
     height: 16px;
     width: 16px;

--- a/src/modules/emote_menu/components/Tip.jsx
+++ b/src/modules/emote_menu/components/Tip.jsx
@@ -24,8 +24,7 @@ function TextButton({children, ...props}) {
 }
 
 function getTipToDisplay() {
-  const [emoteMenuValue, setEmoteMenuValue] = useStorageState(SettingIds.EMOTE_MENU);
-
+  const [emoteMenuValue] = useStorageState(SettingIds.EMOTE_MENU);
   if (!tips[EmoteMenuTips.EMOTE_MENU_PREVENT_CLOSE]) {
     return [
       EmoteMenuTips.EMOTE_MENU_PREVENT_CLOSE,
@@ -60,7 +59,10 @@ function getTipToDisplay() {
           button: ([text]) => (
             <TextButton
               key="emote-menu-replace-default-tip-button"
-              onClick={() => setEmoteMenuValue(EmoteMenuTypes.ENABLED)}>
+              onClick={async () => {
+                const {default: settings} = await import('../../settings/index.js');
+                settings.openSettings(null, 'Emote Menu');
+              }}>
               {text}
             </TextButton>
           ),

--- a/src/modules/emote_menu/components/Tip.jsx
+++ b/src/modules/emote_menu/components/Tip.jsx
@@ -1,9 +1,9 @@
 import React, {useState, useEffect} from 'react';
 import Divider from 'rsuite/Divider';
 import Button from 'rsuite/Button';
-import {EmoteMenuTips, EmoteMenuTypes, SettingIds} from '../../../constants.js';
+import {EmoteMenuTips, EmoteMenuTypes, PlatformTypes, SettingIds} from '../../../constants.js';
 import storage from '../../../storage.js';
-import {isMac} from '../../../utils/window.js';
+import {getPlatform, isMac} from '../../../utils/window.js';
 import emoteMenuStore from '../stores/emote-menu-store.js';
 import Icons from './Icons.jsx';
 import styles from './Tip.module.css';
@@ -50,7 +50,11 @@ function getTipToDisplay() {
     ];
   }
 
-  if (!tips[EmoteMenuTips.EMOTE_MENU_REPLACE_DEFAULT] && emoteMenuValue !== EmoteMenuTypes.ENABLED) {
+  if (
+    !tips[EmoteMenuTips.EMOTE_MENU_REPLACE_DEFAULT] &&
+    emoteMenuValue !== EmoteMenuTypes.ENABLED &&
+    PlatformTypes.TWITCH === getPlatform()
+  ) {
     return [
       EmoteMenuTips.EMOTE_MENU_REPLACE_DEFAULT,
       formatMessage(

--- a/src/modules/emote_menu/components/Tip.jsx
+++ b/src/modules/emote_menu/components/Tip.jsx
@@ -51,7 +51,7 @@ function getTipToDisplay() {
     ];
   }
 
-  if (!tips[EmoteMenuTips.EMOTE_MENU_REPLACE_DEFAULT] && emoteMenuValue !== EmoteMenuTypes.REPLACE_NATIVE) {
+  if (!tips[EmoteMenuTips.EMOTE_MENU_REPLACE_DEFAULT] && emoteMenuValue !== EmoteMenuTypes.ENABLED) {
     return [
       EmoteMenuTips.EMOTE_MENU_REPLACE_DEFAULT,
       formatMessage(
@@ -60,7 +60,7 @@ function getTipToDisplay() {
           button: ([text]) => (
             <TextButton
               key="emote-menu-replace-default-tip-button"
-              onClick={() => setEmoteMenuValue(EmoteMenuTypes.REPLACE_NATIVE)}>
+              onClick={() => setEmoteMenuValue(EmoteMenuTypes.ENABLED)}>
               {text}
             </TextButton>
           ),

--- a/src/modules/emote_menu/components/Tip.jsx
+++ b/src/modules/emote_menu/components/Tip.jsx
@@ -1,20 +1,31 @@
 import React, {useState, useEffect} from 'react';
 import Divider from 'rsuite/Divider';
 import Button from 'rsuite/Button';
-import {EmoteMenuTips} from '../../../constants.js';
+import {EmoteMenuTips, EmoteMenuTypes, SettingIds} from '../../../constants.js';
 import storage from '../../../storage.js';
 import {isMac} from '../../../utils/window.js';
 import emoteMenuStore from '../stores/emote-menu-store.js';
 import Icons from './Icons.jsx';
 import styles from './Tip.module.css';
 import formatMessage from '../../../i18n/index.js';
+import useStorageState from '../../../common/hooks/StorageState.jsx';
 
 const tips = {};
 for (const tipStorageKey of Object.values(EmoteMenuTips)) {
   tips[tipStorageKey] = storage.get(tipStorageKey) || false;
 }
 
+function TextButton({children, ...props}) {
+  return (
+    <Button className={styles.textButton} appearance="link" size="xs" {...props}>
+      {children}
+    </Button>
+  );
+}
+
 function getTipToDisplay() {
+  const [emoteMenuValue, setEmoteMenuValue] = useStorageState(SettingIds.EMOTE_MENU);
+
   if (!tips[EmoteMenuTips.EMOTE_MENU_PREVENT_CLOSE]) {
     return [
       EmoteMenuTips.EMOTE_MENU_PREVENT_CLOSE,
@@ -37,6 +48,24 @@ function getTipToDisplay() {
       isMac()
         ? formatMessage({defaultMessage: 'Control + E to Toggle Emote Menu'})
         : formatMessage({defaultMessage: 'Alt + E to Toggle Emote Menu'}),
+    ];
+  }
+
+  if (!tips[EmoteMenuTips.EMOTE_MENU_REPLACE_DEFAULT] && emoteMenuValue !== EmoteMenuTypes.REPLACE_NATIVE) {
+    return [
+      EmoteMenuTips.EMOTE_MENU_REPLACE_DEFAULT,
+      formatMessage(
+        {defaultMessage: '<button>Replace</button> the default emote picker button'},
+        {
+          button: ([text]) => (
+            <TextButton
+              key="emote-menu-replace-default-tip-button"
+              onClick={() => setEmoteMenuValue(EmoteMenuTypes.REPLACE_NATIVE)}>
+              {text}
+            </TextButton>
+          ),
+        }
+      ),
     ];
   }
 
@@ -74,16 +103,13 @@ export default function Tip({onSetTip}) {
             {strong: Strong, tipDisplayText}
           )}
         </div>
-        <Button
-          className={styles.closeButton}
-          appearance="link"
-          size="xs"
+        <TextButton
           onClick={() => {
             markTipAsSeen(tipStorageKey);
             setTipToDisplay([]);
           }}>
           {formatMessage({defaultMessage: 'Hide'})}
-        </Button>
+        </TextButton>
       </div>
     </>
   );

--- a/src/modules/emote_menu/components/Tip.module.css
+++ b/src/modules/emote_menu/components/Tip.module.css
@@ -19,6 +19,6 @@
   overflow: hidden;
 }
 
-.closeButton {
+.textButton {
   padding: 0;
 }

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -12,11 +12,10 @@ import twitch from '../../../utils/twitch.js';
 const CHAT_TEXT_AREA = 'textarea[data-a-target="chat-input"], div[data-a-target="chat-input"]';
 
 // For legacy button
-const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR =
-  'div[data-a-target="legacy-bttv-emote-picker-button-container"]';
+const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID = 'legacy-bttv-emote-picker-button-container';
 const CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR = '.chat-input div[data-test-selector="chat-input-buttons-container"]';
 
-const BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR = 'div[data-a-target="bttv-emote-picker-button-container"]';
+const BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID = 'bttv-emote-picker-button-container';
 const EMOTE_PICKER_BUTTON_SELECTOR = 'button[data-a-target="emote-picker-button"]';
 
 class SafeEmoteMenuButton extends React.Component {
@@ -50,7 +49,7 @@ function appendToChat({code: text}, shouldFocus = true) {
 
 function unloadLegacyButton(legacyContainer) {
   if (legacyContainer === undefined) {
-    legacyContainer = document.querySelector(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
+    legacyContainer = document.getElementById(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   }
   if (legacyContainer != null) {
     legacyContainer.remove();
@@ -61,7 +60,7 @@ function unloadLegacyButton(legacyContainer) {
 }
 
 function loadLegacyButton() {
-  const legacyContainer = document.querySelector(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
+  const legacyContainer = document.getElementById(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   if (legacyContainer != null) {
     return;
   }
@@ -73,7 +72,7 @@ function loadLegacyButton() {
 
   const rightContainer = container.lastChild;
   const buttonContainer = document.createElement('div');
-  buttonContainer.setAttribute('data-a-target', 'legacy-bttv-emote-picker-button-container');
+  buttonContainer.setAttribute('data-a-target', LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   rightContainer.insertBefore(buttonContainer, rightContainer.lastChild);
 
   if (legacyMountedRoot != null) {
@@ -93,7 +92,7 @@ function loadLegacyButton() {
 
 function unloadButton(container, chatInputIcons) {
   if (container === undefined) {
-    container = document.querySelector(BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
+    container = document.getElementById(BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   }
   if (chatInputIcons === undefined) {
     chatInputIcons = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement?.parentElement;
@@ -110,7 +109,7 @@ function unloadButton(container, chatInputIcons) {
 }
 
 function loadButton() {
-  const container = document.querySelector(BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
+  const container = document.getElementById(BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   if (container != null) {
     return;
   }
@@ -121,7 +120,7 @@ function loadButton() {
   }
 
   const buttonContainer = document.createElement('div');
-  buttonContainer.setAttribute('data-a-target', 'bttv-emote-picker-button-container');
+  buttonContainer.setAttribute('data-a-target', BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   chatInputIcons.classList.add(styles.chatInputIcon);
   chatInputIcons.appendChild(buttonContainer);
 

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -72,7 +72,7 @@ function loadLegacyButton() {
 
   const rightContainer = container.lastChild;
   const buttonContainer = document.createElement('div');
-  buttonContainer.setAttribute('data-a-target', LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
+  buttonContainer.setAttribute('id', LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   rightContainer.insertBefore(buttonContainer, rightContainer.lastChild);
 
   if (legacyMountedRoot != null) {
@@ -121,7 +121,7 @@ function loadButton() {
   }
 
   const buttonContainer = document.createElement('div');
-  buttonContainer.setAttribute('data-a-target', BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
+  buttonContainer.setAttribute('id', BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   chatInputIcons.classList.add(styles.chatInputIcon);
   chatInputIcons.appendChild(buttonContainer);
 

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {createRoot} from 'react-dom/client';
 import settings from '../../../settings.js';
 import {EmoteMenuTypes, SettingIds} from '../../../constants.js';
-import EmoteMenuButton from '../components/LegacyButton.jsx';
+import EmoteMenuButton from '../components/Button.jsx';
 import domObserver from '../../../observers/dom.js';
 import styles from './EmoteMenu.module.css';
 import {getCurrentUser} from '../../../utils/user.js';
@@ -82,6 +82,7 @@ function loadLegacyButton() {
   legacyMountedRoot = createRoot(buttonContainer);
   legacyMountedRoot.render(
     <SafeEmoteMenuButton
+      isLegacy
       onError={() => unloadLegacyButton(legacyContainer)}
       appendToChat={appendToChat}
       className={styles.button}

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -115,9 +115,6 @@ export default class EmoteMenuModule {
 
   show(emoteMenuValue) {
     const legacyContainer = document.querySelector(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
-    if (legacyContainer == null) {
-      return;
-    }
     legacyContainer.classList.toggle(styles.hideEmoteMenuButton, emoteMenuValue === EmoteMenuTypes.NONE);
 
     const emotePickerButtonContainer = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement;

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -12,7 +12,7 @@ import twitch from '../../../utils/twitch.js';
 const CHAT_TEXT_AREA = 'textarea[data-a-target="chat-input"], div[data-a-target="chat-input"]';
 
 // For legacy button
-const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID = 'legacy-bttv-emote-picker-button-container';
+const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID = 'bttv-legacy-emote-picker-button-container';
 const CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR = '.chat-input div[data-test-selector="chat-input-buttons-container"]';
 
 const BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID = 'bttv-emote-picker-button-container';

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -17,6 +17,9 @@ const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR =
 const CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR = '.chat-input div[data-test-selector="chat-input-buttons-container"]';
 const EMOTE_PICKER_BUTTON_SELECTOR = 'button[data-a-target="emote-picker-button"]';
 
+const BTTV_BUTTON_CONTAINER_ID = 'bttv-emote-menu-button-container';
+const BTTV_LEGACY_BUTTON_CONTAINER_ID = 'bttv-legacy-emote-menu-button-container';
+
 class SafeEmoteMenuButton extends React.Component {
   componentDidMount() {
     const {onMount} = this.props;
@@ -65,7 +68,8 @@ export default class EmoteMenuModule {
       const buttonContainer = document.createElement('div');
       buttonContainer.setAttribute('data-a-target', 'legacy-bttv-emote-picker-button-container');
 
-      if (emoteMenuValue === EmoteMenuTypes.ENABLED) {
+      if (emoteMenuValue === EmoteMenuTypes.ENABLED && buttonContainer.id !== BTTV_BUTTON_CONTAINER_ID) {
+        buttonContainer.id = BTTV_BUTTON_CONTAINER_ID;
         const nativeEmotePickerButtonContainer = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement;
         if (nativeEmotePickerButtonContainer == null) {
           return;
@@ -76,7 +80,10 @@ export default class EmoteMenuModule {
         }
         chatInputIcons.classList.add(styles.chatInputIcon);
         chatInputIcons.appendChild(buttonContainer);
-      } else {
+      }
+
+      if (emoteMenuValue === EmoteMenuTypes.LEGACY_ENABLED && buttonContainer.id !== BTTV_LEGACY_BUTTON_CONTAINER_ID) {
+        buttonContainer.id = BTTV_LEGACY_BUTTON_CONTAINER_ID;
         const container = document.querySelector(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR);
         if (container == null) {
           return;

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -11,14 +11,8 @@ import twitch from '../../../utils/twitch.js';
 
 const CHAT_TEXT_AREA = 'textarea[data-a-target="chat-input"], div[data-a-target="chat-input"]';
 
-const BTTV_EMOTE_PICKER_BUTTON_CONTAINER_DATA_A_TARGET = 'bttv-emote-picker-button-container';
-const BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR = `div[data-a-target="${BTTV_EMOTE_PICKER_BUTTON_CONTAINER_DATA_A_TARGET}"]`;
-const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_DATA_A_TARGET = 'legacy-bttv-emote-picker-button-container';
-const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR = `div[data-a-target="${LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_DATA_A_TARGET}"]`;
-
 const CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR = '.chat-input div[data-test-selector="chat-input-buttons-container"]';
 const EMOTE_PICKER_BUTTON_SELECTOR = 'button[data-a-target="emote-picker-button"]';
-
 const BTTV_BUTTON_CONTAINER_ID = 'bttv-emote-menu-button-container';
 const BTTV_BUTTON_CONTAINER_SELECTOR = `#${BTTV_BUTTON_CONTAINER_ID}`;
 
@@ -65,12 +59,19 @@ export default class EmoteMenuModule {
 
     const emoteMenuValue = settings.get(SettingIds.EMOTE_MENU);
     if (emoteMenuValue !== EmoteMenuTypes.NONE) {
-      let container = null;
+      if (isMounted && mountedRoot != null) {
+        mountedRoot.unmount();
+        isMounted = false;
+        const currentContainer = document.querySelector(BTTV_BUTTON_CONTAINER_SELECTOR);
+        if (currentContainer != null) {
+          currentContainer.remove();
+        }
+      }
 
-      const buttonContainer = document.querySelector(BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
-      if (emoteMenuValue === EmoteMenuTypes.ENABLED && buttonContainer == null) {
-        container = document.createElement('div');
-        container.setAttribute('data-a-target', BTTV_EMOTE_PICKER_BUTTON_CONTAINER_DATA_A_TARGET);
+      const container = document.createElement('div');
+      container.setAttribute('id', BTTV_BUTTON_CONTAINER_ID);
+
+      if (emoteMenuValue === EmoteMenuTypes.ENABLED) {
         const nativeEmotePickerButtonContainer = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement;
         if (nativeEmotePickerButtonContainer == null) {
           return;
@@ -81,12 +82,7 @@ export default class EmoteMenuModule {
         }
         chatInputIcons.classList.add(styles.chatInputIcon);
         chatInputIcons.appendChild(container);
-      }
-
-      const legacyContainer = document.querySelector(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
-      if (emoteMenuValue === EmoteMenuTypes.LEGACY_ENABLED && legacyContainer == null) {
-        container = document.createElement('div');
-        container.setAttribute('data-a-target', LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_DATA_A_TARGET);
+      } else {
         const chatSettingsButtonContainer = document.querySelector(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR);
         if (chatSettingsButtonContainer == null) {
           return;
@@ -95,21 +91,6 @@ export default class EmoteMenuModule {
         rightContainer.insertBefore(container, rightContainer.lastChild);
       }
 
-      if (container == null) {
-        this.show(emoteMenuValue);
-        return;
-      }
-
-      const currentContainer = document.querySelector(BTTV_BUTTON_CONTAINER_SELECTOR);
-      if (currentContainer != null) {
-        currentContainer.remove();
-        if (mountedRoot != null) {
-          mountedRoot.unmount();
-          isMounted = false;
-        }
-      }
-
-      container.setAttribute('id', BTTV_BUTTON_CONTAINER_ID);
       mountedRoot = createRoot(container);
       mountedRoot.render(
         <SafeEmoteMenuButton

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -11,17 +11,15 @@ import twitch from '../../../utils/twitch.js';
 
 const CHAT_TEXT_AREA = 'textarea[data-a-target="chat-input"], div[data-a-target="chat-input"]';
 
+// For legacy button
+const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR =
+  'div[data-a-target="legacy-bttv-emote-picker-button-container"]';
 const CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR = '.chat-input div[data-test-selector="chat-input-buttons-container"]';
+
+const BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR = 'div[data-a-target="bttv-emote-picker-button-container"]';
 const EMOTE_PICKER_BUTTON_SELECTOR = 'button[data-a-target="emote-picker-button"]';
-const BTTV_BUTTON_CONTAINER_ID = 'bttv-emote-menu-button-container';
-const BTTV_BUTTON_CONTAINER_SELECTOR = `#${BTTV_BUTTON_CONTAINER_ID}`;
 
 class SafeEmoteMenuButton extends React.Component {
-  componentDidMount() {
-    const {onMount} = this.props;
-    onMount();
-  }
-
   componentDidCatch(error, info) {
     const {onError} = this.props;
     onError(error, info);
@@ -37,7 +35,109 @@ class SafeEmoteMenuButton extends React.Component {
 }
 
 let mountedRoot;
-let isMounted = false;
+let legacyMountedRoot;
+
+function appendToChat({code: text}, shouldFocus = true) {
+  let prefixText = twitch.getChatInputValue();
+
+  // suffix the prefix with a space if it needs one
+  if (prefixText.length > 0 && !prefixText.endsWith(' ')) {
+    prefixText += ' ';
+  }
+
+  twitch.setChatInputValue(`${prefixText}${text} `, shouldFocus);
+}
+
+function unloadLegacyButton(legacyContainer) {
+  if (legacyContainer === undefined) {
+    legacyContainer = document.querySelector(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
+  }
+  if (legacyContainer != null) {
+    legacyContainer.remove();
+  }
+  if (legacyMountedRoot != null) {
+    legacyMountedRoot.unmount();
+  }
+}
+
+function loadLegacyButton() {
+  const legacyContainer = document.querySelector(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
+  if (legacyContainer != null) {
+    return;
+  }
+
+  const container = document.querySelector(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR);
+  if (container == null) {
+    return;
+  }
+
+  const rightContainer = container.lastChild;
+  const buttonContainer = document.createElement('div');
+  buttonContainer.setAttribute('data-a-target', 'legacy-bttv-emote-picker-button-container');
+  rightContainer.insertBefore(buttonContainer, rightContainer.lastChild);
+
+  if (legacyMountedRoot != null) {
+    legacyMountedRoot.unmount();
+  }
+
+  legacyMountedRoot = createRoot(buttonContainer);
+  legacyMountedRoot.render(
+    <SafeEmoteMenuButton
+      onError={() => unloadLegacyButton(legacyContainer)}
+      appendToChat={appendToChat}
+      className={styles.button}
+      boundingQuerySelector={CHAT_TEXT_AREA}
+    />
+  );
+}
+
+function unloadButton(container, chatInputIcons) {
+  if (container === undefined) {
+    container = document.querySelector(BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
+  }
+  if (chatInputIcons === undefined) {
+    chatInputIcons = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement?.parentElement;
+  }
+  if (chatInputIcons != null) {
+    chatInputIcons.classList.remove(styles.chatInputIcon);
+  }
+  if (container != null) {
+    container.remove();
+  }
+  if (mountedRoot != null) {
+    mountedRoot.unmount();
+  }
+}
+
+function loadButton() {
+  const container = document.querySelector(BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
+  if (container != null) {
+    return;
+  }
+  const chatInputIcons = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement?.parentElement;
+  if (chatInputIcons == null) {
+    return;
+  }
+
+  const buttonContainer = document.createElement('div');
+  buttonContainer.setAttribute('data-a-target', 'bttv-emote-picker-button-container');
+  chatInputIcons.classList.add(styles.chatInputIcon);
+  chatInputIcons.appendChild(buttonContainer);
+
+  if (mountedRoot != null) {
+    mountedRoot.unmount();
+  }
+
+  mountedRoot = createRoot(buttonContainer);
+  mountedRoot.render(
+    <SafeEmoteMenuButton
+      onError={() => unloadButton(buttonContainer, chatInputIcons)}
+      appendToChat={appendToChat}
+      className={styles.button}
+      boundingQuerySelector={CHAT_TEXT_AREA}
+    />
+  );
+}
 
 export default class EmoteMenuModule {
   constructor() {
@@ -46,93 +146,30 @@ export default class EmoteMenuModule {
         return;
       }
 
-      this.loadButton();
+      this.load();
     });
-    watcher.on('load.chat', () => this.loadButton());
-    settings.on(`changed.${SettingIds.EMOTE_MENU}`, () => this.loadButton());
+    watcher.on('load.chat', () => this.load());
+    settings.on(`changed.${SettingIds.EMOTE_MENU}`, () => this.load());
   }
 
-  loadButton() {
+  load() {
     if (getCurrentUser() == null) {
       return;
     }
 
-    const emoteMenuValue = settings.get(SettingIds.EMOTE_MENU);
-    if (emoteMenuValue !== EmoteMenuTypes.NONE) {
-      if (isMounted && mountedRoot != null) {
-        mountedRoot.unmount();
-        isMounted = false;
-        const currentContainer = document.querySelector(BTTV_BUTTON_CONTAINER_SELECTOR);
-        if (currentContainer != null) {
-          currentContainer.remove();
-        }
-      }
-
-      const container = document.createElement('div');
-      container.setAttribute('id', BTTV_BUTTON_CONTAINER_ID);
-
-      if (emoteMenuValue === EmoteMenuTypes.ENABLED) {
-        const nativeEmotePickerButtonContainer = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement;
-        if (nativeEmotePickerButtonContainer == null) {
-          return;
-        }
-        const chatInputIcons = nativeEmotePickerButtonContainer.parentElement;
-        if (chatInputIcons == null) {
-          return;
-        }
-        chatInputIcons.classList.add(styles.chatInputIcon);
-        chatInputIcons.appendChild(container);
-      } else {
-        const chatSettingsButtonContainer = document.querySelector(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR);
-        if (chatSettingsButtonContainer == null) {
-          return;
-        }
-        const rightContainer = chatSettingsButtonContainer.lastChild;
-        rightContainer.insertBefore(container, rightContainer.lastChild);
-      }
-
-      mountedRoot = createRoot(container);
-      mountedRoot.render(
-        <SafeEmoteMenuButton
-          onError={() => this.show(EmoteMenuTypes.NONE)}
-          onMount={() => {
-            this.show(emoteMenuValue);
-            isMounted = true;
-          }}
-          appendToChat={this.appendToChat}
-          className={styles.button}
-          boundingQuerySelector={CHAT_TEXT_AREA}
-        />
-      );
+    switch (settings.get(SettingIds.EMOTE_MENU)) {
+      case EmoteMenuTypes.ENABLED:
+        unloadLegacyButton();
+        loadButton();
+        break;
+      case EmoteMenuTypes.LEGACY_ENABLED:
+        loadLegacyButton();
+        unloadButton();
+        break;
+      default:
+        unloadLegacyButton();
+        unloadButton();
+        break;
     }
-
-    if (isMounted) {
-      this.show(emoteMenuValue);
-    }
-  }
-
-  show(emoteMenuValue) {
-    const container = document.querySelector(BTTV_BUTTON_CONTAINER_SELECTOR);
-    container.classList.toggle(styles.hideEmoteMenuButton, emoteMenuValue === EmoteMenuTypes.NONE);
-
-    const emotePickerButtonContainer = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement;
-    if (emotePickerButtonContainer == null) {
-      return;
-    }
-    emotePickerButtonContainer.classList.toggle(
-      styles.hideDefaultEmoteMenuButton,
-      emoteMenuValue === EmoteMenuTypes.ENABLED
-    );
-  }
-
-  appendToChat({code: text}, shouldFocus = true) {
-    let prefixText = twitch.getChatInputValue();
-
-    // suffix the prefix with a space if it needs one
-    if (prefixText.length > 0 && !prefixText.endsWith(' ')) {
-      prefixText += ' ';
-    }
-
-    twitch.setChatInputValue(`${prefixText}${text} `, shouldFocus);
   }
 }

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -121,7 +121,8 @@ function loadButton() {
   }
 
   const chatInputIcons = nativeEmotePickerButton?.parentElement?.parentElement?.parentElement;
-  if (chatInputIcons == null) {
+  const chatInputIconsStyle = chatInputIcons != null ? window.getComputedStyle(chatInputIcons) : null;
+  if (chatInputIcons == null && (chatInputIconsStyle?.display !== 'absolute' || chatInputIconsStyle.right !== '0px')) {
     return;
   }
 

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -114,6 +114,7 @@ function loadButton() {
   if (container != null) {
     return;
   }
+
   const chatInputIcons = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement?.parentElement;
   if (chatInputIcons == null) {
     return;

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -15,7 +15,6 @@ const CHAT_TEXT_AREA = 'textarea[data-a-target="chat-input"], div[data-a-target=
 const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR =
   'div[data-a-target="legacy-bttv-emote-picker-button-container"]';
 const CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR = '.chat-input div[data-test-selector="chat-input-buttons-container"]';
-const CHAT_INPUT_ICONS_SELECTOR = '.chat-input__input-icons';
 const EMOTE_PICKER_BUTTON_SELECTOR = 'button[data-a-target="emote-picker-button"]';
 
 class SafeEmoteMenuButton extends React.Component {
@@ -67,12 +66,16 @@ export default class EmoteMenuModule {
       buttonContainer.setAttribute('data-a-target', 'legacy-bttv-emote-picker-button-container');
 
       if (emoteMenuValue === EmoteMenuTypes.ENABLED) {
-        const container = document.querySelector(CHAT_INPUT_ICONS_SELECTOR);
-        if (container == null) {
+        const nativeEmotePickerButtonContainer = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement;
+        if (nativeEmotePickerButtonContainer == null) {
           return;
         }
-        container.classList.add(styles.chatInputIcon);
-        container.appendChild(buttonContainer);
+        const chatInputIcons = nativeEmotePickerButtonContainer.parentElement;
+        if (chatInputIcons == null) {
+          return;
+        }
+        chatInputIcons.classList.add(styles.chatInputIcon);
+        chatInputIcons.appendChild(buttonContainer);
       } else {
         const container = document.querySelector(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR);
         if (container == null) {

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -66,7 +66,7 @@ export default class EmoteMenuModule {
       const buttonContainer = document.createElement('div');
       buttonContainer.setAttribute('data-a-target', 'legacy-bttv-emote-picker-button-container');
 
-      if (emoteMenuValue === EmoteMenuTypes.REPLACE_NATIVE) {
+      if (emoteMenuValue === EmoteMenuTypes.ENABLED) {
         const container = document.querySelector(CHAT_INPUT_ICONS_SELECTOR);
         if (container == null) {
           return;
@@ -123,7 +123,7 @@ export default class EmoteMenuModule {
     }
     emotePickerButtonContainer.classList.toggle(
       styles.hideDefaultEmoteMenuButton,
-      emoteMenuValue === EmoteMenuTypes.REPLACE_NATIVE
+      emoteMenuValue === EmoteMenuTypes.ENABLED
     );
   }
 

--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -91,15 +91,15 @@ function loadLegacyButton() {
   );
 }
 
-function unloadButton(container, chatInputIcons) {
+function unloadButton(container, nativeEmotePickerButton) {
   if (container === undefined) {
     container = document.getElementById(BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   }
-  if (chatInputIcons === undefined) {
-    chatInputIcons = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement?.parentElement;
+  if (nativeEmotePickerButton === undefined) {
+    nativeEmotePickerButton = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR);
   }
-  if (chatInputIcons != null) {
-    chatInputIcons.classList.remove(styles.chatInputIcon);
+  if (nativeEmotePickerButton != null) {
+    nativeEmotePickerButton.classList.remove(styles.hideEmoteMenuButton);
   }
   if (container != null) {
     container.remove();
@@ -115,14 +115,20 @@ function loadButton() {
     return;
   }
 
-  const chatInputIcons = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR)?.parentElement?.parentElement;
+  const nativeEmotePickerButton = document.querySelector(EMOTE_PICKER_BUTTON_SELECTOR);
+  if (nativeEmotePickerButton == null) {
+    return;
+  }
+
+  const chatInputIcons = nativeEmotePickerButton?.parentElement?.parentElement?.parentElement;
   if (chatInputIcons == null) {
     return;
   }
 
+  nativeEmotePickerButton.classList.add(styles.hideEmoteMenuButton);
   const buttonContainer = document.createElement('div');
   buttonContainer.setAttribute('id', BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
-  chatInputIcons.classList.add(styles.chatInputIcon);
+  buttonContainer.classList.add(styles.container);
   chatInputIcons.appendChild(buttonContainer);
 
   if (mountedRoot != null) {
@@ -132,7 +138,7 @@ function loadButton() {
   mountedRoot = createRoot(buttonContainer);
   mountedRoot.render(
     <SafeEmoteMenuButton
-      onError={() => unloadButton(buttonContainer, chatInputIcons)}
+      onError={() => unloadButton(buttonContainer, nativeEmotePickerButton)}
       appendToChat={appendToChat}
       className={styles.button}
       boundingQuerySelector={CHAT_TEXT_AREA}

--- a/src/modules/emote_menu/twitch/EmoteMenu.module.css
+++ b/src/modules/emote_menu/twitch/EmoteMenu.module.css
@@ -3,12 +3,6 @@
   position: relative !important;
 }
 
-.hideDefaultEmoteMenuButton {
-  button[data-a-target='emote-picker-button'] {
-    display: none !important;
-  }
-}
-
 .hideEmoteMenuButton {
   display: none;
 }
@@ -16,6 +10,9 @@
 .chatInputIcon {
   display: inline-flex;
   vertical-align: top;
+  button[data-a-target='emote-picker-button'] {
+    display: none;
+  }
 }
 
 .button {

--- a/src/modules/emote_menu/twitch/EmoteMenu.module.css
+++ b/src/modules/emote_menu/twitch/EmoteMenu.module.css
@@ -1,18 +1,10 @@
 .container {
-  display: inline-flex !important;
-  position: relative !important;
+  display: inline-block !important;
+  vertical-align: bottom !important;
 }
 
 .hideEmoteMenuButton {
   display: none;
-}
-
-.chatInputIcon {
-  display: inline-flex;
-  vertical-align: top;
-  button[data-a-target='emote-picker-button'] {
-    display: none;
-  }
 }
 
 .button {

--- a/src/modules/emote_menu/twitch/EmoteMenu.module.css
+++ b/src/modules/emote_menu/twitch/EmoteMenu.module.css
@@ -13,6 +13,11 @@
   display: none;
 }
 
+.chatInputIcon {
+  display: inline-flex;
+  vertical-align: top;
+}
+
 .button {
   border-radius: var(--border-radius-medium);
 

--- a/src/modules/emote_menu/youtube/EmoteMenu.jsx
+++ b/src/modules/emote_menu/youtube/EmoteMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import settings from '../../../settings.js';
-import {EmoteProviders, SettingIds} from '../../../constants.js';
+import {EmoteMenuTypes, EmoteProviders, SettingIds} from '../../../constants.js';
 import EmoteMenuButton from '../components/LegacyButton.jsx';
 import domObserver from '../../../observers/dom.js';
 import styles from './EmoteMenu.module.css';
@@ -59,7 +59,8 @@ export default class EmoteMenuModule {
     }
 
     const legacyContainer = document.querySelector(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
-    const emoteMenuEnabled = settings.get(SettingIds.EMOTE_MENU);
+    const emoteMenuValue = settings.get(SettingIds.EMOTE_MENU);
+    const emoteMenuEnabled = emoteMenuValue !== EmoteMenuTypes.NONE;
 
     // TODO: take into account emote menu setting in the future
     if (legacyContainer == null && emoteMenuEnabled) {

--- a/src/modules/emote_menu/youtube/EmoteMenu.jsx
+++ b/src/modules/emote_menu/youtube/EmoteMenu.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {createRoot} from 'react-dom/client';
 import settings from '../../../settings.js';
 import {EmoteMenuTypes, EmoteProviders, SettingIds} from '../../../constants.js';
-import EmoteMenuButton from '../components/LegacyButton.jsx';
+import EmoteMenuButton from '../components/Button.jsx';
 import domObserver from '../../../observers/dom.js';
 import styles from './EmoteMenu.module.css';
 import {getCurrentUser} from '../../../utils/user.js';
@@ -80,6 +80,7 @@ export default class EmoteMenuModule {
       mountedRoot = createRoot(buttonContainer);
       mountedRoot.render(
         <SafeEmoteMenuButton
+          isLegacy
           onError={() => this.show(false)}
           onMount={() => {
             this.show(true);

--- a/src/modules/emote_menu/youtube/EmoteMenu.jsx
+++ b/src/modules/emote_menu/youtube/EmoteMenu.jsx
@@ -11,9 +11,7 @@ import {createYoutubeEmojiNode} from '../../../utils/youtube.js';
 
 const CHAT_TEXT_AREA = 'div#input[contenteditable]';
 
-// For legacy button
-const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR =
-  'div[data-a-target="legacy-bttv-emote-picker-button-container"]';
+const BTTV_EMOTE_PICKER_BUTTON_CONTAINER_CLASS = 'bttv-emote-picker-button-container';
 const CHAT_BUTTON_CONTAINER_SELECTOR = '#picker-buttons';
 const NATIVE_EMOTE_MENU_BUTTON_CONTAINER_SELECTOR = '.yt-live-chat-icon-toggle-button-renderer';
 
@@ -47,29 +45,29 @@ export default class EmoteMenuModule {
         return;
       }
 
-      this.loadLegacyButton();
+      this.loadButton();
     });
-    watcher.on('load.youtube', () => this.loadLegacyButton());
-    settings.on(`changed.${SettingIds.EMOTE_MENU}`, () => this.loadLegacyButton());
+    watcher.on('load.youtube', () => this.loadButton());
+    settings.on(`changed.${SettingIds.EMOTE_MENU}`, () => this.loadButton());
   }
 
-  loadLegacyButton() {
+  loadButton() {
     if (getCurrentUser() == null) {
       return;
     }
 
-    const legacyContainer = document.querySelector(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
+    const container = document.querySelector(`.${BTTV_EMOTE_PICKER_BUTTON_CONTAINER_CLASS}`);
     const emoteMenuValue = settings.get(SettingIds.EMOTE_MENU);
     const emoteMenuEnabled = emoteMenuValue !== EmoteMenuTypes.NONE;
 
     // TODO: take into account emote menu setting in the future
-    if (legacyContainer == null && emoteMenuEnabled) {
+    if (container == null && emoteMenuEnabled) {
       const nativeButtonContainer = document.querySelector(CHAT_BUTTON_CONTAINER_SELECTOR);
       if (nativeButtonContainer == null) {
         return;
       }
       const buttonContainer = document.createElement('div');
-      buttonContainer.setAttribute('data-a-target', 'legacy-bttv-emote-picker-button-container');
+      buttonContainer.classList.add(BTTV_EMOTE_PICKER_BUTTON_CONTAINER_CLASS);
       nativeButtonContainer.insertBefore(buttonContainer, nativeButtonContainer.firstChild);
 
       if (mountedRoot != null) {
@@ -80,7 +78,6 @@ export default class EmoteMenuModule {
       mountedRoot = createRoot(buttonContainer);
       mountedRoot.render(
         <SafeEmoteMenuButton
-          isLegacy
           onError={() => this.show(false)}
           onMount={() => {
             this.show(true);
@@ -104,9 +101,9 @@ export default class EmoteMenuModule {
       nativeContainer.classList.toggle(styles.hideEmoteMenuButton, visible);
     }
 
-    const legacyContainer = document.querySelector(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_SELECTOR);
-    if (legacyContainer != null) {
-      legacyContainer.classList.toggle(styles.hideEmoteMenuButton, !visible);
+    const container = document.querySelector(`.${BTTV_EMOTE_PICKER_BUTTON_CONTAINER_CLASS}`);
+    if (container != null) {
+      container.classList.toggle(styles.hideEmoteMenuButton, !visible);
     }
   }
 

--- a/src/modules/settings/components/Window.jsx
+++ b/src/modules/settings/components/Window.jsx
@@ -37,10 +37,14 @@ function isWindowSmallStandaloneChat() {
 function Window({setHandleOpen}) {
   const [page, setPage] = useState(PageTypes.CHAT_SETTINGS);
   const [open, setOpen] = useState(false);
+  const [defaultSearchInput, setDefaultSearchInput] = useState('');
   const [isSmallStandaloneChat, setStandaloneChat] = useState(isWindowSmallStandaloneChat());
 
   useEffect(() => {
-    setHandleOpen(setOpen);
+    setHandleOpen((isOpen, searchInput) => {
+      setOpen(isOpen);
+      setDefaultSearchInput(searchInput);
+    });
 
     function checkStandaloneChat() {
       setStandaloneChat(isWindowSmallStandaloneChat());
@@ -73,7 +77,7 @@ function Window({setHandleOpen}) {
             setPage(value);
           }}
         />
-        <Page page={page} onClose={() => setOpen(false)} />
+        <Page page={page} defaultSearchInput={defaultSearchInput} onClose={() => setOpen(false)} />
       </Modal>
     </ThemeProvider>
   );

--- a/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
+++ b/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
@@ -23,7 +23,7 @@ function EmoteMenu() {
       {toggled ? (
         <div className={styles.settingRow}>
           <p className={styles.settingDescription}>
-            {formatMessage({defaultMessage: "Replace twitch's native emote menu."})}
+            {formatMessage({defaultMessage: "Replace Twitch's native emote menu."})}
           </p>
           <Toggle
             checked={value === EmoteMenuTypes.ENABLED}

--- a/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
+++ b/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
@@ -22,19 +22,19 @@ function EmoteMenu() {
         </p>
         <FormGroup controlId="radioList">
           <RadioGroup name="radioList" value={value} onChange={(state) => setValue(state)}>
-            <Radio key="default" value={EmoteMenuTypes.DEFAULT}>
+            <Radio key="default" value={EmoteMenuTypes.ENABLED}>
               <div>
                 <p className={styles.heading}>{formatMessage({defaultMessage: 'Enabled'})}</p>
                 <p className={styles.settingDescription}>
-                  {formatMessage({defaultMessage: 'Emote picker button appears below chat input box'})}
+                  {formatMessage({defaultMessage: 'Replace the default emote picker button'})}
                 </p>
               </div>
             </Radio>
-            <Radio key="replace-native" value={EmoteMenuTypes.REPLACE_NATIVE}>
+            <Radio key="replace-native" value={EmoteMenuTypes.LEGACY}>
               <div>
-                <p className={styles.heading}>{formatMessage({defaultMessage: 'Replace'})}</p>
+                <p className={styles.heading}>{formatMessage({defaultMessage: 'Legacy'})}</p>
                 <p className={styles.settingDescription}>
-                  {formatMessage({defaultMessage: 'Replace the default emote picker button'})}
+                  {formatMessage({defaultMessage: 'Emote picker button appears below chat input box'})}
                 </p>
               </div>
             </Radio>

--- a/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
+++ b/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
@@ -18,7 +18,10 @@ function EmoteMenu() {
         <p className={styles.settingDescription}>
           {formatMessage({defaultMessage: 'Enables a more advanced emote menu for chat'})}
         </p>
-        <Toggle checked={toggled} onChange={(state) => setValue(state ? EmoteMenuTypes.LEGACY : EmoteMenuTypes.NONE)} />
+        <Toggle
+          checked={toggled}
+          onChange={(state) => setValue(state ? EmoteMenuTypes.ENABLED : EmoteMenuTypes.NONE)}
+        />
       </div>
       {toggled ? (
         <div className={styles.settingRow}>
@@ -27,7 +30,7 @@ function EmoteMenu() {
           </p>
           <Toggle
             checked={value === EmoteMenuTypes.ENABLED}
-            onChange={(state) => setValue(state ? EmoteMenuTypes.ENABLED : EmoteMenuTypes.LEGACY)}
+            onChange={(state) => setValue(state ? EmoteMenuTypes.ENABLED : EmoteMenuTypes.LEGACY_ENABLED)}
           />
         </div>
       ) : null}

--- a/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
+++ b/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import Panel from 'rsuite/Panel';
-import Radio from 'rsuite/Radio';
-import RadioGroup from 'rsuite/RadioGroup';
-import FormGroup from 'rsuite/FormGroup';
+import {Toggle} from 'rsuite';
 import {registerComponent} from '../../Store.jsx';
 import {CategoryTypes, SettingIds, EmoteMenuTypes} from '../../../../../constants.js';
 import styles from '../../../styles/header.module.css';
@@ -13,42 +11,26 @@ const SETTING_NAME = formatMessage({defaultMessage: 'Emote Menu'});
 
 function EmoteMenu() {
   const [value, setValue] = useStorageState(SettingIds.EMOTE_MENU);
-
+  const toggled = value !== EmoteMenuTypes.NONE;
   return (
     <Panel header={SETTING_NAME}>
-      <div className={styles.setting}>
+      <div className={styles.settingRow}>
         <p className={styles.settingDescription}>
           {formatMessage({defaultMessage: 'Enables a more advanced emote menu for chat'})}
         </p>
-        <FormGroup controlId="radioList">
-          <RadioGroup name="radioList" value={value} onChange={(state) => setValue(state)}>
-            <Radio key="default" value={EmoteMenuTypes.ENABLED}>
-              <div>
-                <p className={styles.heading}>{formatMessage({defaultMessage: 'Enabled'})}</p>
-                <p className={styles.settingDescription}>
-                  {formatMessage({defaultMessage: 'Replace the default emote picker button'})}
-                </p>
-              </div>
-            </Radio>
-            <Radio key="replace-native" value={EmoteMenuTypes.LEGACY}>
-              <div>
-                <p className={styles.heading}>{formatMessage({defaultMessage: 'Legacy'})}</p>
-                <p className={styles.settingDescription}>
-                  {formatMessage({defaultMessage: 'Emote picker button appears below chat input box'})}
-                </p>
-              </div>
-            </Radio>
-            <Radio key="none" value={EmoteMenuTypes.NONE}>
-              <div>
-                <p className={styles.heading}>{formatMessage({defaultMessage: 'None'})}</p>
-                <p className={styles.settingDescription}>
-                  {formatMessage({defaultMessage: 'Hide the emote picker button entirely'})}
-                </p>
-              </div>
-            </Radio>
-          </RadioGroup>
-        </FormGroup>
+        <Toggle checked={toggled} onChange={(state) => setValue(state ? EmoteMenuTypes.LEGACY : EmoteMenuTypes.NONE)} />
       </div>
+      {toggled ? (
+        <div className={styles.settingRow}>
+          <p className={styles.settingDescription}>
+            {formatMessage({defaultMessage: "Replace twitch's native emote menu."})}
+          </p>
+          <Toggle
+            checked={value === EmoteMenuTypes.ENABLED}
+            onChange={(state) => setValue(state ? EmoteMenuTypes.ENABLED : EmoteMenuTypes.LEGACY)}
+          />
+        </div>
+      ) : null}
     </Panel>
   );
 }

--- a/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
+++ b/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import Panel from 'rsuite/Panel';
+import Radio from 'rsuite/Radio';
+import RadioGroup from 'rsuite/RadioGroup';
+import FormGroup from 'rsuite/FormGroup';
+import {registerComponent} from '../../Store.jsx';
+import {CategoryTypes, SettingIds, EmoteMenuTypes} from '../../../../../constants.js';
+import styles from '../../../styles/header.module.css';
+import useStorageState from '../../../../../common/hooks/StorageState.jsx';
+import formatMessage from '../../../../../i18n/index.js';
+
+const SETTING_NAME = formatMessage({defaultMessage: 'Emote Menu'});
+
+function EmoteMenu() {
+  const [value, setValue] = useStorageState(SettingIds.EMOTE_MENU);
+
+  return (
+    <Panel header={SETTING_NAME}>
+      <div className={styles.setting}>
+        <p className={styles.settingDescription}>
+          {formatMessage({defaultMessage: 'Enables a more advanced emote menu for chat'})}
+        </p>
+        <FormGroup controlId="radioList">
+          <RadioGroup name="radioList" value={value} onChange={(state) => setValue(state)}>
+            <Radio key="default" value={EmoteMenuTypes.DEFAULT}>
+              <div>
+                <p className={styles.heading}>{formatMessage({defaultMessage: 'Enabled'})}</p>
+                <p className={styles.settingDescription}>
+                  {formatMessage({defaultMessage: 'Emote picker button appears below chat input box'})}
+                </p>
+              </div>
+            </Radio>
+            <Radio key="replace-native" value={EmoteMenuTypes.REPLACE_NATIVE}>
+              <div>
+                <p className={styles.heading}>{formatMessage({defaultMessage: 'Replace'})}</p>
+                <p className={styles.settingDescription}>
+                  {formatMessage({defaultMessage: 'Replace the default emote picker button'})}
+                </p>
+              </div>
+            </Radio>
+            <Radio key="none" value={EmoteMenuTypes.NONE}>
+              <div>
+                <p className={styles.heading}>{formatMessage({defaultMessage: 'None'})}</p>
+                <p className={styles.settingDescription}>
+                  {formatMessage({defaultMessage: 'Hide the emote picker button entirely'})}
+                </p>
+              </div>
+            </Radio>
+          </RadioGroup>
+        </FormGroup>
+      </div>
+    </Panel>
+  );
+}
+
+registerComponent(EmoteMenu, {
+  settingId: SettingIds.EMOTE_MENU,
+  name: SETTING_NAME,
+  category: CategoryTypes.CHAT,
+  keywords: ['twitch', 'emotes', 'popup'],
+});

--- a/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
+++ b/src/modules/settings/components/settings/twitch/EmoteMenu.jsx
@@ -42,5 +42,5 @@ registerComponent(EmoteMenu, {
   settingId: SettingIds.EMOTE_MENU,
   name: SETTING_NAME,
   category: CategoryTypes.CHAT,
-  keywords: ['twitch', 'emotes', 'popup'],
+  keywords: ['emotes', 'popup'],
 });

--- a/src/modules/settings/components/settings/youtube/EmoteMenu.jsx
+++ b/src/modules/settings/components/settings/youtube/EmoteMenu.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Panel from 'rsuite/Panel';
 import Toggle from 'rsuite/Toggle';
 import {registerComponent} from '../../Store.jsx';
-import {CategoryTypes, SettingIds} from '../../../../../constants.js';
+import {SettingIds, CategoryTypes, EmoteMenuTypes} from '../../../../../constants.js';
 import styles from '../../../styles/header.module.css';
 import useStorageState from '../../../../../common/hooks/StorageState.jsx';
 import formatMessage from '../../../../../i18n/index.js';
@@ -10,7 +10,8 @@ import formatMessage from '../../../../../i18n/index.js';
 const SETTING_NAME = formatMessage({defaultMessage: 'Emote Menu'});
 
 function EmoteMenu() {
-  const [emoteMenuValue, setEmoteMenuValue] = useStorageState(SettingIds.EMOTE_MENU);
+  const [value, setValue] = useStorageState(SettingIds.EMOTE_MENU);
+  const isEnabled = value !== EmoteMenuTypes.NONE;
 
   return (
     <Panel header={SETTING_NAME}>
@@ -18,7 +19,10 @@ function EmoteMenu() {
         <p className={styles.settingDescription}>
           {formatMessage({defaultMessage: 'Enables a more advanced emote menu for chat'})}
         </p>
-        <Toggle checked={emoteMenuValue} onChange={(state) => setEmoteMenuValue(state)} />
+        <Toggle
+          checked={isEnabled}
+          onChange={(state) => setValue(state ? EmoteMenuTypes.DEFAULT : EmoteMenuTypes.NONE)}
+        />
       </div>
     </Panel>
   );
@@ -28,5 +32,5 @@ registerComponent(EmoteMenu, {
   settingId: SettingIds.EMOTE_MENU,
   name: SETTING_NAME,
   category: CategoryTypes.CHAT,
-  keywords: ['twitch', 'emotes', 'popup'],
+  keywords: ['youtube', 'emotes', 'popup'],
 });

--- a/src/modules/settings/components/settings/youtube/EmoteMenu.jsx
+++ b/src/modules/settings/components/settings/youtube/EmoteMenu.jsx
@@ -21,7 +21,7 @@ function EmoteMenu() {
         </p>
         <Toggle
           checked={isEnabled}
-          onChange={(state) => setValue(state ? EmoteMenuTypes.DEFAULT : EmoteMenuTypes.NONE)}
+          onChange={(state) => setValue(state ? EmoteMenuTypes.ENABLED : EmoteMenuTypes.NONE)}
         />
       </div>
     </Panel>

--- a/src/modules/settings/components/settings/youtube/EmoteMenu.jsx
+++ b/src/modules/settings/components/settings/youtube/EmoteMenu.jsx
@@ -32,5 +32,5 @@ registerComponent(EmoteMenu, {
   settingId: SettingIds.EMOTE_MENU,
   name: SETTING_NAME,
   category: CategoryTypes.CHAT,
-  keywords: ['youtube', 'emotes', 'popup'],
+  keywords: ['emotes', 'popup'],
 });

--- a/src/modules/settings/pages/ChannelSettings.jsx
+++ b/src/modules/settings/pages/ChannelSettings.jsx
@@ -7,8 +7,8 @@ import styles from '../styles/header.module.css';
 import CloseButton from '../components/CloseButton.jsx';
 import formatMessage from '../../../i18n/index.js';
 
-function ChannelSettings({onClose}) {
-  const [search, setSearch] = useState('');
+function ChannelSettings({onClose, defaultSearchInput}) {
+  const [search, setSearch] = useState(defaultSearchInput ?? '');
 
   return (
     <>

--- a/src/modules/settings/pages/ChatSettings.jsx
+++ b/src/modules/settings/pages/ChatSettings.jsx
@@ -7,8 +7,8 @@ import styles from '../styles/header.module.css';
 import CloseButton from '../components/CloseButton.jsx';
 import formatMessage from '../../../i18n/index.js';
 
-function ChatSettings({onClose}) {
-  const [search, setSearch] = useState('');
+function ChatSettings({onClose, defaultSearchInput}) {
+  const [search, setSearch] = useState(defaultSearchInput ?? '');
 
   return (
     <>

--- a/src/modules/settings/pages/DirectorySettings.jsx
+++ b/src/modules/settings/pages/DirectorySettings.jsx
@@ -7,8 +7,8 @@ import styles from '../styles/header.module.css';
 import CloseButton from '../components/CloseButton.jsx';
 import formatMessage from '../../../i18n/index.js';
 
-function DirectorySettings({onClose}) {
-  const [search, setSearch] = useState('');
+function DirectorySettings({onClose, defaultSearchInput}) {
+  const [search, setSearch] = useState(defaultSearchInput ?? '');
 
   return (
     <>

--- a/src/modules/settings/twitch/Settings.jsx
+++ b/src/modules/settings/twitch/Settings.jsx
@@ -92,8 +92,8 @@ export default class SettingsModule {
     dropdownIconAspect.appendChild(bttvSettingsIconDropDown);
   }
 
-  openSettings(e) {
-    e.preventDefault();
-    handleOpen?.(true);
+  openSettings(e, defaultSearchInput = '') {
+    e?.preventDefault?.();
+    handleOpen?.(true, defaultSearchInput);
   }
 }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,6 +1,6 @@
 import SafeEventEmitter from './utils/safe-event-emitter.js';
 import storage from './storage.js';
-import {SettingIds, FlagSettings, SettingDefaultValues, ChatFlags} from './constants.js';
+import {SettingIds, FlagSettings, SettingDefaultValues, ChatFlags, EmoteMenuTypes} from './constants.js';
 import {getChangedFlags, setFlag} from './utils/flags.js';
 
 export const SETTINGS_STORAGE_KEY = 'settings';
@@ -22,10 +22,11 @@ class Settings extends SafeEventEmitter {
     const oldSettings = storage.get(SETTINGS_STORAGE_KEY);
     settings = {...defaultSettings, ...oldSettings};
 
-    for (const [key, value] of Object.entries(settings)) {
-      if (typeof value === 'function') {
-        settings[key] = value(settings);
-      }
+    if (oldSettings != null && oldSettings.version !== process.env.EXT_VER) {
+      const oldEmoteMenuValue = oldSettings[SettingIds.LEGACY_EMOTE_MENU];
+      const emoteMenuValue = oldEmoteMenuValue ? EmoteMenuTypes.LEGACY : EmoteMenuTypes.NONE;
+      settings = {...settings, [SettingIds.EMOTE_MENU]: emoteMenuValue};
+      delete settings[SettingIds.LEGACY_EMOTE_MENU];
     }
 
     if (oldSettings == null || (oldSettings != null && oldSettings.version == null)) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -61,6 +61,10 @@ class Settings extends SafeEventEmitter {
     }
 
     const updatedSettings = {...settings, [id]: storageValue, version: process.env.EXT_VER};
+    if (storageValue == null) {
+      delete updatedSettings[id];
+    }
+
     settings = updatedSettings;
 
     const storageSettings = {...updatedSettings};

--- a/src/settings.js
+++ b/src/settings.js
@@ -81,7 +81,7 @@ class Settings extends SafeEventEmitter {
     if (version !== process.env.EXT_VER) {
       const oldEmoteMenuValue = this.get(SettingIds.LEGACY_EMOTE_MENU);
       if (oldEmoteMenuValue != null) {
-        const emoteMenuValue = oldEmoteMenuValue ? EmoteMenuTypes.LEGACY : EmoteMenuTypes.NONE;
+        const emoteMenuValue = oldEmoteMenuValue ? EmoteMenuTypes.LEGACY_ENABLED : EmoteMenuTypes.NONE;
         // now storing emote menu as an enum rather than a boolean
         this.set(SettingIds.EMOTE_MENU, emoteMenuValue);
         this.set(SettingIds.LEGACY_EMOTE_MENU, undefined);

--- a/src/settings.js
+++ b/src/settings.js
@@ -22,6 +22,12 @@ class Settings extends SafeEventEmitter {
     const oldSettings = storage.get(SETTINGS_STORAGE_KEY);
     settings = {...defaultSettings, ...oldSettings};
 
+    for (const [key, value] of Object.entries(settings)) {
+      if (typeof value === 'function') {
+        settings[key] = value(settings);
+      }
+    }
+
     if (oldSettings == null || (oldSettings != null && oldSettings.version == null)) {
       settings = {...settings, version: process.env.EXT_VER};
       storage.set(SETTINGS_STORAGE_KEY, settings);

--- a/src/settings.js
+++ b/src/settings.js
@@ -88,7 +88,7 @@ class Settings extends SafeEventEmitter {
         const emoteMenuValue = oldEmoteMenuValue ? EmoteMenuTypes.LEGACY_ENABLED : EmoteMenuTypes.NONE;
         // now storing emote menu as an enum rather than a boolean
         this.set(SettingIds.EMOTE_MENU, emoteMenuValue);
-        this.set(SettingIds.LEGACY_EMOTE_MENU, undefined);
+        this.set(SettingIds.LEGACY_EMOTE_MENU, null);
       }
     }
 


### PR DESCRIPTION
PR Changes:
- Migrates legacy setting to allow replacing the native emote menu button
- Reworks some default setting value logic to migrate past settings
- Future installations will have the emote menu defaultly enabled
- Adds tip to give users option to replace default emote picker button