### PR TITLE
Fix numerous quirks and emote menu issues

### DIFF
--- a/src/common/stores/emote-menu-view-store.js
+++ b/src/common/stores/emote-menu-view-store.js
@@ -118,6 +118,10 @@ class EmoteMenuViewStore extends SafeEventEmitter {
       cols = Math.floor((width - EMOTE_MENU_WINDOW_MARGIN) / EMOTE_MENU_COLUMN_WIDTH);
     }
 
+    if (this.totalCols === cols) {
+      return;
+    }
+
     this.totalCols = Math.max(1, cols);
     this.markDirty(false);
   }

--- a/src/modules/emote_menu/components/EmoteList.jsx
+++ b/src/modules/emote_menu/components/EmoteList.jsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo} from 'react';
 import {NavigationModeTypes, EMOTE_MENU_GRID_ROW_HEIGHT} from '../../../constants.js';
 import useGridKeyboardNavigation from '../hooks/GridKeyboardNavigation.jsx';
 import EmoteButton from './EmoteButton.jsx';

--- a/src/modules/emote_menu/components/EmoteList.jsx
+++ b/src/modules/emote_menu/components/EmoteList.jsx
@@ -1,66 +1,19 @@
 import classNames from 'classnames';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {NavigationModeTypes, EMOTE_MENU_GRID_ROW_HEIGHT} from '../../../constants.js';
 import useGridKeyboardNavigation from '../hooks/GridKeyboardNavigation.jsx';
 import EmoteButton from './EmoteButton.jsx';
 import Icons from './Icons.jsx';
 import VirtualizedList from './VirtualizedList.jsx';
 import Preview from './Preview.jsx';
-import {mergeRefs, useElementSize, useMergedRef} from '@mantine/hooks';
+import {useElementSize, useMergedRef} from '@mantine/hooks';
 import {Text} from '@mantine/core';
 import styles from './EmoteList.module.css';
 import scrollbarStyles from '../../../common/styles/Scrollbar.module.css';
+import {getEmoteKey, getRowColumnCounts} from '../utils/emote-list-grid.js';
+import emoteMenuViewStore from '../../../common/stores/emote-menu-view-store.js';
 
 const GUARD_HEIGHT = 8;
