### PR TITLE
Refactor saving/importing settings

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,8 @@ export const API_ENDPOINT = process.env.API_ENDPOINT;
 export const API_VERSION = process.env.API_VERSION;
 export const SOCKET_ENDPOINT = process.env.SOCKET_ENDPOINT;
 
+export const CLOUD_BACKUP_SETTINGS_STORAGE_KEY = 'cloudBackupSettings';
+
 export const SettingIds = {
   ANON_CHAT: 'anonChat',
   ANON_CHAT_WHITELISTED_CHANNELS: 'anonChatWhitelistedChannels',

--- a/src/modules/cloud_backup/index.js
+++ b/src/modules/cloud_backup/index.js
@@ -2,7 +2,7 @@ import debounce from 'lodash.debounce';
 import isEqual from 'lodash.isequal';
 import {getExtensionSettings, updateExtensionSettings} from '../../actions/extension.js';
 import {openConfirmModal} from '../../common/utils/modal.js';
-import {FlagSettings} from '../../constants.js';
+import {CLOUD_BACKUP_SETTINGS_STORAGE_KEY, FlagSettings} from '../../constants.js';
 import formatMessage from '../../i18n/index.js';
 import settings from '../../settings.js';
 import socketClient, {EventNames} from '../../socket-client.js';
@@ -11,8 +11,6 @@ import useAuthStore from '../../stores/auth.js';
 import HTTPError from '../../utils/http-error.js';
 import {isUserPro} from '../../utils/pro.js';
 import SafeEventEmitter from '../../utils/safe-event-emitter.js';
-
-const CLOUD_BACKUP_SETTINGS_STORAGE_KEY = 'cloudBackupSettings';
 
 let unlistenSettingsChange = null;
 let unlistenSocketChange = null;

--- a/src/modules/cloud_backup/index.js
+++ b/src/modules/cloud_backup/index.js
@@ -167,7 +167,7 @@ class CloudBackup extends SafeEventEmitter {
     }
   }
 
