### PR TITLE
Fixed localascii command descriptions

### DIFF
--- a/src/modules/chat_commands/commands/localascii.js
+++ b/src/modules/chat_commands/commands/localascii.js
@@ -18,7 +18,7 @@ commandStore.registerCommand({
   name: 'localasciioff',
   commandArgs: [],
   description: formatMessage({
-    defaultMessage: 'Usage: "/localmod" - Turns on local mod-only mode (only your chat is mod-only mode)',
+    defaultMessage: 'Usage: "/localasciioff" - Turns on local ascii-only mode (only your chat is ascii-only mode)',
   }),
   handler: () => {
     chat.asciiOnly(false);

--- a/src/modules/chat_commands/commands/localascii.js
+++ b/src/modules/chat_commands/commands/localascii.js
@@ -6,7 +6,7 @@ import commandStore, {PermissionLevels} from '../store.js';
 commandStore.registerCommand({
   name: 'localascii',
   commandArgs: [],
-  description: formatMessage({defaultMessage: 'Usage: "/localasciioff" - Turns off local ascii-only mode'}),
+  description: formatMessage({defaultMessage: 'Usage: "/localascii" - Turns on local ascii-only mode (only your chat is ascii-only mode)'}),
   handler: () => {
     chat.asciiOnly(true);
     twitch.sendChatAdminMessage(`Local ascii-only mode enabled.`);
@@ -18,7 +18,7 @@ commandStore.registerCommand({
   name: 'localasciioff',
   commandArgs: [],
   description: formatMessage({
-    defaultMessage: 'Usage: "/localasciioff" - Turns on local ascii-only mode (only your chat is ascii-only mode)',
+    defaultMessage: 'Usage: "/localasciioff" - Turns off local ascii-only mode',
   }),
   handler: () => {
     chat.asciiOnly(false);


### PR DESCRIPTION
The /localascii and /localasciioff commands had the wrong descriptions.