### PR TITLE
[Fix] Render emotes in hype chat message

### DIFF
--- a/src/modules/hype_chat/index.js
+++ b/src/modules/hype_chat/index.js
@@ -1,0 +1,26 @@
+import {PlatformTypes} from '../../constants.js';
+import dom from '../../observers/dom.js';
+import {loadModuleForPlatforms} from '../../utils/modules.js';
+import twitch from '../../utils/twitch.js';
+import chat from '../chat/index.js';
+
+const HYPE_CHAT_WRAPPER_SELECTOR = '.paid-pinned-chat-message-content-wrapper';
+const HYPE_CHAT_MESSAGE_SELECTOR = 'span[data-a-target="chat-message-text"]';
+
+class HypeChatModule {
+  constructor() {
+    dom.on(HYPE_CHAT_WRAPPER_SELECTOR, (node, isConnected) => {
+      if (!isConnected) {
+        return;
+      }
+      const user = twitch.getUserFromPinnedChat(node);
+      const messageNode = node.querySelector(HYPE_CHAT_MESSAGE_SELECTOR);
+      if (messageNode == null) {
+        return;
+      }
+      chat.messageReplacer(messageNode, user);
+    });
+  }
+}
+
+export default loadModuleForPlatforms([PlatformTypes.TWITCH, () => new HypeChatModule()]);

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -802,4 +802,15 @@ export default {
     } catch (_) {}
     return context;
   },
+
+  getUserFromPinnedChat(node) {
+    let user;
+
+    try {
+      const reactNode = searchReactParents(getReactInstance(node), (n) => n?.pendingProps?.message?.pinnedBy != null);
+      user = reactNode.pendingProps.message.pinnedBy;
+    } catch (_) {}
+
+    return user;
+  },
 };


### PR DESCRIPTION
PR: renders emotes in twitch's new hype chat messages, addresses #6233

<img width="376" alt="Screenshot 2023-06-28 at 10 48 16" src="https://github.com/night/betterttv/assets/43322006/96a0962a-37c3-4231-b1c4-56900bc1e468">

@night you owe me £1