-  async _handleInternalSettingsChange(newSettings) {
+  async _handleInternalSettingsChange(newSettings, forceOverwrite = false) {
     if (ignoringInternalSettingChanges) {
       return;
     }
@@ -193,6 +193,11 @@ class CloudBackup extends SafeEventEmitter {
       }
 
       if (error instanceof HTTPError && error.data?.message === 'Version mismatch') {
+        if (forceOverwrite) {
+          this.updateBackupSettings({version: newSettings.version});
+          return this._handleInternalSettingsChange(newSettings);
+        }
+
         const {expected: expectedVersion} = error.data;
         this.handleVersionMismatch(expectedVersion);
       }

--- a/src/modules/settings/components/ImportSetting.jsx
+++ b/src/modules/settings/components/ImportSetting.jsx
@@ -1,0 +1,125 @@
+import React, {useRef} from 'react';
+import {Button} from '@mantine/core';
+import formatMessage from '../../../i18n/index.js';
+import {SETTINGS_STORAGE_KEY} from '../../../settings.js';
+import storage from '../../../storage.js';
+import {loadLegacySettings} from '../../../utils/legacy-settings.js';
+import {CLOUD_BACKUP_SETTINGS_STORAGE_KEY} from '../../../constants.js';
+import SettingWrapper from './SettingWrapper.jsx';
+import useCloudBackupSettings from '../../../common/hooks/CloudBackup.jsx';
+import {openConfirmModal} from '../../../common/utils/modal.js';
+import cloudBackup from '../../cloud_backup/index.js';
+import {isUserPro} from '../../../utils/pro.js';
+import useAuthStore from '../../../stores/auth.js';
+import {useShallow} from 'zustand/react/shallow';
+
+function loadJSON(string) {
+  let json = null;
+
+  try {
+    json = JSON.parse(string);
+  } catch (e) {
+    json = null;
+  }
+
+  return json;
+}
+
+function getDataURLFromUpload(input) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', ({target}) => resolve(target.result), {once: true});
+
+    if (input.files.length === 0) {
+      reject(new Error('No file selected'));
+    }
+
+    const [file] = input.files;
+
+    reader.readAsText(file);
+  });
+}
+
+async function importSettingsFromFile(target) {
+  const dataUrl = await getDataURLFromUpload(target);
+  let data = loadJSON(dataUrl);
+
+  if (data == null) {
+    return;
+  }
+
+  let importLegacy = true;
+  const sanitizedData = {};
+
+  for (const key of Object.keys(data)) {
+    const nonPrefixedKey = key.split('bttv_')[1];
+    let value = data[key];
+
+    if (nonPrefixedKey === SETTINGS_STORAGE_KEY) {
+      importLegacy = false;
+    }
+
+    storage.set(nonPrefixedKey, value);
+    sanitizedData[nonPrefixedKey] = value;
+  }
+
+  if (importLegacy) {
+    const migratedSettings = loadLegacySettings(sanitizedData);
+    storage.set(SETTINGS_STORAGE_KEY, migratedSettings);
+  }
+
+  return sanitizedData;
+}
+
+function ImportSetting({description, disabled, importing, setImporting}) {
+  const fileImportRef = useRef(null);
+  const [cloudBackupSettings, setCloudBackupSettings] = useCloudBackupSettings();
+  const currentUser = useAuthStore(useShallow((state) => state.user));
+
+  async function importFile(target) {
+    const sanitizedData = await importSettingsFromFile(target);
+
+    let cloudBackupEnabled = cloudBackupSettings.enabled;
+
+    if (typeof sanitizedData[CLOUD_BACKUP_SETTINGS_STORAGE_KEY] !== 'undefined') {
+      cloudBackupEnabled = sanitizedData[CLOUD_BACKUP_SETTINGS_STORAGE_KEY]?.enabled === true;
+    }
+
+    if (!cloudBackupEnabled || !isUserPro(currentUser)) {
+      window.location.reload();
+      return;
+    }
+
+    openConfirmModal({
+      title: formatMessage({defaultMessage: 'Sync to Cloud Backup?'}),
+      description: formatMessage({
+        defaultMessage:
+          'Your settings were imported successfully, Would you like to sync your imported settings to the cloud?',
+      }),
+      onConfirm: () => cloudBackup._handleInternalSettingsChange(sanitizedData, true),
+      onCancel: () => setCloudBackupSettings({enabled: false}),
+      onClose: () => window.location.reload(),
+      labels: {
+        confirm: formatMessage({defaultMessage: 'Sync to Cloud'}),
+        cancel: formatMessage({defaultMessage: 'Disable Cloud Backup'}),
+      },
+    });
+  }
+
+  return (
+    <SettingWrapper reverse name={formatMessage({defaultMessage: 'Import Settings'})} description={description}>
+      <input
+        type="file"
+        hidden
+        ref={fileImportRef}
+        accept=".backup,.json"
+        onChange={({target}) => importFile(target)}
+      />
+      <Button onClick={() => fileImportRef.current?.click()} disabled={disabled} loading={importing} size="lg">
+        {formatMessage({defaultMessage: 'Import'})}
+      </Button>
+    </SettingWrapper>
+  );
+}
+
+export default ImportSetting;

--- a/src/modules/settings/components/ImportSetting.jsx
+++ b/src/modules/settings/components/ImportSetting.jsx
@@ -93,16 +93,16 @@ function ImportSetting({description, disabled, importing, setImporting}) {
     openConfirmModal({
       title: formatMessage({defaultMessage: 'Sync to Cloud Backup?'}),
       description: formatMessage({
-        defaultMessage:
-          'Your settings were imported successfully, Would you like to sync your imported settings to the cloud?',
+        defaultMessage: 'Your settings were imported successfully, Would you like to sync them to the cloud?',
       }),
       onConfirm: () => cloudBackup._handleInternalSettingsChange(sanitizedData, true),
       onCancel: () => setCloudBackupSettings({enabled: false}),
-      onClose: () => window.location.reload(),
+      onClose: () => setTimeout(() => window.location.reload(), 500),
       labels: {
         confirm: formatMessage({defaultMessage: 'Sync to Cloud'}),
         cancel: formatMessage({defaultMessage: 'Disable Cloud Backup'}),
       },
+      confirmProps: {color: 'red', size: 'lg', variant: 'elevated'},
     });
   }
 

