### PR TITLE
New option: Enable hypechat

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -93,6 +93,7 @@ export const ChatFlags = {
   SUB_NOTICE: 1 << 4,
   COMMUNITY_HIGHLIGHTS: 1 << 5,
   CHAT_MESSAGE_HISTORY: 1 << 6,
+  HYPECHAT: 1 << 7,
 };
 
 export const ChannelPointsFlags = {
@@ -234,7 +235,8 @@ export const SettingDefaultValues = {
       ChatFlags.COMMUNITY_HIGHLIGHTS |
       ChatFlags.SUB_NOTICE |
       ChatFlags.VIEWER_GREETING |
-      ChatFlags.CHAT_MESSAGE_HISTORY,
+      ChatFlags.CHAT_MESSAGE_HISTORY |
+      ChatFlags.HYPECHAT,
     0,
   ],
   [SettingIds.AUTO_PLAY]: [

--- a/src/i18n/messages/de-DE.json
+++ b/src/i18n/messages/de-DE.json
@@ -286,5 +286,6 @@
   "zTSLs0": "Gebe den aktualisierten Nicknamen von {name} ein (leer lassen zum Zurücksetzen)",
   "zb3gic": "BetterTTV Pro Abonnent",
   "zdP5KO": "Chatverlauf löschen",
-  "zgSj28": "Bewegt den Chat auf die linke Seite des Players."
+  "zgSj28": "Bewegt den Chat auf die linke Seite des Players.",
+  "ytF97Q": "Hypechat im Chatfenster anzeigen"
 }

--- a/src/modules/hide_hypechat/index.js
+++ b/src/modules/hide_hypechat/index.js
@@ -1,0 +1,17 @@
+import {ChatFlags, PlatformTypes, SettingIds} from '../../constants.js';
+import settings from '../../settings.js';
+import {hasFlag} from '../../utils/flags.js';
+import {loadModuleForPlatforms} from '../../utils/modules.js';
+
+class HideHypeChatModule {
+  constructor() {
+    settings.on(`changed.${SettingIds.CHAT}`, () => this.load());
+    this.load();
+  }
+
+  load() {
+    document.body.classList.toggle('bttv-hide-hypechat', !hasFlag(settings.get(SettingIds.CHAT), ChatFlags.HYPECHAT));
+  }
+}
+
+export default loadModuleForPlatforms([PlatformTypes.TWITCH, () => new HideHypeChatModule()]);

--- a/src/modules/hide_hypechat/style.css
+++ b/src/modules/hide_hypechat/style.css
@@ -1,0 +1,7 @@
+.bttv-hide-hypechat {
+    .paid-pinned-chat-message-list,
+    button[aria-label="Hype-Chat"]  {
+      display: none !important;
+    }
+  }
+  

--- a/src/modules/settings/components/settings/twitch/Chat.jsx
+++ b/src/modules/settings/components/settings/twitch/Chat.jsx
@@ -65,6 +65,12 @@ function ChatModule() {
               })}
             </p>
           </Checkbox>
+          <Checkbox key="hypeChat" value={ChatFlags.HYPECHAT}>
+            <p className={styles.heading}>{formatMessage({defaultMessage: 'HypeChat'})}</p>
+            <p className={styles.settingDescription}>
+              {formatMessage({defaultMessage: 'Show hype chat in the chat window'})}
+            </p>
+          </Checkbox>
         </CheckboxGroup>
       </div>
     </Panel>

--- a/src/utils/legacy-settings.js
+++ b/src/utils/legacy-settings.js
@@ -61,6 +61,7 @@ const LegacySettingIds = {
   DELETED_MESSAGES: 'deletedMessages',
   BLACKLIST_KEYWORDS: 'blacklistKeywords',
   HIGHLIGHT_KEYWORDS: 'highlightKeywords',
+  HIDE_HYPECHAT: 'hideHypeChat',
 };
 
 function deserializeSettingForLegacy(data, settingId) {
@@ -111,6 +112,8 @@ function deserializeSettingForLegacy(data, settingId) {
       return !data[LegacySettingIds.DISABLE_USERNAME_COLORS];
     case SettingIds.BITS:
       return !data[LegacySettingIds.HIDE_BITS];
+    case SettingIds.HYPECHAT:
+        return !data[LegacySettingIds.HIDE_HYPECHAT];
     case SettingIds.CHAT_CLIPS:
       return !data[LegacySettingIds.HIDE_CHAT_CLIPS];
     case SettingIds.NEW_VIEWER_GREETING:
@@ -155,6 +158,7 @@ function deserializeSettingForLegacy(data, settingId) {
       const hideNewViewerGreeting = data[LegacySettingIds.HIDE_NEW_VIEWER_GREETING] || false;
       const hideSubscriptionNotices = data[LegacySettingIds.HIDE_SUBSCRIPTION_NOTICES] || false;
       const hideCommunityHighlights = data[LegacySettingIds.HIDE_COMMUNITY_HIGHLIGHTS] || false;
+      const hideHypeChat = data[LegacySettingIds.HIDE_HYPECHAT] || false;
 
       let flags = setFlag(0, ChatFlags.CHAT_REPLIES, !hideChatReplies);
       flags = setFlag(flags, ChatFlags.BITS, !hideBits);
@@ -162,6 +166,7 @@ function deserializeSettingForLegacy(data, settingId) {
       flags = setFlag(flags, ChatFlags.VIEWER_GREETING, !hideNewViewerGreeting);
       flags = setFlag(flags, ChatFlags.SUB_NOTICE, !hideSubscriptionNotices);
       flags = setFlag(flags, ChatFlags.COMMUNITY_HIGHLIGHTS, !hideCommunityHighlights);
+      flags = setFlag(flags, ChatFlags.HYPECHAT, !hideHypeChat);
       return [
         flags,
         ChatFlags.CHAT_REPLIES |


### PR DESCRIPTION
Twitch released a new "feature" a few days ago: hypechat. These are chat messages pinned for money, just like Youtube Superchat. 

Besides the huge prices of up to 600 dollars, there is the problem that the streamer can NOT disable this feature. Currently, this is only for Twitch partners, but it will definitely be coming to all channels soon.

Following the existing code for bits, you can now also hide hypechat.

More information at: https://help.twitch.tv/s/article/hype-chat-by-twitch?language=en_US
