### PR TITLE
Kick.com base, Global Emotes Support

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -253,6 +253,7 @@ export const PlatformTypes = {
   TWITCH: 1,
   TWITCH_CLIPS: 2,
   YOUTUBE: 3,
+  KICK: 4,
 };
 
 export const EMOTE_MENU_SIDEBAR_ROW_HEIGHT = 36;

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@
       'embed.twitch.tv',
       'www.youtube.com',
       'studio.youtube.com',
+      'www.kick.com',
+      'kick.com',
     ].includes(window.location.hostname) &&
     !window.location.hostname.endsWith('.release.twitch.tv')
   )

--- a/src/modules/kick/index.js
+++ b/src/modules/kick/index.js
@@ -1,0 +1,51 @@
+import chat from '../chat/index.js';
+import settings from '../../settings.js';
+import watcher from '../../watcher.js';
+import {EmoteTypeFlags, PlatformTypes, SettingIds} from '../../constants.js';
+import {loadModuleForPlatforms} from '../../utils/modules.js';
+import {hasFlag} from '../../utils/flags.js';
+
+const CHAT_MESSAGE_SELECTOR = '.chat-entry-content';
+const CHAT_BADGES_CONTAINER_SELECTOR = '#chat-badges';
+
+class KickModule {
+  constructor() {
+    watcher.on('load.kick', () => this.load());
+    watcher.on('kick.message', (el, messageObj) => this.parseMessage(el, messageObj));
+  }
+
+  load() {}
+
+  parseMessage(element) {
+    /* Only has global emote support currently */
+    const mockUser = {
+      id: null,
+      name: null,
+      displayName: null,
+    };
+
+    const emotesSettingValue = settings.get(SettingIds.EMOTES);
+    const handleAnimatedEmotes =
+      !hasFlag(emotesSettingValue, EmoteTypeFlags.ANIMATED_PERSONAL_EMOTES) ||
+      !hasFlag(emotesSettingValue, EmoteTypeFlags.ANIMATED_EMOTES);
+    if (handleAnimatedEmotes) {
+      element.addEventListener('mousemove', chat.handleEmoteMouseEvent);
+    }
+
+    const customBadges = chat.customBadges(mockUser);
+    const badgesContainer = element.querySelector(CHAT_BADGES_CONTAINER_SELECTOR);
+    if (
+      customBadges.length > 0 &&
+      badgesContainer != null &&
+      element.getElementsByClassName(customBadges[0].className)[0] == null
+    ) {
+      for (const badge of customBadges) {
+        badgesContainer.after(badge);
+      }
+    }
+
+    chat.messageReplacer(element.querySelector(CHAT_MESSAGE_SELECTOR), mockUser);
+  }
+}
+
+export default loadModuleForPlatforms([PlatformTypes.KICK, () => new KickModule()]);

--- a/src/modules/kick/style.css
+++ b/src/modules/kick/style.css
@@ -1,0 +1,5 @@
+.chat-entry .bttv-tooltip {
+	background-color: var(--toastify-toast-background);
+	color: var(--toastify-color-dark);
+	font-size: 0.7rem;
+}

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -16,6 +16,8 @@ export function getPlatform() {
     platform = PlatformTypes.TWITCH_CLIPS;
   } else if (hostname.endsWith('.twitch.tv')) {
     platform = PlatformTypes.TWITCH;
+  } else if (hostname.endsWith('kick.com')) {
+    platform = PlatformTypes.KICK;
   } else {
     throw new Error('unsupported platform');
   }
@@ -57,6 +59,10 @@ export function isStandaloneWindow() {
 
   if (currentPlatform === PlatformTypes.YOUTUBE) {
     return window.location.pathname.endsWith('/live_chat');
+  }
+
+  if (currentPlatform === PlatformTypes.KICK) {
+    return window.location.pathname.endsWith('/chatroom');
   }
 
   return false;

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -17,6 +17,8 @@ class Watcher extends SafeEventEmitter {
       (await import('./watchers/chat.js')).default(this);
       (await import('./watchers/conversations.js')).default(this);
       (await import('./watchers/routes.js')).default(this);
+    } else if (platform === PlatformTypes.KICK) {
+      (await import('./watchers/kick.js')).default(this);
     }
 
     debug.log('Watcher started');

--- a/src/watchers/kick.js
+++ b/src/watchers/kick.js
@@ -1,0 +1,18 @@
+import domObserver from '../observers/dom.js';
+
+export default function kickWatcher(watcher) {
+  function processMessageNode(node) {
+    if (node == null) {
+      return;
+    }
+
+    watcher.emit('kick.message', node, node.__data);
+  }
+
+  domObserver.on('.chat-entry', (node, isConnected) => {
+    if (!isConnected) return;
+    processMessageNode(node);
+  });
+
+  watcher.emit('load.kick');
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,7 @@ export default async (env, argv) => {
   return {
     devServer: {
       port: PORT,
-      allowedHosts: ['127.0.0.1', '.twitch.tv', '.youtube.com'],
+      allowedHosts: ['127.0.0.1', '.twitch.tv', '.youtube.com', '.kick.com'],
       devMiddleware: {
         writeToDisk: true,
       },


### PR DESCRIPTION
Hi! This PR adds base kick.com support for bttv. It currently only supports BTTV Global Emotes.
![image](https://user-images.githubusercontent.com/32551454/235281833-ee32891f-28be-4d22-a2f5-5640647b40d4.png)

The additions follow the same styles as the addition of youtube. It makes minimal adjustments and relies on existing emote replacement functionality. 

Adds the following:
- Adds a kick.com watcher and module
- Adds kick message emitter
- Processes message node usuing chat.messageReplacer
- Configures css for kick messages

Im unsure on whether or not BTTV has plans for kick, but if so, this would be a start.