### PR TITLE
7tv channel emotes overrides 7tv global emotes

### DIFF
--- a/src/modules/emotes/index.js
+++ b/src/modules/emotes/index.js
@@ -20,8 +20,8 @@ class EmotesModule {
       globalEmotes,
       frankerfacezGlobalEmotes,
       frankerfacezChannelEmotes,
-      seventvGlobalEmotes,
       seventvChannelEmotes,
+      seventvGlobalEmotes,
       emojis,
     ];
   }


### PR DESCRIPTION
Change 7tv emote behavior so that channel emotes override global emotes.
This brings BTTV's 7tv behavior inline with the official 7TV extension and Chatterino.