### PR TITLE
fix mute invisible player overriding manual mute

### DIFF
--- a/src/modules/video_player/index.js
+++ b/src/modules/video_player/index.js
@@ -138,7 +138,7 @@ document.addEventListener('visibilitychange', () => {
       video.muted = false;
       isMuted = false;
     }
-  } else if (!document.pictureInPictureElement) {
+  } else if (!document.pictureInPictureElement && !video.muted) {
     video.muted = true;
     isMuted = true;
   }


### PR DESCRIPTION
## Summary
- Closes #7972
- When the tab hides, only flag `isMuted = true` if the video wasn't already muted, so a manual mute survives a tab switch
- The visible-branch already gates on `isMuted`, so leaving the flag false when we didn't do the muting is enough to stop the unwanted unmute

## Test plan
- [x] With "Mute Invisible Player" on: mute a channel manually, switch tabs, return, verify it stays muted
- [x] With "Mute Invisible Player" on: leave audio on, switch tabs, return, verify it auto-unmutes as before
- [x] Verify PiP path is unaffected (no mute when entering PiP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)