### PR TITLE
Fetch correct flags object from 7tv global emote response

### DIFF
--- a/src/modules/seventv/global-emotes.js
+++ b/src/modules/seventv/global-emotes.js
@@ -40,8 +40,7 @@ class SevenTVGlobalEmotes extends AbstractEmotes {
         for (const {
           id,
           name: code,
-          flags,
-          data: {listed, animated, owner},
+          data: {listed, animated, owner, flags},
         } of globalEmotes) {
           if (!listed && !hasFlag(settings.get(SettingIds.EMOTES), EmoteTypeFlags.SEVENTV_UNLISTED_EMOTES)) {
             continue;


### PR DESCRIPTION
The incorrect flags object is currently being fetched for 7tv global emotes.

In this example we are looking at RainTime which is an overlay emote and hence carries the flag `1 << 8`/`256`.
![image](https://github.com/night/betterttv/assets/72096833/38a78183-e631-4ff4-900c-25ebcf79f998)
