### PR TITLE
Fix: Twitch is Showing Live Unfollowed Channels in the Sidebar

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -80,7 +80,7 @@ export const SidebarFlags = {
   // 1 << 2: RECOMMENDED_FRIENDS,
   OFFLINE_FOLLOWED_CHANNELS: 1 << 3,
   AUTO_EXPAND_CHANNELS: 1 << 4,
-  RECENTLY_WATCHED_CHANNELS: 1 << 5,
+  // RECENTLY_WATCHED_CHANNELS: 1 << 5,
   SIMILAR_CHANNELS: 1 << 6,
   STORIES: 1 << 7,
 };
@@ -232,7 +232,6 @@ export const SettingDefaultValues = {
   [SettingIds.SIDEBAR]: [
     SidebarFlags.OFFLINE_FOLLOWED_CHANNELS |
       SidebarFlags.RECOMMENDED_CHANNELS |
-      SidebarFlags.RECENTLY_WATCHED_CHANNELS |
       SidebarFlags.SIMILAR_CHANNELS |
       SidebarFlags.STORIES,
     0,

--- a/src/modules/hide_sidebar_elements/index.js
+++ b/src/modules/hide_sidebar_elements/index.js
@@ -20,16 +20,16 @@ function toggleSidebarSectionClass(node, flags) {
   }
 
   const setting = flags ?? settings.get(SettingIds.SIDEBAR);
-  switch (sidebarSection.type) {
+  switch (sidebarSection.title.key) {
     case 'RECENTLY_VISITED_SECTION': {
       node.classList.toggle(styles.hide, !hasFlag(setting, SidebarFlags.RECENTLY_WATCHED_CHANNELS));
       break;
     }
-    case 'RECOMMENDED_SECTION': {
+    case 'LiveSectionTitle': {
       node.classList.toggle(styles.hide, !hasFlag(setting, SidebarFlags.RECOMMENDED_CHANNELS));
       break;
     }
-    case 'SIMILAR_SECTION': {
+    case 'SimilarSectionTitle': {
       node.classList.toggle(styles.hide, !hasFlag(setting, SidebarFlags.SIMILAR_CHANNELS));
       break;
     }

--- a/src/modules/hide_sidebar_elements/index.js
+++ b/src/modules/hide_sidebar_elements/index.js
@@ -21,10 +21,6 @@ function toggleSidebarSectionClass(node, flags) {
 
   const setting = flags ?? settings.get(SettingIds.SIDEBAR);
   switch (sidebarSection.title.key) {
-    case 'RECENTLY_VISITED_SECTION': {
-      node.classList.toggle(styles.hide, !hasFlag(setting, SidebarFlags.RECENTLY_WATCHED_CHANNELS));
-      break;
-    }
     case 'LiveSectionTitle': {
       node.classList.toggle(styles.hide, !hasFlag(setting, SidebarFlags.RECOMMENDED_CHANNELS));
       break;
@@ -57,10 +53,9 @@ class HideSidebarElementsModule {
 
   loadHideSidebarElements() {
     const setting = settings.get(SettingIds.SIDEBAR);
-    const hideRecentlyWatched = !hasFlag(setting, SidebarFlags.RECENTLY_WATCHED_CHANNELS);
     const hideRecommended = !hasFlag(setting, SidebarFlags.RECOMMENDED_CHANNELS);
     const hideSimilar = !hasFlag(setting, SidebarFlags.SIMILAR_CHANNELS);
-    const enabled = hideRecentlyWatched || hideRecommended || hideSimilar;
+    const enabled = hideRecommended || hideSimilar;
 
     if (enabled && sidebarSectionObserverRemover == null) {
       sidebarSectionObserverRemover = domObserver.on(sidebarSectionSelector, (node, isConnected) => {

--- a/src/modules/settings/components/settings/twitch/Sidebar.jsx
+++ b/src/modules/settings/components/settings/twitch/Sidebar.jsx
@@ -23,12 +23,6 @@ function SidebarComponent() {
         <CheckboxGroup
           value={Object.values(SidebarFlags).filter((value) => hasFlag(sidebar, value))}
           onChange={(value) => setSidebar(value.reduce((a, b) => a | b, 0))}>
-          <Checkbox key="recentlyWatchedChannels" value={SidebarFlags.RECENTLY_WATCHED_CHANNELS}>
-            <p className={styles.heading}>{formatMessage({defaultMessage: 'Recently Watched Channels'})}</p>
-            <p className={styles.settingDescription}>
-              {formatMessage({defaultMessage: 'Show recently watched channels in the sidebar'})}
-            </p>
-          </Checkbox>
           <Checkbox key="recommendedChannels" value={SidebarFlags.RECOMMENDED_CHANNELS}>
             <p className={styles.heading}>{formatMessage({defaultMessage: 'Recommended Channels'})}</p>
             <p className={styles.settingDescription}>
@@ -69,5 +63,5 @@ registerComponent(SidebarComponent, {
   settingId: SettingIds.SIDEBAR,
   name: SETTING_NAME,
   category: CategoryTypes.DIRECTORY,
-  keywords: ['sidebar', 'recently', 'watched', 'recommended', 'similar', 'offline', 'channels', 'expand', 'stories'],
+  keywords: ['sidebar', 'recommended', 'similar', 'offline', 'channels', 'expand', 'stories'],
 });

--- a/src/utils/legacy-settings.js
+++ b/src/utils/legacy-settings.js
@@ -128,11 +128,7 @@ function deserializeSettingForLegacy(data, settingId) {
       const hideOfflineFollowedChannels = data[LegacySettingIds.HIDE_OFFLINE_FOLLOWED_CHANNELS] || false;
       const autoExpand = data[LegacySettingIds.AUTO_EXPAND_CHANNELS] || false;
 
-      let flags = setFlag(
-        0,
-        SidebarFlags.RECOMMENDED_CHANNELS | SidebarFlags.RECENTLY_WATCHED_CHANNELS | SidebarFlags.SIMILAR_CHANNELS,
-        !hideFeaturedChannels
-      );
+      let flags = setFlag(0, SidebarFlags.RECOMMENDED_CHANNELS | SidebarFlags.SIMILAR_CHANNELS, !hideFeaturedChannels);
       flags = setFlag(flags, SidebarFlags.OFFLINE_FOLLOWED_CHANNELS, !hideOfflineFollowedChannels);
       flags = setFlag(flags, SidebarFlags.AUTO_EXPAND_CHANNELS, autoExpand);
       return [
@@ -140,7 +136,6 @@ function deserializeSettingForLegacy(data, settingId) {
         SidebarFlags.RECOMMENDED_CHANNELS |
           SidebarFlags.OFFLINE_FOLLOWED_CHANNELS |
           SidebarFlags.AUTO_EXPAND_CHANNELS |
-          SidebarFlags.RECENTLY_WATCHED_CHANNELS |
           SidebarFlags.SIMILAR_CHANNELS,
       ];
     }


### PR DESCRIPTION
The goal of this PR is to fix the following issue: https://github.com/night/betterttv/issues/7394

The section "Recently watched channels" seems to no longer exist: I did not retrieve the mapping value, and decided to remove the option.