### PR TITLE
Add logo/settings button to emote menu

### DIFF
--- a/src/modules/emote_menu/components/Header.jsx
+++ b/src/modules/emote_menu/components/Header.jsx
@@ -1,6 +1,6 @@
 import React, {useCallback} from 'react';
 import formatMessage from '../../../i18n/index.js';
-import {ActionIcon, CloseButton, TextInput} from '@mantine/core';
+import {CloseButton, TextInput} from '@mantine/core';
 import styles from './Header.module.css';
 import classNames from 'classnames';
 import {useFocusTrap} from '@mantine/hooks';

--- a/src/modules/emote_menu/components/Header.jsx
+++ b/src/modules/emote_menu/components/Header.jsx
@@ -1,17 +1,28 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import formatMessage from '../../../i18n/index.js';
-import {CloseButton, TextInput} from '@mantine/core';
+import {ActionIcon, CloseButton, TextInput} from '@mantine/core';
 import styles from './Header.module.css';
 import classNames from 'classnames';
 import {useFocusTrap} from '@mantine/hooks';
+import LogoIcon from '../../../common/components/LogoIcon.jsx';
+import settings from '../../settings/index.js';
 
 function Header({value, opened, onChange, toggleWhisper, selected, className, ...props}) {
   const focusRef = useFocusTrap(opened);
+
+  const handleLogoClick = useCallback(() => {
+    settings.openSettings();
+    toggleWhisper();
+  }, [toggleWhisper]);
+
   return (
     <div className={classNames(styles.header, className)} {...props}>
+      <button color="primary" variant="subtle" className={styles.logoButton} onClick={handleLogoClick}>
+        <LogoIcon className={styles.logoIcon} />
+      </button>
       <TextInput
         ref={focusRef}
-        size="lg"
+        size="md"
         placeholder={selected == null ? formatMessage({defaultMessage: 'Search for Emotes'}) : selected.code}
         value={value}
         onChange={({target: {value}}) => onChange(value)}

--- a/src/modules/emote_menu/components/Header.module.css
+++ b/src/modules/emote_menu/components/Header.module.css
@@ -12,16 +12,55 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 8px;
   background-color: var(--mantine-color-body);
 }
 
 .closeButton {
-  min-width: 36px;
-  min-height: 36px;
+  margin-right: 8px;
+  min-width: 32px;
+  min-height: 32px;
 
   svg {
     max-width: 24px;
     max-height: 24px;
   }
+}
+
+.logoButton {
+  all: unset;
+  cursor: pointer;
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 48px;
+  max-width: 47px; /* 48px - 1px border */
+  border-radius: 0;
+  border-right: 1px solid var(--mantine-color-default-border);
+  color: var(--mantine-primary-color-filled) !important;
+}
+
+.logoIcon {
+  width: 24px;
+  height: 24px;
+}
+
+.logoButton:hover::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--mantine-primary-color-light-hover);
+}
+
+.logoButton:active::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--mantine-primary-color-light-active);
 }

--- a/src/modules/emote_menu/components/Header.module.css
+++ b/src/modules/emote_menu/components/Header.module.css
@@ -11,12 +11,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 6px; /* 8px - 2px border */
   background-color: var(--mantine-color-body);
 }
 
 .closeButton {
-  margin-right: 8px;
+  margin-right: 6px;
   min-width: 32px;
   min-height: 32px;
 


### PR DESCRIPTION
<img width="317" height="207" alt="Screenshot 2026-04-22 at 09 13 10" src="https://github.com/user-attachments/assets/917ace88-41f3-42d8-9902-25402b23047e" />

PR adds new button that opens settings-menu upon clicked