### PR TITLE
Sort tab-completion case-insensitively

### DIFF
--- a/src/modules/chat_tab_completion/index.js
+++ b/src/modules/chat_tab_completion/index.js
@@ -164,12 +164,12 @@ class ChatTabcompletionModule {
         emoteSet.add(code);
       });
       emoteList = Array.from(emoteSet);
-      emoteList.sort();
+      emoteList.sort((a, b) => a.localeCompare(b));
     }
 
     if (includeUsers) {
       userList = Array.from(this.userList).filter((word) => normalizedStartsWith(word, prefix));
-      userList.sort();
+      userList.sort((a, b) => a.localeCompare(b));
     }
 
     if (settings.get(SettingIds.TAB_COMPLETION_EMOTE_PRIORITY) === true) {


### PR DESCRIPTION
I noticed that tab-completing `cl` would bring up an emote called `CLEAN` before `Clap` on a channel I was watching. I believe this should fix it.