### PR TITLE
fix: preserve hyphens in autocomplete emote codes

### DIFF
--- a/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
+++ b/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
@@ -27,11 +27,11 @@ function deserializeEmoteFromURL(url) {
     return null;
   }
   try {
-    const [emoteProvider, emoteId, emoteCode] = decodeURIComponent(atob(emoteData)).split('-');
+    const parts = decodeURIComponent(atob(emoteData)).split('-');
     return {
-      provider: emoteProvider,
-      id: emoteId,
-      code: emoteCode,
+      provider: parts[0],
+      id: parts[1],
+      code: parts.slice(2).join('-'),
     };
   } catch (_) {
     return null;


### PR DESCRIPTION
## Summary
- Fixes #7924
- The serialized URL payload joins `provider-id-code` with `-`, but `split('-')` + array destructuring drops everything after the third segment.
- For codes with hyphens (e.g. `plink-182`), the deserialized code becomes `plink`, so `getEligibleEmote` returns the wrong emote and renders its image in the autocomplete row.
- Provider values come from a fixed enum (`bttv`/`ffz`/`twitch`/`youtube`/`seventv`) and IDs are hex/numeric — only the code can contain hyphens, so rejoining `parts.slice(2)` recovers the full code without changing the URL format.

## Test plan
- [x] Join a channel with two 7TV emotes whose codes share a prefix where one contains a hyphen (e.g. `plink` and `plink-182` in maya's channel).
- [x] Type `:plink` in the chat box and confirm the autocomplete row for `plink-182` now shows the correct image.
- [x] Confirm `plink` autocomplete row still shows the correct image.
- [x] Confirm sending the suggestion still inserts the correct emote text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)