### PR TITLE
fix: force autocomplete re-render when emotes are updated

### DIFF
--- a/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
+++ b/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
@@ -86,6 +86,8 @@ function injectEmoteSets() {
   } else {
     autocompleteEmotes[index] = emoteSet;
   }
+
+  autocompleteEmoteProvider.forceUpdate();
 }
 
 function patchEmoteImage(image, isConnected) {
@@ -205,7 +207,7 @@ export default class EmoteAutocomplete {
         }
 
         if (twitchComponentDidUpdate != null) {
-          twitchComponentDidUpdate.call(this, ...prevProps);
+          twitchComponentDidUpdate.call(this, prevProps);
         }
       }
 

--- a/src/modules/emotes/personal-emotes.js
+++ b/src/modules/emotes/personal-emotes.js
@@ -43,7 +43,7 @@ class PersonalEmotes extends AbstractEmotes {
   getEmotes(user) {
     if (!user) return [];
 
-    const emotes = this.emotes.get(user.id);
+    const emotes = this.emotes.get(String(user.id));
     if (!emotes) return [];
 
     return [...emotes.values()];
@@ -52,7 +52,7 @@ class PersonalEmotes extends AbstractEmotes {
   getEligibleEmote(code, user) {
     if (!user) return null;
 
-    const emotes = this.emotes.get(user.id);
+    const emotes = this.emotes.get(String(user.id));
     if (!emotes) return null;
 
     return emotes.get(code);
@@ -104,10 +104,11 @@ class PersonalEmotes extends AbstractEmotes {
   updatePersonalEmotes({providerId, pro, emotes}) {
     if (!pro) return;
 
-    let personalEmotes = this.emotes.get(providerId);
+    const providerIdStr = String(providerId);
+    let personalEmotes = this.emotes.get(providerIdStr);
     if (!personalEmotes) {
       personalEmotes = new Map();
-      this.emotes.set(providerId, personalEmotes);
+      this.emotes.set(providerIdStr, personalEmotes);
     }
 
     let updated = false;


### PR DESCRIPTION
## Summary

- Calls `forceUpdate()` on the Twitch autocomplete provider after injecting updated emote sets, so the component re-renders immediately when emotes change
- Fixes newly added channel emotes and personal emotes not appearing in the chat input box until a full page reload
- Also fixes an incorrect `...prevProps` spread in `bttvComponentDidUpdate` when forwarding to Twitch's native `componentDidUpdate` (objects are not iterable and would throw a `TypeError`)

## Root cause

`injectEmoteSets()` mutates Twitch's React autocomplete props array in-place but never triggers a re-render. The `load()` method correctly calls `forceUpdate()`, but `injectEmoteSets()` (called on `emotes.updated` events) did not — so any emote changes after initial load were invisible until page refresh.

## Test plan

- [ ] Add a new emote to a BetterTTV channel and verify it renders in the chat input box without refreshing
- [ ] Confirm personal emotes render in the chat input box
- [ ] Verify tab-complete and emote menu still work correctly for existing emotes

Closes #5968

🤖 Generated with [Claude Code](https://claude.com/claude-code)