### PR TITLE
Party Emote Modifier

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -30,6 +30,7 @@ const EMOTE_MODIFIERS = {
   'c!': 'bttv-emote-modifier-cursed',
   'l!': 'bttv-emote-modifier-rotate-left',
   'r!': 'bttv-emote-modifier-rotate-right',
+  'p!': 'bttv-emote-modifier-party',
   ffzW: 'bttv-emote-modifier-wide',
   ffzX: 'bttv-emote-modifier-flip-horizontal',
   ffzY: 'bttv-emote-modifier-flip-vertical',

--- a/src/modules/chat/style.css
+++ b/src/modules/chat/style.css
@@ -50,3 +50,16 @@
 .bttv-emote-modifier-cursed img {
   filter: grayscale(1) brightness(0.7) contrast(2.5);
 }
+
+.bttv-emote-modifier-party img {
+  animation: bttv-emote-modifier-party 1.5s linear infinite;
+}
+
+@keyframes bttv-emote-modifier-party {
+  0% {
+    filter: sepia(0.5) hue-rotate(0deg) saturate(2.5);
+  }
+  100% {
+    filter: sepia(0.5) hue-rotate(360deg) saturate(2.5);
+  }
+}

--- a/src/modules/settings/components/settings/global/Emotes.jsx
+++ b/src/modules/settings/components/settings/global/Emotes.jsx
@@ -85,7 +85,7 @@ function EmotesModule() {
               {formatMessage(
                 {
                   defaultMessage:
-                    'Emote modifiers allow you to transform emotes in realtime. Wide: <code>w! emoteName</code>, Horizontal Flip: <code>h! emoteName</code>, Vertical Flip: <code>v! emoteName</code>, Zero-Width: <code>z! emoteName</code>, Rotate Left: <code>l! emoteName</code>, Rotate Right: <code>r! emoteName</code>, Cursed: <code>c! emoteName</code>',
+                    'Emote modifiers allow you to transform emotes in realtime. Wide: <code>w! emoteName</code>, Horizontal Flip: <code>h! emoteName</code>, Vertical Flip: <code>v! emoteName</code>, Zero-Width: <code>z! emoteName</code>, Rotate Left: <code>l! emoteName</code>, Rotate Right: <code>r! emoteName</code>, Cursed: <code>c! emoteName</code>, Party: <code>p! emoteName</code>',
                 },
                 {
                   // eslint-disable-next-line react/no-unstable-nested-components


### PR DESCRIPTION
Implements a modifier `p!` which adds a "party" effect to emotes. The modifier gives the emote a rotating color change effect using a CSS `filter` that increases saturation and animates `hue-rotate()`. It also uses a bit of `sepia()` which "averages" the base emote's colors a little while also making the effect work for emotes that have a lot of white in them.

I also made the global emote for `p!` if that is helpful:
![bttv-party](https://github.com/night/betterttv/assets/50426566/93b70ed6-f82e-4586-a295-8b6f0158279f)