-
-function getEmoteKey(emote) {
-  return `${emote.category.id}-${emote.id}`;
-}
-
-function getRowColumnCounts(emoteListRows) {
-  return emoteListRows.map((row) => (!Array.isArray(row) ? 0 : row.length));
-}
-
-function getSelectedAtCoords(emoteListRows, coords) {
-  const row = emoteListRows[coords.y];
-  const cell = row?.[coords.x];
-  return cell != null ? cell : null;
-}
-
-function getCoordsOfSelected(emoteListRows, selected) {
-  if (selected == null) {
-    return null;
-  }
-
-  for (let y = 0; y < emoteListRows.length; y++) {
-    if (!Array.isArray(emoteListRows[y])) {
-      continue;
-    }
-
-    for (let x = 0; x < emoteListRows[y].length; x++) {
-      if (getEmoteKey(emoteListRows[y][x]) === getEmoteKey(selected)) {
-        return {y, x};
-      }
-    }
-  }
-
-  return null;
-}
-
-function getFirstCoords(emoteListRows) {
-  for (let y = 0; y < emoteListRows.length; y++) {
-    if (!Array.isArray(emoteListRows[y])) {
-      continue;
-    }
-
-    for (let x = 0; x < emoteListRows[y].length; x++) {
-      if (emoteListRows[y][x] != null) {
-        return {y, x};
-      }
-    }
-  }
-  return null;
-}
 
 function HeaderRow({style, className, row}) {
   return (
@@ -91,14 +44,14 @@ function EmoteRow({style, className, row, rowIndex: y, coords, onClick, onMouseO
   );
 }
 
-function EmptySearchState() {
+const EmptySearchState = React.forwardRef((props, ref) => {
   return (
-    <div className={styles.empty}>
+    <div className={styles.empty} ref={ref}>
       <div className={styles.emptyIcon}>{Icons.HEART_BROKEN}</div>
       <Text c="dimmed">No results...</Text>
     </div>
   );
-}
+});
 
 const BrowseEmotes = React.forwardRef(
   (
@@ -154,7 +107,7 @@ const BrowseEmotes = React.forwardRef(
     );
 
     if (emoteListRows.length === 0) {
-      return <EmptySearchState />;
+      return <EmptySearchState ref={ref} />;
     }
 
     return (
@@ -163,7 +116,6 @@ const BrowseEmotes = React.forwardRef(
         bottomGuardHeight={GUARD_HEIGHT}
         stickyRows={headerRows}
         rowHeight={EMOTE_MENU_GRID_ROW_HEIGHT}
-        windowHeight={windowHeight}
         totalRows={emoteListRows.length}
         renderRow={renderRow}
         className={classNames(styles.emotesContainer, className, scrollbarStyles.scroll)}
@@ -174,31 +126,79 @@ const BrowseEmotes = React.forwardRef(
 );
 
 const EmoteList = React.forwardRef(
-  ({data, onClick, selected, setSelected, section, onSection, setKeyPressCallback, className}, ref) => {
+  (
+    {
+      data,
+      onClick,
+      selected,
+      section,
+      onSection,
+      setKeyPressCallback,
+      className,
+      coords,
+      setCoords,
+      setNavigationMode,
+      navigationMode,
+    },
+    ref
+  ) => {
     const {rows, totalCols} = data;
-    const {ref: listViewportRef, height} = useElementSize();
+    const {ref: listViewportRef, height, width} = useElementSize();
     const mergedRef = useMergedRef(ref, listViewportRef);
-    const [coords, setCoords] = useState({x: 0, y: 0});
     const rowColumnCounts = useMemo(() => getRowColumnCounts(rows), [rows]);
-    const [navigationMode, setNavigationMode] = useState(NavigationModeTypes.MOUSE);
     const handleMouseMove = useCallback(() => setNavigationMode(NavigationModeTypes.MOUSE), [setNavigationMode]);
 
-    const handleCoordsChange = useCallback(
+    const headerRows = useMemo(() => {
+      return rows
+        .map((row, index) => ({isHeader: !Array.isArray(row), index}))
+        .filter((row) => row.isHeader)
+        .map((row) => row.index);
+    }, [rows]);
+
+    useEffect(() => {
+      const currentRef = listViewportRef.current;
+      if (currentRef == null) {
+        return;
+      }
+
+      const clientWidth = currentRef.clientWidth;
+      emoteMenuViewStore.updateTotalColumns(clientWidth);
+    }, [listViewportRef, width]);
+
+    const updateScrollPositionByCoords = useCallback(
       (newCoords) => {
-        if (rows.length === 0) {
+        const currentRef = ref.current;
+        if (navigationMode !== NavigationModeTypes.ARROW_KEYS || currentRef == null) {
           return;
         }
 
-        if (newCoords == null) {
-          newCoords = getFirstCoords(rows);
+        const depth = newCoords.y * EMOTE_MENU_GRID_ROW_HEIGHT;
+        const {scrollTop} = currentRef;
+
+        let isPreceededByHeader = false;
+
+        if (headerRows.length > 0) {
+          const firstHeaderRowY = headerRows[0] * EMOTE_MENU_GRID_ROW_HEIGHT;
+          isPreceededByHeader = firstHeaderRowY < depth;
         }
 
-        const selected = getSelectedAtCoords(rows, newCoords);
+        if (depth < scrollTop + EMOTE_MENU_GRID_ROW_HEIGHT) {
+          currentRef.scrollTo(0, isPreceededByHeader ? depth - EMOTE_MENU_GRID_ROW_HEIGHT : depth);
+        }
 
-        setSelected(selected);
-        setCoords(newCoords);
+        if (depth + EMOTE_MENU_GRID_ROW_HEIGHT >= scrollTop + height) {
+          currentRef.scrollTo(0, depth + EMOTE_MENU_GRID_ROW_HEIGHT - height);
+        }
       },
-      [setCoords, setSelected, rows]
+      [navigationMode, height, headerRows]
+    );
+
+    const handleCoordsChange = useCallback(
+      (newCoords) => {
+        setCoords(newCoords);
+        updateScrollPositionByCoords(newCoords);
+      },
+      [updateScrollPositionByCoords]
     );
 
     const {handleKeyPress} = useGridKeyboardNavigation({
@@ -210,45 +210,8 @@ const EmoteList = React.forwardRef(
     });
 
     useEffect(() => {
-      const coords = getCoordsOfSelected(rows, selected);
-      handleCoordsChange(coords);
-    }, [rows]);
-
-    const headerRows = useMemo(() => {
-      return rows
-        .map((row, index) => ({isHeader: !Array.isArray(row), index}))
-        .filter((row) => row.isHeader)
-        .map((row) => row.index);
-    }, [rows]);
-
-    useEffect(() => {
       setKeyPressCallback(handleKeyPress);
     }, [handleKeyPress]);
-
-    useEffect(() => {
-      const currentRef = ref.current;
-      if (navigationMode !== NavigationModeTypes.ARROW_KEYS || currentRef == null) {
-        return;
-      }
-
-      const depth = coords.y * EMOTE_MENU_GRID_ROW_HEIGHT;
-      const {scrollTop} = currentRef;
-
-      let isPreceededByHeader = false;
-
-      if (headerRows.length > 0) {
-        const firstHeaderRowY = headerRows[0] * EMOTE_MENU_GRID_ROW_HEIGHT;
-        isPreceededByHeader = firstHeaderRowY < depth;
-      }
-
-      if (depth < scrollTop + EMOTE_MENU_GRID_ROW_HEIGHT) {
-        currentRef.scrollTo(0, isPreceededByHeader ? depth - EMOTE_MENU_GRID_ROW_HEIGHT : depth);
-      }
-
-      if (depth + EMOTE_MENU_GRID_ROW_HEIGHT >= scrollTop + height) {
-        currentRef.scrollTo(0, depth + EMOTE_MENU_GRID_ROW_HEIGHT - height);
-      }
-    }, [coords, navigationMode, height, headerRows]);
 
     return (
       <div className={classNames(styles.emoteListRoot, className)} onMouseMove={handleMouseMove}>
@@ -260,7 +223,7 @@ const EmoteList = React.forwardRef(
           emoteListRows={rows}
           navigationMode={navigationMode}
           coords={coords}
-          setCoords={handleCoordsChange}
+          setCoords={setCoords}
           windowHeight={height}
           headerRows={headerRows}
         />
@@ -273,13 +236,16 @@ const EmoteList = React.forwardRef(
 export default React.memo(EmoteList, (prevProps, nextProps) => {
   return (
     prevProps.selected === nextProps.selected &&
-    prevProps.setSelected === nextProps.setSelected &&
     prevProps.onClick === nextProps.onClick &&
     prevProps.setKeyPressCallback === nextProps.setKeyPressCallback &&
     prevProps.data.rows === nextProps.data.rows &&
     prevProps.data.totalCols === nextProps.data.totalCols &&
     prevProps.className === nextProps.className &&
     prevProps.section === nextProps.section &&
-    prevProps.onSection === nextProps.onSection
+    prevProps.onSection === nextProps.onSection &&
+    prevProps.coords === nextProps.coords &&
+    prevProps.setCoords === nextProps.setCoords &&
+    prevProps.setNavigationMode === nextProps.setNavigationMode &&
+    prevProps.navigationMode === nextProps.navigationMode
   );
 });

--- a/src/modules/emote_menu/components/EmoteList.jsx
+++ b/src/modules/emote_menu/components/EmoteList.jsx
@@ -216,6 +216,7 @@ const EmoteList = React.forwardRef(
     return (
       <div className={classNames(styles.emoteListRoot, className)} onMouseMove={handleMouseMove}>
         <BrowseEmotes
+          key={data.search}
           ref={mergedRef}
           section={section}
           onSection={onSection}

--- a/src/modules/emote_menu/components/EmoteMenu.jsx
+++ b/src/modules/emote_menu/components/EmoteMenu.jsx
@@ -86,7 +86,7 @@ function EmoteMenu({
   const {refs, floatingStyles, context} = useFloating({
     strategy: 'fixed',
     open: opened,
-    onOpenChange: (isOpen) => (isOpen ? handleOpen() : close()),
+    onOpenChange: (isOpen) => (isOpen ? handleOpen() : handleClose()),
     placement: 'top-end',
     middleware: [offset(offsetOptions)],
     whileElementsMounted: autoUpdate,
@@ -114,22 +114,7 @@ function EmoteMenu({
 
     const chatTextArea = document.querySelector(boundingQuerySelector);
     refs.setPositionReference(chatTextArea);
-
-    const currentEmoteListData = emoteListDataRef.current;
-    if (currentEmoteListData.rows.length === 0) {
-      return;
-    }
-
-    const firstCoords = getFirstCoords(currentEmoteListData.rows);
-    if (firstCoords != null) {
-      handleCoordsChange(firstCoords);
-    }
-
-    handleScrollToPendingRow(0);
-    setNavigationMode(NavigationModeTypes.ARROW_KEYS);
-  }, [open, handleCoordsChange, boundingQuerySelector, refs]);
-
-  const toggle = useCallback(() => (opened ? close() : handleOpen()), [opened, close, open]);
+  }, [open, boundingQuerySelector, refs]);
 
   const handleScrollToPendingRow = useCallback((pendingScrollRowIndex) => {
     const listEl = emoteListRef.current;
@@ -145,6 +130,25 @@ function EmoteMenu({
     const scrollTop = pendingScrollRowIndex * EMOTE_MENU_GRID_ROW_HEIGHT + 1;
     listEl.scrollTo(0, scrollTop);
   }, []);
+
+  const handleClose = useCallback(() => {
+    close();
+
+    const currentEmoteListData = emoteListDataRef.current;
+    if (currentEmoteListData.rows.length === 0) {
+      return;
+    }
+
+    const firstCoords = getFirstCoords(currentEmoteListData.rows);
+    if (firstCoords != null) {
+      handleCoordsChange(firstCoords);
+    }
+
+    handleScrollToPendingRow(0);
+    setNavigationMode(NavigationModeTypes.ARROW_KEYS);
+  }, [close, handleCoordsChange, handleScrollToPendingRow]);
+
+  const toggle = useCallback(() => (opened ? handleClose() : handleOpen()), [opened, handleClose, handleOpen]);
 
   const updateEmoteListData = useCallback((currentSearch = '') => {
     let rows = emoteMenuViewStore.rows;
@@ -224,9 +228,9 @@ function EmoteMenu({
         return;
       }
 
-      close();
+      handleClose();
     },
-    [close]
+    [handleClose]
   );
 
   const handleKeyEvent = useCallback((event) => {
@@ -329,7 +333,7 @@ function EmoteMenu({
           setCoords={handleCoordsChange}
         />
       </div>
-      {opened ? <Tip className={styles.tip} onClose={close} /> : null}
+      {opened ? <Tip className={styles.tip} onClose={handleClose} /> : null}
     </div>
   );
 }

--- a/src/modules/emote_menu/components/EmoteMenu.jsx
+++ b/src/modules/emote_menu/components/EmoteMenu.jsx
@@ -162,7 +162,7 @@ function EmoteMenu({
     updateEmoteListData('');
     setSection(null);
     handleCoordsChange(null);
-  }, [updateEmoteListData, handleCoordsChange, handleScrollToPendingRow, setSection, close, setNavigationMode]);
+  }, [updateEmoteListData, handleCoordsChange, setSection, close, setNavigationMode]);
 
   const toggle = useCallback(() => (opened ? handleClose() : handleOpen()), [opened, handleClose, handleOpen]);
 

--- a/src/modules/emote_menu/components/EmoteMenu.jsx
+++ b/src/modules/emote_menu/components/EmoteMenu.jsx
@@ -1,18 +1,24 @@
 import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import emoteMenuViewStore, {CategoryPositions} from '../../../common/stores/emote-menu-view-store.js';
-import {EMOTE_MENU_GRID_ROW_HEIGHT, EmoteMenuTips} from '../../../constants.js';
+import {EMOTE_MENU_GRID_ROW_HEIGHT, EmoteMenuTips, NavigationModeTypes} from '../../../constants.js';
 import useHorizontalResize from '../hooks/HorizontalResize.jsx';
 import Header from './Header.jsx';
 import Sidebar from './Sidebar.jsx';
 import Tip, {markTipAsSeen} from './Tip.jsx';
 import styles from './EmoteMenu.module.css';
-import classNames from 'classnames';
 import EmoteList from './EmoteList.jsx';
 import keyCodes from '../../../utils/keycodes.js';
-import {useDisclosure, useResizeObserver} from '@mantine/hooks';
+import {useDisclosure, useFocusTrap} from '@mantine/hooks';
 import {autoUpdate, offset, useDismiss, useFloating, useInteractions} from '@floating-ui/react';
 import {isMac} from '../../../utils/window.js';
 import useEmoteMenuViewStoreUpdated from '../../../common/hooks/EmoteMenuViewStore.jsx';
+import {
+  getCoordsOfSelected,
+  getFirstCoords,
+  getFirstCoordsInCategory,
+  getSelectedAtCoords,
+} from '../utils/emote-list-grid.js';
+import classNames from 'classnames';
 
 let keyPressCallback;
 function setKeyPressCallback(newKeyPressCallback) {
@@ -35,70 +41,122 @@ function EmoteMenu({
   emoteMenuToggleButtonSelector,
 }) {
   const handleRef = useRef(null);
-  const [search, setSearch] = useState('');
   const [selected, setSelected] = useState(null);
   const altPressed = useRef(false);
   const shiftPressed = useRef(false);
   const [section, setSection] = useState(null);
-  const [opened, {close, open, toggle}] = useDisclosure(false);
-  const width = useHorizontalResize({boundingQuerySelector, handleRef});
-  const [emoteListRef, emoteListRect] = useResizeObserver();
-
-  useLayoutEffect(() => {
-    if (emoteListRef.current == null) {
-      return;
-    }
-
-    const clientWidth = emoteListRef.current.clientWidth;
-    emoteMenuViewStore.updateTotalColumns(clientWidth);
-  }, [emoteListRect.width]);
+  const [opened, {close, open}] = useDisclosure(false);
+  const width = useHorizontalResize({boundingQuerySelector, handleRef, open: opened});
+  const emoteListRef = useRef(null);
+  const [emoteListCoords, setEmoteListCoords] = useState({x: 0, y: 0});
+  const [navigationMode, setNavigationMode] = useState(NavigationModeTypes.ARROW_KEYS);
+  const focusRef = useFocusTrap(opened && navigationMode === NavigationModeTypes.ARROW_KEYS);
 
   const [emoteListData, setEmoteListData] = useState({
+    search: '',
     rows: [],
-    totalCols: 0,
+    totalCols: emoteMenuViewStore.totalCols,
     categories: getCategories(),
   });
 
-  const handleScrollToPendingRow = useCallback(
-    (pendingScrollRowIndex) => {
-      const listEl = emoteListRef.current;
-      if (listEl == null) {
+  const emoteListDataRef = useRef(emoteListData);
+
+  const handleCoordsChange = useCallback(
+    (newCoords) => {
+      const currentEmoteListData = emoteListDataRef.current;
+      if (currentEmoteListData.rows.length === 0) {
         return;
       }
 
-      if (emoteListData.rows.length === 0) {
-        return;
+      if (newCoords == null) {
+        newCoords = getFirstCoords(currentEmoteListData.rows);
       }
 
-      const scrollTop = pendingScrollRowIndex * EMOTE_MENU_GRID_ROW_HEIGHT + 1;
-      listEl.scrollTo(0, scrollTop);
+      const selected = getSelectedAtCoords(currentEmoteListData.rows, newCoords);
+      if (section == null && selected != null) {
+        setSection(selected.category.id);
+      }
+
+      setSelected(selected);
+      setEmoteListCoords(newCoords);
     },
-    [emoteListData.rows]
+    [setSelected, setEmoteListCoords, section]
   );
+
+  const handleOpen = useCallback(() => {
+    open();
+
+    const currentEmoteListData = emoteListDataRef.current;
+    if (currentEmoteListData.rows.length === 0) {
+      return;
+    }
+
+    const firstCoords = getFirstCoords(currentEmoteListData.rows);
+    if (firstCoords != null) {
+      handleCoordsChange(firstCoords);
+    }
+
+    handleScrollToPendingRow(0);
+    setNavigationMode(NavigationModeTypes.ARROW_KEYS);
+  }, [open, handleCoordsChange]);
+
+  const toggle = useCallback(() => (opened ? close() : handleOpen()), [opened, close, open]);
+
+  const handleScrollToPendingRow = useCallback((pendingScrollRowIndex) => {
+    const listEl = emoteListRef.current;
+    if (listEl == null) {
+      return;
+    }
+
+    const currentEmoteListData = emoteListDataRef.current;
+    if (currentEmoteListData.rows.length === 0) {
+      return;
+    }
+
+    const scrollTop = pendingScrollRowIndex * EMOTE_MENU_GRID_ROW_HEIGHT + 1;
+    listEl.scrollTo(0, scrollTop);
+  }, []);
 
   const updateEmoteListData = useCallback((currentSearch = '') => {
     let rows = emoteMenuViewStore.rows;
 
     if (currentSearch.length > 0) {
-      handleScrollToPendingRow(0);
       rows = emoteMenuViewStore.search(currentSearch);
     }
 
-    setEmoteListData({
+    const newData = {
       rows,
+      search: currentSearch,
       totalCols: emoteMenuViewStore.totalCols,
       categories: getCategories(),
-    });
+    };
 
-    setSearch(currentSearch);
+    setEmoteListData(newData);
+    emoteListDataRef.current = newData;
+
+    return newData;
   }, []);
 
-  useEmoteMenuViewStoreUpdated(opened, updateEmoteListData);
+  const handleEmoteListDataUpdate = useCallback(
+    (newData) => {
+      const parsedData = updateEmoteListData(newData);
+
+      let newCoords = getCoordsOfSelected(parsedData.rows, selected);
+      if (newCoords == null) {
+        newCoords = getFirstCoords(parsedData.rows);
+      }
+
+      handleCoordsChange(newCoords);
+    },
+    [selected, handleCoordsChange, updateEmoteListData]
+  );
+
+  useEmoteMenuViewStoreUpdated(opened, handleEmoteListDataUpdate);
 
   const {refs, floatingStyles, context} = useFloating({
     strategy: 'fixed',
     open: opened,
-    onOpenChange: (isOpen) => (isOpen ? open() : close()),
+    onOpenChange: (isOpen) => (isOpen ? handleOpen() : close()),
     placement: 'top-end',
     middleware: [offset(offsetOptions)],
     whileElementsMounted: autoUpdate,
@@ -122,12 +180,6 @@ function EmoteMenu({
   const {getFloatingProps} = useInteractions([dismiss]);
 
   useLayoutEffect(() => {
-    const listEl = emoteListRef.current;
-
-    if (listEl != null && opened) {
-      listEl.scrollTo(0, 0);
-    }
-
     const chatTextArea = document.querySelector(boundingQuerySelector);
     refs.setPositionReference(chatTextArea);
   }, [opened]);
@@ -208,7 +260,7 @@ function EmoteMenu({
 
   const handleSection = useCallback(
     (eventKey, shouldScroll = true) => {
-      updateEmoteListData('');
+      const parsedData = updateEmoteListData('');
       setSection(eventKey);
 
       const index = emoteMenuViewStore.getCategoryIndexById(eventKey);
@@ -216,18 +268,33 @@ function EmoteMenu({
         return;
       }
 
+      const firstInCategory = getFirstCoordsInCategory(parsedData.rows, eventKey);
+      if (firstInCategory != null) {
+        handleCoordsChange(firstInCategory);
+      }
+
       handleScrollToPendingRow(index);
     },
-    [updateEmoteListData, handleScrollToPendingRow]
+    [updateEmoteListData, handleScrollToPendingRow, handleCoordsChange]
   );
 
   const onSection = useCallback((eventKey) => handleSection(eventKey, false), [handleSection]);
   const style = useMemo(() => ({...floatingStyles, width}), [floatingStyles, width]);
 
+  const handleSearchChange = useCallback(
+    (search) => {
+      handleScrollToPendingRow(0);
+      setNavigationMode(NavigationModeTypes.ARROW_KEYS);
+      const parsedData = updateEmoteListData(search);
+      handleCoordsChange(getFirstCoords(parsedData.rows));
+    },
+    [updateEmoteListData, handleCoordsChange, handleScrollToPendingRow]
+  );
+
   return (
     <div
       ref={refs.setFloating}
-      className={classNames(styles.emoteMenu, {[styles.emoteMenuHidden]: !opened})}
+      className={classNames(styles.emoteMenu, {[styles.hidden]: !opened})}
       style={style}
       onKeyDown={handleKeyDown}
       onKeyUp={handleKeyEvent}
@@ -235,11 +302,12 @@ function EmoteMenu({
       <div className={styles.emoteMenuContent}>
         <div ref={handleRef} className={styles.resizeHandle} />
         <Header
+          focusRef={focusRef}
           opened={opened}
           className={styles.header}
-          value={search}
-          onChange={updateEmoteListData}
-          toggleWhisper={close}
+          value={emoteListData.search}
+          onChange={handleSearchChange}
+          toggleWhisper={toggle}
           selected={selected}
         />
         <Sidebar
@@ -252,12 +320,15 @@ function EmoteMenu({
           data={emoteListData}
           ref={emoteListRef}
           selected={selected}
-          setSelected={setSelected}
           className={styles.emotes}
           section={section}
           onClick={handleClick}
           setKeyPressCallback={setKeyPressCallback}
           onSection={onSection}
+          navigationMode={navigationMode}
+          setNavigationMode={setNavigationMode}
+          coords={emoteListCoords}
+          setCoords={handleCoordsChange}
         />
       </div>
       {opened ? <Tip className={styles.tip} onClose={close} /> : null}

--- a/src/modules/emote_menu/components/EmoteMenu.jsx
+++ b/src/modules/emote_menu/components/EmoteMenu.jsx
@@ -83,6 +83,32 @@ function EmoteMenu({
     [setSelected, setEmoteListCoords, section]
   );
 
+  const {refs, floatingStyles, context} = useFloating({
+    strategy: 'fixed',
+    open: opened,
+    onOpenChange: (isOpen) => (isOpen ? handleOpen() : close()),
+    placement: 'top-end',
+    middleware: [offset(offsetOptions)],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const dismiss = useDismiss(context, {
+    outsidePress(event) {
+      if (emoteMenuToggleButtonSelector == null || emoteMenuToggleButtonSelector.length === 0) {
+        return true;
+      }
+
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return true;
+      }
+
+      return target.closest(emoteMenuToggleButtonSelector) == null;
+    },
+  });
+
+  const {getFloatingProps} = useInteractions([dismiss]);
+
   const handleOpen = useCallback(() => {
     open();
 
@@ -155,32 +181,6 @@ function EmoteMenu({
   );
 
   useEmoteMenuViewStoreUpdated(opened, handleEmoteMenuViewStoreUpdate);
-
-  const {refs, floatingStyles, context} = useFloating({
-    strategy: 'fixed',
-    open: opened,
-    onOpenChange: (isOpen) => (isOpen ? handleOpen() : close()),
-    placement: 'top-end',
-    middleware: [offset(offsetOptions)],
-    whileElementsMounted: autoUpdate,
-  });
-
-  const dismiss = useDismiss(context, {
-    outsidePress(event) {
-      if (emoteMenuToggleButtonSelector == null || emoteMenuToggleButtonSelector.length === 0) {
-        return true;
-      }
-
-      const target = event.target;
-      if (!(target instanceof Element)) {
-        return true;
-      }
-
-      return target.closest(emoteMenuToggleButtonSelector) == null;
-    },
-  });
-
-  const {getFloatingProps} = useInteractions([dismiss]);
 
   useEffect(() => {
     function handleKeyDown(event) {

--- a/src/modules/emote_menu/components/EmoteMenu.jsx
+++ b/src/modules/emote_menu/components/EmoteMenu.jsx
@@ -131,25 +131,6 @@ function EmoteMenu({
     listEl.scrollTo(0, scrollTop);
   }, []);
 
-  const handleClose = useCallback(() => {
-    close();
-
-    const currentEmoteListData = emoteListDataRef.current;
-    if (currentEmoteListData.rows.length === 0) {
-      return;
-    }
-
-    const firstCoords = getFirstCoords(currentEmoteListData.rows);
-    if (firstCoords != null) {
-      handleCoordsChange(firstCoords);
-    }
-
-    handleScrollToPendingRow(0);
-    setNavigationMode(NavigationModeTypes.ARROW_KEYS);
-  }, [close, handleCoordsChange, handleScrollToPendingRow]);
-
-  const toggle = useCallback(() => (opened ? handleClose() : handleOpen()), [opened, handleClose, handleOpen]);
-
   const updateEmoteListData = useCallback((currentSearch = '') => {
     let rows = emoteMenuViewStore.rows;
 
@@ -169,6 +150,17 @@ function EmoteMenu({
 
     return newData;
   }, []);
+
+  const handleClose = useCallback(() => {
+    close();
+    setNavigationMode(NavigationModeTypes.ARROW_KEYS);
+    updateEmoteListData('');
+    setSection(null);
+    handleCoordsChange(null);
+    handleScrollToPendingRow(0);
+  }, [updateEmoteListData, handleCoordsChange, handleScrollToPendingRow, setSection, close, setNavigationMode]);
+
+  const toggle = useCallback(() => (opened ? handleClose() : handleOpen()), [opened, handleClose, handleOpen]);
 
   const handleEmoteMenuViewStoreUpdate = useCallback(
     (newData) => {

--- a/src/modules/emote_menu/components/EmoteMenu.jsx
+++ b/src/modules/emote_menu/components/EmoteMenu.jsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import emoteMenuViewStore, {CategoryPositions} from '../../../common/stores/emote-menu-view-store.js';
 import {EMOTE_MENU_GRID_ROW_HEIGHT, EmoteMenuTips, NavigationModeTypes} from '../../../constants.js';
 import useHorizontalResize from '../hooks/HorizontalResize.jsx';
@@ -86,6 +86,9 @@ function EmoteMenu({
   const handleOpen = useCallback(() => {
     open();
 
+    const chatTextArea = document.querySelector(boundingQuerySelector);
+    refs.setPositionReference(chatTextArea);
+
     const currentEmoteListData = emoteListDataRef.current;
     if (currentEmoteListData.rows.length === 0) {
       return;
@@ -98,7 +101,7 @@ function EmoteMenu({
 
     handleScrollToPendingRow(0);
     setNavigationMode(NavigationModeTypes.ARROW_KEYS);
-  }, [open, handleCoordsChange]);
+  }, [open, handleCoordsChange, boundingQuerySelector, refs]);
 
   const toggle = useCallback(() => (opened ? close() : handleOpen()), [opened, close, open]);
 
@@ -137,7 +140,7 @@ function EmoteMenu({
     return newData;
   }, []);
 
-  const handleEmoteListDataUpdate = useCallback(
+  const handleEmoteMenuViewStoreUpdate = useCallback(
     (newData) => {
       const parsedData = updateEmoteListData(newData);
 
@@ -151,7 +154,7 @@ function EmoteMenu({
     [selected, handleCoordsChange, updateEmoteListData]
   );
 
-  useEmoteMenuViewStoreUpdated(opened, handleEmoteListDataUpdate);
+  useEmoteMenuViewStoreUpdated(opened, handleEmoteMenuViewStoreUpdate);
 
   const {refs, floatingStyles, context} = useFloating({
     strategy: 'fixed',
@@ -178,11 +181,6 @@ function EmoteMenu({
   });
 
   const {getFloatingProps} = useInteractions([dismiss]);
-
-  useLayoutEffect(() => {
-    const chatTextArea = document.querySelector(boundingQuerySelector);
-    refs.setPositionReference(chatTextArea);
-  }, [opened]);
 
   useEffect(() => {
     function handleKeyDown(event) {

--- a/src/modules/emote_menu/components/EmoteMenu.jsx
+++ b/src/modules/emote_menu/components/EmoteMenu.jsx
@@ -152,12 +152,16 @@ function EmoteMenu({
   }, []);
 
   const handleClose = useCallback(() => {
+    const listEl = emoteListRef.current;
+    if (listEl != null) {
+      listEl.scrollTo(0, 0);
+    }
+
     close();
     setNavigationMode(NavigationModeTypes.ARROW_KEYS);
     updateEmoteListData('');
     setSection(null);
     handleCoordsChange(null);
-    handleScrollToPendingRow(0);
   }, [updateEmoteListData, handleCoordsChange, handleScrollToPendingRow, setSection, close, setNavigationMode]);
 
   const toggle = useCallback(() => (opened ? handleClose() : handleOpen()), [opened, handleClose, handleOpen]);

--- a/src/modules/emote_menu/components/EmoteMenu.module.css
+++ b/src/modules/emote_menu/components/EmoteMenu.module.css
@@ -33,10 +33,6 @@
   overflow: hidden;
 }
 
-.emoteMenuHidden {
-  display: none;
-}
-
 .emotes {
   flex: 1;
   overflow: hidden;
@@ -67,4 +63,10 @@
   left: 0;
   cursor: col-resize;
   z-index: 2;
+}
+
+.hidden {
+  pointer-events: none;
+  visibility: hidden;
+  opacity: 0;
 }

--- a/src/modules/emote_menu/components/Header.jsx
+++ b/src/modules/emote_menu/components/Header.jsx
@@ -3,13 +3,10 @@ import formatMessage from '../../../i18n/index.js';
 import {CloseButton, TextInput} from '@mantine/core';
 import styles from './Header.module.css';
 import classNames from 'classnames';
-import {useFocusTrap} from '@mantine/hooks';
 import LogoIcon from '../../../common/components/LogoIcon.jsx';
 import settings from '../../settings/index.js';
 
-function Header({value, opened, onChange, toggleWhisper, selected, className, ...props}) {
-  const focusRef = useFocusTrap(opened);
-
+function Header({value, opened, onChange, toggleWhisper, selected, className, focusRef, ...props}) {
   const handleLogoClick = useCallback(() => {
     settings.openSettings();
     toggleWhisper();

--- a/src/modules/emote_menu/components/VirtualizedList.jsx
+++ b/src/modules/emote_menu/components/VirtualizedList.jsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styles from './VirtualizedList.module.css';
 import throttle from 'lodash.throttle';
-import {useMergedRef} from '@mantine/hooks';
+import {useElementSize, useMergedRef} from '@mantine/hooks';
 
 function VirtualizedList(
   {
@@ -10,7 +10,6 @@ function VirtualizedList(
     totalRows,
     rowHeight,
     renderRow,
-    windowHeight,
     stickyRows,
     onHeaderChange = () => {},
     bottomGuardHeight = 0,
@@ -20,7 +19,7 @@ function VirtualizedList(
   },
   forwardedRef
 ) {
-  const ref = useRef(null);
+  const {ref, height: windowHeight} = useElementSize(null);
   const mergedRef = useMergedRef(forwardedRef, ref);
   const headerIndex = useRef(null);
 
@@ -29,69 +28,75 @@ function VirtualizedList(
     [totalRows, rowHeight, windowHeight, topGuardHeight, bottomGuardHeight]
   );
 
-  const [data, setData] = useState({
-    top: 0,
-    rows: [],
-    headerIndex: null,
-  });
+  const handleViewportUpdate = useCallback(
+    (scrollTop = 0) => {
+      const scrollBottom = scrollTop + windowHeight;
+      const startIndex = Math.floor(scrollTop / rowHeight);
+      const endIndex = Math.min(totalRows - 1, Math.floor(scrollBottom / rowHeight));
 
-  const handleViewportUpdate = useCallback(() => {
+      let stickyRowIndex;
+      for (const rowIndex of stickyRows ?? []) {
+        if (rowIndex > startIndex) {
+          break;
+        }
+        stickyRowIndex = rowIndex;
+      }
+
+      const hasAdditionalStickyRow = stickyRowIndex != null && stickyRowIndex < startIndex;
+      const hasCollapsedGap = hasAdditionalStickyRow && startIndex > stickyRowIndex + 1;
+
+      const renderEnd = Math.min(totalRows - 1, endIndex + overscanCount);
+
+      let renderStart = Math.max(0, startIndex - overscanCount);
+      if (hasAdditionalStickyRow) {
+        renderStart = Math.max(stickyRowIndex + 1, renderStart);
+      }
+
+      if (hasCollapsedGap && startIndex - overscanCount > stickyRowIndex + 1) {
+        renderStart = startIndex;
+      }
+
+      const rowsVisible = [];
+      if (hasAdditionalStickyRow) {
+        rowsVisible.push(stickyRowIndex);
+      }
+
+      for (let i = renderStart; i <= renderEnd; i++) {
+        rowsVisible.push(i);
+      }
+
+      let top = renderStart * rowHeight;
+
+      if (hasAdditionalStickyRow && hasCollapsedGap && renderStart < startIndex) {
+        top = stickyRowIndex * rowHeight;
+      } else if (hasAdditionalStickyRow) {
+        top = (startIndex - 1) * rowHeight;
+      }
+
+      return {rows: rowsVisible, top, headerIndex: stickyRowIndex};
+    },
+    [totalRows, rowHeight, windowHeight, stickyRows, overscanCount, onHeaderChange]
+  );
+
+  const [data, setData] = useState(handleViewportUpdate(0));
+
+  const handleScroll = useCallback(() => {
     const currentWrapperRef = ref.current;
     if (currentWrapperRef == null) {
       return;
     }
-    const {scrollTop} = currentWrapperRef;
-    const scrollBottom = scrollTop + windowHeight;
 
-    const startIndex = Math.floor(scrollTop / rowHeight);
-    const endIndex = Math.min(totalRows - 1, Math.floor(scrollBottom / rowHeight));
+    const scrollTop = currentWrapperRef?.scrollTop ?? 0;
 
-    let stickyRowIndex;
-    for (const rowIndex of stickyRows ?? []) {
-      if (rowIndex > startIndex) {
-        break;
-      }
-      stickyRowIndex = rowIndex;
+    const {rows, top, headerIndex: newHeaderIndex} = handleViewportUpdate(scrollTop);
+
+    if (headerIndex.current != null && headerIndex.current !== newHeaderIndex) {
+      onHeaderChange(newHeaderIndex);
     }
 
-    const hasAdditionalStickyRow = stickyRowIndex != null && stickyRowIndex < startIndex;
-    const hasCollapsedGap = hasAdditionalStickyRow && startIndex > stickyRowIndex + 1;
-
-    const renderEnd = Math.min(totalRows - 1, endIndex + overscanCount);
-
-    let renderStart = Math.max(0, startIndex - overscanCount);
-    if (hasAdditionalStickyRow) {
-      renderStart = Math.max(stickyRowIndex + 1, renderStart);
-    }
-
-    if (hasCollapsedGap && startIndex - overscanCount > stickyRowIndex + 1) {
-      renderStart = startIndex;
-    }
-
-    const rowsVisible = [];
-    if (hasAdditionalStickyRow) {
-      rowsVisible.push(stickyRowIndex);
-    }
-
-    for (let i = renderStart; i <= renderEnd; i++) {
-      rowsVisible.push(i);
-    }
-
-    let top = renderStart * rowHeight;
-
-    if (hasAdditionalStickyRow && hasCollapsedGap && renderStart < startIndex) {
-      top = stickyRowIndex * rowHeight;
-    } else if (hasAdditionalStickyRow) {
-      top = (startIndex - 1) * rowHeight;
-    }
-
-    if (headerIndex.current !== stickyRowIndex) {
-      onHeaderChange(stickyRowIndex);
-      headerIndex.current = stickyRowIndex;
-    }
-
-    setData({rows: rowsVisible, top, headerIndex: stickyRowIndex});
-  }, [totalRows, rowHeight, windowHeight, stickyRows, overscanCount]);
+    headerIndex.current = newHeaderIndex;
+    setData({rows, top, headerIndex: newHeaderIndex});
+  }, [handleViewportUpdate, onHeaderChange]);
 
   useEffect(() => {
     const currentWrapperRef = ref.current;
@@ -99,24 +104,14 @@ function VirtualizedList(
       return;
     }
 
-    handleViewportUpdate();
-    const throttledCallback = throttle(handleViewportUpdate, 50);
+    const throttledCallback = throttle(handleScroll, 50);
 
     currentWrapperRef.addEventListener('scroll', throttledCallback);
-    return () => {
-      currentWrapperRef.removeEventListener('scroll', throttledCallback);
-    };
-  }, [handleViewportUpdate]);
+    return () => currentWrapperRef.removeEventListener('scroll', throttledCallback);
+  }, [handleScroll]);
 
   const rows = useMemo(
-    () =>
-      data.rows.map((value) =>
-        renderRow({
-          key: `row-${value}`,
-          index: value,
-          style: {height: `${rowHeight}px`},
-        })
-      ),
+    () => data.rows.map((value) => renderRow({key: `row-${value}`, index: value, style: {height: `${rowHeight}px`}})),
     [data.rows, renderRow]
   );
 

--- a/src/modules/emote_menu/components/VirtualizedList.jsx
+++ b/src/modules/emote_menu/components/VirtualizedList.jsx
@@ -81,11 +81,8 @@ function VirtualizedList(
   const [data, setData] = useState(handleViewportUpdate(0));
 
   const handleScroll = useCallback(() => {
+    console.log('handleScroll');
     const currentWrapperRef = ref.current;
-    if (currentWrapperRef == null) {
-      return;
-    }
-
     const scrollTop = currentWrapperRef?.scrollTop ?? 0;
 
     const {rows, top, headerIndex: newHeaderIndex} = handleViewportUpdate(scrollTop);

--- a/src/modules/emote_menu/hooks/HorizontalResize.jsx
+++ b/src/modules/emote_menu/hooks/HorizontalResize.jsx
@@ -5,7 +5,12 @@ import {SettingIds} from '../../../constants.js';
 
 const WINDOW_HORIZONTAL_MARGIN = 20;
 
-export default function useHorizontalResize({boundingQuerySelector, handleRef, minWidth = EMOTE_MENU_MIN_WIDTH}) {
+export default function useHorizontalResize({
+  boundingQuerySelector,
+  handleRef,
+  minWidth = EMOTE_MENU_MIN_WIDTH,
+  open = true,
+}) {
   const [emoteMenuWidth, setEmoteMenuWidth] = useStorageState(SettingIds.EMOTE_MENU_WIDTH); // desired width
   const [displayWidth, setDisplayWidth] = React.useState(emoteMenuWidth); // actual width
   const [isResizing, setIsResizing] = React.useState(false);
@@ -26,6 +31,10 @@ export default function useHorizontalResize({boundingQuerySelector, handleRef, m
   }
 
   React.useEffect(() => {
+    if (!open) {
+      setIsResizing(false);
+    }
+
     const currentRef = handleRef.current;
     if (currentRef == null) {
       return;
@@ -53,10 +62,10 @@ export default function useHorizontalResize({boundingQuerySelector, handleRef, m
     // eslint-disable-next-line consistent-return
     return () => {
       currentRef.removeEventListener('mousedown', handleResizeStart);
-      document.addEventListener('mouseup', handleResizeEnd);
+      document.removeEventListener('mouseup', handleResizeEnd);
       window.removeEventListener('resize', handleWindowResize);
     };
-  }, [handleRef, emoteMenuWidth]);
+  }, [handleRef, emoteMenuWidth, open]);
 
   React.useEffect(() => {
     function handleResizeMove(e) {

--- a/src/modules/emote_menu/utils/emote-list-grid.js
+++ b/src/modules/emote_menu/utils/emote-list-grid.js
@@ -1,0 +1,75 @@
+export function getEmoteKey(emote) {
+  return `${emote.category.id}-${emote.id}`;
+}
+
+export function getRowColumnCounts(emoteListRows) {
+  return emoteListRows.map((row) => (!Array.isArray(row) ? 0 : row.length));
+}
+
+export function getSelectedAtCoords(emoteListRows, coords) {
+  const row = emoteListRows[coords.y];
+  const cell = row?.[coords.x];
+  return cell != null ? cell : null;
+}
+
+export function getCoordsOfSelected(emoteListRows, selected) {
+  if (selected == null) {
+    return null;
+  }
+
+  for (let y = 0; y < emoteListRows.length; y++) {
+    if (!Array.isArray(emoteListRows[y])) {
+      continue;
+    }
+
+    for (let x = 0; x < emoteListRows[y].length; x++) {
+      if (getEmoteKey(emoteListRows[y][x]) === getEmoteKey(selected)) {
+        return {y, x};
+      }
+    }
+  }
+
+  return null;
+}
+
+export function getFirstCoords(emoteListRows) {
+  if (!Array.isArray(emoteListRows)) {
+    return null;
+  }
+
+  for (let y = 0; y < emoteListRows.length; y++) {
+    if (!Array.isArray(emoteListRows[y])) {
+      continue;
+    }
+
+    for (let x = 0; x < emoteListRows[y].length; x++) {
+      if (emoteListRows[y][x] != null) {
+        return {y, x};
+      }
+    }
+  }
+
+  return null;
+}
+
+/** First grid cell for an emote whose `category.id` matches `categoryId`, or null. */
+export function getFirstCoordsInCategory(emoteListRows, categoryId) {
+  if (categoryId == null) {
+    return null;
+  }
+
+  for (let y = 0; y < emoteListRows.length; y++) {
+    if (!Array.isArray(emoteListRows[y])) {
+      continue;
+    }
+
+    for (let x = 0; x < emoteListRows[y].length; x++) {
+      const emote = emoteListRows[y][x];
+      if (emote != null && emote.category?.id === categoryId) {
+        return {y, x};
+      }
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
- New emote-list-grid.js (keys, coords, first cell in category). 
- Store: skip updateTotalColumns when column count unchanged. 
- EmoteMenu: owns coords + nav mode + focus trap, open/close reset state, store updates resync coords, section picks first emote in category. 
- EmoteList: uses util, width → updateTotalColumns, coords from parent, 
- VirtualizedList height internal. 
- VirtualizedList: useElementSize + refactored viewport/scroll. 
- HorizontalResize + small Header/CSS tweaks.