### PR TITLE
Fixes #7095 Auto Leave Raids

### DIFF
--- a/src/modules/auto_join_raids/index.js
+++ b/src/modules/auto_join_raids/index.js
@@ -27,10 +27,7 @@ class AutoJoinRaidsModule {
 
   leaveRaid() {
     const leaveButton = document.querySelector(RAID_LEAVE_BUTTON_SELECTOR);
-    if (
-      leaveButton == null ||
-      ['raid-cancel-button', 'raid-now-button'].includes(leaveButton.getAttribute('data-test-selector'))
-    ) {
+    if ( leaveButton == null ) {
       return;
     }
 


### PR DESCRIPTION
According to the code and this source:
![image](https://github.com/user-attachments/assets/d6427d06-982c-4de2-bab4-3f264b3f9232)

...the condition should be changed because there are no attributes anymore.
Then the feature should work again...