--- a/src/modules/settings/components/ResetSetting.jsx
+++ b/src/modules/settings/components/ResetSetting.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {Button} from '@mantine/core';
+import {useShallow} from 'zustand/react/shallow';
+import formatMessage from '../../../i18n/index.js';
+import {SETTINGS_STORAGE_KEY} from '../../../settings.js';
+import storage from '../../../storage.js';
+import {EXT_VER, SettingDefaultValues} from '../../../constants.js';
+import SettingWrapper from './SettingWrapper.jsx';
+import useCloudBackupSettings from '../../../common/hooks/CloudBackup.jsx';
+import {openConfirmModal} from '../../../common/utils/modal.js';
+import cloudBackup from '../../cloud_backup/index.js';
+import {isUserPro} from '../../../utils/pro.js';
+import useAuthStore from '../../../stores/auth.js';
+
+function ResetSetting({description, disabled, resetting, setResetting}) {
+  const [cloudBackupSettings, setCloudBackupSettings] = useCloudBackupSettings();
+  const currentUser = useAuthStore(useShallow((state) => state.user));
+
+  function resetDefault() {
+    setResetting(true);
+    storage.set(SETTINGS_STORAGE_KEY, null);
+
+    if (!cloudBackupSettings.enabled || !isUserPro(currentUser)) {
+      setTimeout(() => window.location.reload(), 500);
+      return;
+    }
+
+    openConfirmModal({
+      title: formatMessage({defaultMessage: 'Reset Cloud Backup?'}),
+      description: formatMessage({
+        defaultMessage:
+          'Your local settings have been reset to default. Would you like to reset your cloud backup to default as well?',
+      }),
+      onConfirm: () => cloudBackup._handleInternalSettingsChange(SettingDefaultValues, true),
+      onCancel: () => setCloudBackupSettings({enabled: false}),
+      onClose: () => setTimeout(() => window.location.reload(), 500),
+      labels: {
+        confirm: formatMessage({defaultMessage: 'Reset'}),
+        cancel: formatMessage({defaultMessage: 'Disable Cloud Backup'}),
+      },
+      confirmProps: {color: 'red', size: 'lg', variant: 'elevated'},
+    });
+  }
+
+  function handleReset() {
+    openConfirmModal({
+      title: formatMessage({defaultMessage: 'Reset to Default'}),
+      description: formatMessage({
+        defaultMessage: 'Are you sure you want to reset your settings to default? This cannot be reversed.',
+      }),
+      onConfirm: resetDefault,
+      labels: {
+        confirm: formatMessage({defaultMessage: 'Reset'}),
+        cancel: formatMessage({defaultMessage: 'Cancel'}),
+      },
+      confirmProps: {color: 'red', size: 'lg', variant: 'elevated'},
+    });
+  }
+
+  return (
+    <SettingWrapper reverse name={formatMessage({defaultMessage: 'Reset to Default'})} description={description}>
+      <Button size="lg" color="red" disabled={disabled} loading={resetting} onClick={handleReset}>
+        {formatMessage({defaultMessage: 'Reset'})}
+      </Button>
+    </SettingWrapper>
+  );
+}
+
+export default ResetSetting;

--- a/src/modules/settings/pages/UserSettings.jsx
+++ b/src/modules/settings/pages/UserSettings.jsx
@@ -18,6 +18,7 @@ import useCloudBackupSettings from '../../../common/hooks/CloudBackup.jsx';
 import SettingSwitch from '../components/SettingSwitch.jsx';
 import useProRequiredState from '../../../common/hooks/ProRequiredState.jsx';
 import Promotion from '../components/Promotion.jsx';
