### PR TITLE
Fix localsuboff

### DIFF
--- a/src/modules/chat_commands/commands/localsub.js
+++ b/src/modules/chat_commands/commands/localsub.js
@@ -17,7 +17,7 @@ commandStore.registerCommand({
 });
 
 commandStore.registerCommand({
-  name: 'localmodoff',
+  name: 'localsuboff',
   commandArgs: [],
   description: formatMessage({defaultMessage: 'Usage: "/localsuboff" - Turns off local sub-only mode'}),
   handler: () => {


### PR DESCRIPTION
At some point this must have gotten renamed, and so no longer works. At least, /localmodoff does not additionally disable localsub, as of today on firefox.