### PR TITLE
fix: hide shield mode button when legacy emote menu is active

### DIFF
--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -60,6 +60,10 @@ function unloadLegacyButton(legacyContainer) {
   if (legacyContainer === undefined) {
     legacyContainer = document.getElementById(LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
   }
+  const chatInput = document.querySelector(CHAT_INPUT);
+  if (chatInput != null) {
+    chatInput.classList.remove(styles.hideShieldModeButton);
+  }
   if (legacyContainer != null) {
     legacyContainer.remove();
   }
@@ -74,6 +78,11 @@ function loadLegacyButton() {
   const container = document.querySelector(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR);
   if (container == null) {
     return;
+  }
+
+  const chatInput = document.querySelector(CHAT_INPUT);
+  if (chatInput != null) {
+    chatInput.classList.add(styles.hideShieldModeButton);
   }
 
   const rightContainer = container.lastChild;

--- a/src/modules/emote_menu/twitch/EmoteMenu.module.css
+++ b/src/modules/emote_menu/twitch/EmoteMenu.module.css
@@ -58,3 +58,7 @@
 .hideEmoteMenuButtonContainer button[data-a-target='emote-picker-button'] {
   display: none;
 }
+
+.hideShieldModeButton button:has(svg path[d^='M19.004 4.867']) {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Fixes #7914
- When the BTTV emote menu is enabled with **Replace Native** OFF (`LEGACY_ENABLED`), `loadLegacyButton()` inserts a BTTV button into the chat-input button row right next to the CHAT button. With Twitch's shield mode button also present (visible to moderators), the row exceeds the chat panel width and the CHAT button gets clipped on the right edge.
- Hide the shield mode button while the legacy BTTV button is mounted, via `:has()` + a path-data attribute selector. Mirrors the existing `hideEmoteMenuButtonContainer` pattern that already hides the native emote picker when the BTTV button replaces it.

## Test plan
- [x] In a channel where you have moderator privileges, with **Emote Menu** ON and **Replace Native** OFF, confirm the shield mode button is hidden and the CHAT button is no longer clipped.
- [x] Toggle **Replace Native** ON — shield mode button should reappear and CHAT button stays normal.
- [x] Toggle **Emote Menu** OFF entirely — shield mode button reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)