+import {EXT_VER} from '../../../constants.js';
 
 function loadJSON(string) {
   let json = null;
@@ -45,7 +46,20 @@ function getDataURLFromUpload(input) {
 function BackupSetting({description, disabled}) {
   function backupFile() {
     const rv = storage.getStorage();
-    saveAs(new Blob([JSON.stringify(rv)], {type: 'application/json;charset=utf-8'}), 'bttv_settings.backup');
+    const version = `v${EXT_VER}`;
+    const now = new Date();
+
+    const date = [
+      now.toLocaleDateString('en-US', {month: 'long'}),
+      now.toLocaleDateString('en-US', {day: 'numeric'}),
+      now.toLocaleDateString('en-US', {year: 'numeric'}),
+    ].join(' ');
+
+    const filename = formatMessage({defaultMessage: 'BetterTTV Settings Backup ({version}) {date}'}, {version, date});
+    const filenameWithExtension = `${filename}.json`;
+    const blob = new Blob([JSON.stringify(rv)], {type: 'application/json;charset=utf-8'});
+
+    saveAs(blob, filenameWithExtension);
   }
 
   return (
@@ -59,33 +73,58 @@ function BackupSetting({description, disabled}) {
 
 function ImportSetting({description, disabled, importing, setImporting}) {
   const fileImportRef = useRef(null);
+  const [cloudBackupSettings, setCloudBackupSettings] = useCloudBackupSettings();
 
   async function importFile(target) {
     setImporting(true);
-    const data = loadJSON(await getDataURLFromUpload(target));
-    if (data == null) {
-      setImporting(false);
-      return;
-    }
-    let importLegacy = true;
-    const sanitizedData = {};
-    for (const key of Object.keys(data)) {
-      const nonPrefixedKey = key.split('bttv_')[1];
-      storage.set(nonPrefixedKey, data[key]);
-      sanitizedData[nonPrefixedKey] = data[key];
-      if (nonPrefixedKey === SETTINGS_STORAGE_KEY) {
-        importLegacy = false;
+
+    try {
+      const dataUrl = await getDataURLFromUpload(target);
+      let data = loadJSON(dataUrl);
+
+      if (data == null) {
+        return;
       }
+
+      let importLegacy = true;
+      const sanitizedData = {};
+
+      for (const key of Object.keys(data)) {
+        const nonPrefixedKey = key.split('bttv_')[1];
+        const value = data[key];
+
+        if (nonPrefixedKey === SETTINGS_STORAGE_KEY) {
+          importLegacy = false;
+        }
+
+        storage.set(nonPrefixedKey, value);
+        sanitizedData[nonPrefixedKey] = value;
+      }
+
+      if (importLegacy) {
+        const migratedSettings = loadLegacySettings(sanitizedData);
+        storage.set(SETTINGS_STORAGE_KEY, migratedSettings);
+      }
+
+      if (cloudBackupSettings.enabled) {
+        setCloudBackupSettings({enabled: false});
+      }
+
+      window.location.reload();
+    } finally {
+      setImporting(false);
     }
-    if (importLegacy) {
-      storage.set(SETTINGS_STORAGE_KEY, loadLegacySettings(sanitizedData));
-    }
-    setTimeout(() => window.location.reload(), 1000);
   }
 
   return (
     <SettingWrapper reverse name={formatMessage({defaultMessage: 'Import Settings'})} description={description}>
-      <input type="file" hidden ref={fileImportRef} onChange={({target}) => importFile(target)} />
+      <input
+        type="file"
+        hidden
+        ref={fileImportRef}
+        accept=".backup,.json"
+        onChange={({target}) => importFile(target)}
+      />
       <Button onClick={() => fileImportRef.current?.click()} disabled={disabled} loading={importing} size="lg">
         {formatMessage({defaultMessage: 'Import'})}
       </Button>
@@ -94,13 +133,16 @@ function ImportSetting({description, disabled, importing, setImporting}) {
 }
 
 function ResetSetting({description, disabled, setResetting}) {
-  const [_, setCloudBackupSettings] = useCloudBackupSettings();
+  const [cloudBackupSettings, setCloudBackupSettings] = useCloudBackupSettings();
 
-  async function resetDefault() {
+  function resetDefault() {
     setResetting(true);
-    setCloudBackupSettings({enabled: false});
+
+    if (cloudBackupSettings.enabled) {
+      setCloudBackupSettings({enabled: false});
+    }
+
     storage.set(SETTINGS_STORAGE_KEY, null);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     window.location.reload();
   }
 

--- a/src/modules/settings/pages/UserSettings.jsx
+++ b/src/modules/settings/pages/UserSettings.jsx
@@ -18,7 +18,7 @@ import useCloudBackupSettings from '../../../common/hooks/CloudBackup.jsx';
 import SettingSwitch from '../components/SettingSwitch.jsx';
 import useProRequiredState from '../../../common/hooks/ProRequiredState.jsx';
 import Promotion from '../components/Promotion.jsx';
-import {EXT_VER} from '../../../constants.js';
+import {CLOUD_BACKUP_SETTINGS_STORAGE_KEY, EXT_VER} from '../../../constants.js';
 
 function loadJSON(string) {
   let json = null;
@@ -73,7 +73,6 @@ function BackupSetting({description, disabled}) {
 
 function ImportSetting({description, disabled, importing, setImporting}) {
   const fileImportRef = useRef(null);
-  const [cloudBackupSettings, setCloudBackupSettings] = useCloudBackupSettings();
 
   async function importFile(target) {
     setImporting(true);
@@ -91,10 +90,14 @@ function ImportSetting({description, disabled, importing, setImporting}) {
 
       for (const key of Object.keys(data)) {
         const nonPrefixedKey = key.split('bttv_')[1];
-        const value = data[key];
+        let value = data[key];
 
         if (nonPrefixedKey === SETTINGS_STORAGE_KEY) {
           importLegacy = false;
+        }
+
+        if (nonPrefixedKey === CLOUD_BACKUP_SETTINGS_STORAGE_KEY) {
+          value = {enabled: false};
         }
 
         storage.set(nonPrefixedKey, value);
@@ -104,10 +107,6 @@ function ImportSetting({description, disabled, importing, setImporting}) {
       if (importLegacy) {
         const migratedSettings = loadLegacySettings(sanitizedData);
         storage.set(SETTINGS_STORAGE_KEY, migratedSettings);
-      }
-
-      if (cloudBackupSettings.enabled) {
-        setCloudBackupSettings({enabled: false});
       }
 
       window.location.reload();

--- a/src/modules/settings/pages/UserSettings.jsx
+++ b/src/modules/settings/pages/UserSettings.jsx
@@ -2,13 +2,13 @@ import {saveAs} from 'file-saver';
 import React, {useState} from 'react';
 import {useShallow} from 'zustand/react/shallow';
 import formatMessage from '../../../i18n/index.js';
-import {SETTINGS_STORAGE_KEY} from '../../../settings.js';
 import storage from '../../../storage.js';
 import Footer from '../components/Footer.jsx';
 import PageScrollBody from '../components/PageScrollBody.jsx';
 import SettingGroup from '../components/SettingGroup.jsx';
 import SettingWrapper from '../components/SettingWrapper.jsx';
 import ImportSetting from '../components/ImportSetting.jsx';
+import ResetSetting from '../components/ResetSetting.jsx';
 import {Button} from '@mantine/core';
 import useAuthStore, {getCredentials, setCredentials} from '../../../stores/auth.js';
 import {revokeAccessToken} from '../../../utils/oauth.js';
@@ -43,44 +43,6 @@ function BackupSetting({description, disabled}) {
     <SettingWrapper reverse name={formatMessage({defaultMessage: 'Backup Settings'})} description={description}>
       <Button size="lg" onClick={backupFile} disabled={disabled}>
         {formatMessage({defaultMessage: 'Backup'})}
-      </Button>
-    </SettingWrapper>
-  );
-}
-
-function ResetSetting({description, disabled, setResetting}) {
-  const [cloudBackupSettings, setCloudBackupSettings] = useCloudBackupSettings();
-
-  function resetDefault() {
-    setResetting(true);
-
-    if (cloudBackupSettings.enabled) {
-      setCloudBackupSettings({enabled: false});
-    }
-
-    storage.set(SETTINGS_STORAGE_KEY, null);
-    window.location.reload();
-  }
-
-  function handleReset() {
-    openConfirmModal({
-      title: formatMessage({defaultMessage: 'Reset to Default'}),
-      description: formatMessage({
-        defaultMessage: 'Are you sure you want to reset your settings to default? This cannot be reversed.',
-      }),
-      onConfirm: resetDefault,
-      labels: {
-        confirm: formatMessage({defaultMessage: 'Reset'}),
-        cancel: formatMessage({defaultMessage: 'Cancel'}),
-      },
-      confirmProps: {color: 'red', size: 'lg', variant: 'elevated'},
-    });
-  }
-
-  return (
-    <SettingWrapper reverse name={formatMessage({defaultMessage: 'Reset to Default'})} description={description}>
-      <Button size="lg" color="red" disabled={disabled} onClick={handleReset}>
-        {formatMessage({defaultMessage: 'Reset'})}
       </Button>
     </SettingWrapper>
   );

--- a/src/modules/settings/pages/UserSettings.jsx
+++ b/src/modules/settings/pages/UserSettings.jsx
@@ -1,14 +1,14 @@
 import {saveAs} from 'file-saver';
-import React, {useRef, useState} from 'react';
+import React, {useState} from 'react';
 import {useShallow} from 'zustand/react/shallow';
 import formatMessage from '../../../i18n/index.js';
 import {SETTINGS_STORAGE_KEY} from '../../../settings.js';
 import storage from '../../../storage.js';
-import {loadLegacySettings} from '../../../utils/legacy-settings.js';
 import Footer from '../components/Footer.jsx';
 import PageScrollBody from '../components/PageScrollBody.jsx';
 import SettingGroup from '../components/SettingGroup.jsx';
 import SettingWrapper from '../components/SettingWrapper.jsx';
+import ImportSetting from '../components/ImportSetting.jsx';
 import {Button} from '@mantine/core';
 import useAuthStore, {getCredentials, setCredentials} from '../../../stores/auth.js';
 import {revokeAccessToken} from '../../../utils/oauth.js';
@@ -18,30 +18,7 @@ import useCloudBackupSettings from '../../../common/hooks/CloudBackup.jsx';
 import SettingSwitch from '../components/SettingSwitch.jsx';
 import useProRequiredState from '../../../common/hooks/ProRequiredState.jsx';
 import Promotion from '../components/Promotion.jsx';
-import {CLOUD_BACKUP_SETTINGS_STORAGE_KEY, EXT_VER} from '../../../constants.js';
-
-function loadJSON(string) {
-  let json = null;
-  try {
-    json = JSON.parse(string);
-  } catch (e) {
-    json = null;
-  }
-  return json;
-}
-
-function getDataURLFromUpload(input) {
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onload = ({target}) => resolve(target.result);
-    const file = input.files[0];
-    if (!file) {
-      resolve(null);
-      return;
-    }
-    reader.readAsText(file);
-  });
-}
+import {EXT_VER} from '../../../constants.js';
 
 function BackupSetting({description, disabled}) {
   function backupFile() {
@@ -66,66 +43,6 @@ function BackupSetting({description, disabled}) {
     <SettingWrapper reverse name={formatMessage({defaultMessage: 'Backup Settings'})} description={description}>
       <Button size="lg" onClick={backupFile} disabled={disabled}>
         {formatMessage({defaultMessage: 'Backup'})}
-      </Button>
-    </SettingWrapper>
-  );
-}
-
-function ImportSetting({description, disabled, importing, setImporting}) {
-  const fileImportRef = useRef(null);
-
-  async function importFile(target) {
-    setImporting(true);
-
-    try {
-      const dataUrl = await getDataURLFromUpload(target);
-      let data = loadJSON(dataUrl);
-
-      if (data == null) {
-        return;
-      }
-
-      let importLegacy = true;
-      const sanitizedData = {};
-
-      for (const key of Object.keys(data)) {
-        const nonPrefixedKey = key.split('bttv_')[1];
-        let value = data[key];
-
-        if (nonPrefixedKey === SETTINGS_STORAGE_KEY) {
-          importLegacy = false;
-        }
-
-        if (nonPrefixedKey === CLOUD_BACKUP_SETTINGS_STORAGE_KEY) {
-          value = {enabled: false};
-        }
-
-        storage.set(nonPrefixedKey, value);
-        sanitizedData[nonPrefixedKey] = value;
-      }
-
-      if (importLegacy) {
-        const migratedSettings = loadLegacySettings(sanitizedData);
-        storage.set(SETTINGS_STORAGE_KEY, migratedSettings);
-      }
-
-      window.location.reload();
-    } finally {
-      setImporting(false);
-    }
-  }
-
-  return (
-    <SettingWrapper reverse name={formatMessage({defaultMessage: 'Import Settings'})} description={description}>
-      <input
-        type="file"
-        hidden
-        ref={fileImportRef}
-        accept=".backup,.json"
-        onChange={({target}) => importFile(target)}
-      />
-      <Button onClick={() => fileImportRef.current?.click()} disabled={disabled} loading={importing} size="lg">
-        {formatMessage({defaultMessage: 'Import'})}
       </Button>
     </SettingWrapper>
   );


### PR DESCRIPTION
Changes:

Backed up files are now suffixed with `.json` rather than `.backup`
Importing files will filter by extension either `.json` or `.backup` for legacy imports
Cloud syncing will be disabled when importing a new backup