### PR TITLE
Fix cursed modifier effect spreading to tooltip

### DIFF
--- a/src/modules/chat/style.css
+++ b/src/modules/chat/style.css
@@ -47,6 +47,6 @@
   margin-left: -4px;
 }
 
-.bttv-emote-modifier-cursed {
+.bttv-emote-modifier-cursed img {
   filter: grayscale(1) brightness(0.7) contrast(2.5);
 }

--- a/src/modules/settings/components/settings/global/Emotes.jsx
+++ b/src/modules/settings/components/settings/global/Emotes.jsx
@@ -85,7 +85,7 @@ function EmotesModule() {
               {formatMessage(
                 {
                   defaultMessage:
-                    'Emote modifiers allow you to transform emotes in realtime. Wide: <code>w! emoteName</code>, Horizontal Flip: <code>h! emoteName</code>, Vertical Flip: <code>v! emoteName</code>, Zero-Width: <code>z! emoteName</code>, Rotate Left: <code>l! emoteName</code>, Rotate Right: <code>r! emoteName</code>',
+                    'Emote modifiers allow you to transform emotes in realtime. Wide: <code>w! emoteName</code>, Horizontal Flip: <code>h! emoteName</code>, Vertical Flip: <code>v! emoteName</code>, Zero-Width: <code>z! emoteName</code>, Rotate Left: <code>l! emoteName</code>, Rotate Right: <code>r! emoteName</code>, Cursed: <code>c! emoteName</code>',
                 },
                 {
                   // eslint-disable-next-line react/no-unstable-nested-components


### PR DESCRIPTION
- Fix cursed modifier effect spreading to tooltip
- Add cursed modifier (c!) to the emote modifiers setting description

Before:
![cursed_catjam_before](https://github.com/night/betterttv/assets/93066036/a6d28613-27c0-4376-91c0-532f29aabd9c)

After:
![cursed_catjam_after](https://github.com/night/betterttv/assets/93066036/a6487a7c-02b2-43d1-9db6-d86f672f71ee)
