### PR TITLE
fix: emote pre-rendering in Slate chat input box

### DIFF
--- a/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
+++ b/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
@@ -63,13 +63,8 @@ function createTwitchEmoteSet(allEmotes) {
   };
 }
 
-function getSlateEmoteMapHook() {
-  // Delegated to twitch.js which walks up from the editor DOM element
-  return twitch.getSlateEmoteMapHook();
-}
-
 function syncSlateEmoteMap(emoteSet) {
-  const hook = getSlateEmoteMapHook();
+  const hook = twitch.getSlateEmoteMapHook();
   if (hook == null) return;
 
   const currentMap = hook.memoizedState;

--- a/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
+++ b/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
@@ -51,13 +51,38 @@ function getAutocompleteEmoteProvider() {
 function createTwitchEmoteSet(allEmotes) {
   return {
     emotes: allEmotes.map((emote) => ({
+      __typename: 'Emote',
       id: serializeEmoteId(emote),
       modifiers: null,
       setID: CUSTOM_SET_ID,
       token: emote.code,
+      type: 'SUBSCRIPTIONS',
+      assetType: emote.animated ? 'ANIMATED' : 'STATIC',
     })),
     id: CUSTOM_SET_ID,
   };
+}
+
+function getSlateEmoteMapHook() {
+  // Delegated to twitch.js which walks up from the editor DOM element
+  return twitch.getSlateEmoteMapHook();
+}
+
+function syncSlateEmoteMap(emoteSet) {
+  const hook = getSlateEmoteMapHook();
+  if (hook == null) return;
+
+  const currentMap = hook.memoizedState;
+  const additions = {};
+  for (const emote of emoteSet.emotes) {
+    if (!(emote.token in currentMap)) {
+      additions[emote.token] = emote;
+    }
+  }
+
+  if (Object.keys(additions).length === 0) return;
+
+  hook.queue.dispatch({...currentMap, ...additions});
 }
 
 function injectEmoteSets() {
@@ -88,6 +113,7 @@ function injectEmoteSets() {
   }
 
   autocompleteEmoteProvider.forceUpdate();
+  syncSlateEmoteMap(emoteSet);
 }
 
 function patchEmoteImage(image, isConnected) {

--- a/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
+++ b/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
@@ -86,6 +86,8 @@ function injectEmoteSets() {
   } else {
     autocompleteEmotes[index] = emoteSet;
   }
+
+  autocompleteEmoteProvider.forceUpdate();
 }
 
 function patchEmoteImage(image, isConnected) {
@@ -205,7 +207,7 @@ export default class EmoteAutocomplete {
         }
 
         if (twitchComponentDidUpdate != null) {
-          twitchComponentDidUpdate.call(this, ...prevProps);
+          twitchComponentDidUpdate.call(this, prevProps);
         }
       }
 

--- a/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
+++ b/src/modules/emote_autocomplete/twitch/EmoteAutocomplete.jsx
@@ -64,20 +64,28 @@ function createTwitchEmoteSet(allEmotes) {
 }
 
 function syncSlateEmoteMap(emoteSet) {
-  const hook = twitch.getSlateEmoteMapHook();
-  if (hook == null) return;
+  const slateEmoteMapHook = twitch.getSlateEmoteMapHook();
+  if (slateEmoteMapHook == null) {
+    return;
+  }
 
-  const currentMap = hook.memoizedState;
-  const additions = {};
+  const currentMap = slateEmoteMapHook.memoizedState;
+  const newMap = {...currentMap};
+
+  let emoteMapUpdated = false;
+
   for (const emote of emoteSet.emotes) {
-    if (!(emote.token in currentMap)) {
-      additions[emote.token] = emote;
+    if (currentMap[emote.token] == null) {
+      emoteMapUpdated = true;
+      newMap[emote.token] = emote;
     }
   }
 
-  if (Object.keys(additions).length === 0) return;
+  if (!emoteMapUpdated) {
+    return;
+  }
 
-  hook.queue.dispatch({...currentMap, ...additions});
+  slateEmoteMapHook.queue.dispatch(newMap);
 }
 
 function injectEmoteSets() {
@@ -107,8 +115,8 @@ function injectEmoteSets() {
     autocompleteEmotes[index] = emoteSet;
   }
 
-  autocompleteEmoteProvider.forceUpdate();
   syncSlateEmoteMap(emoteSet);
+  autocompleteEmoteProvider.forceUpdate();
 }
 
 function patchEmoteImage(image, isConnected) {

--- a/src/modules/emotes/personal-emotes.js
+++ b/src/modules/emotes/personal-emotes.js
@@ -43,7 +43,7 @@ class PersonalEmotes extends AbstractEmotes {
   getEmotes(user) {
     if (!user) return [];
 
-    const emotes = this.emotes.get(String(user.id));
+    const emotes = this.emotes.get(user.id);
     if (!emotes) return [];
 
     return [...emotes.values()];
@@ -52,7 +52,7 @@ class PersonalEmotes extends AbstractEmotes {
   getEligibleEmote(code, user) {
     if (!user) return null;
 
-    const emotes = this.emotes.get(String(user.id));
+    const emotes = this.emotes.get(user.id);
     if (!emotes) return null;
 
     return emotes.get(code);
@@ -104,11 +104,10 @@ class PersonalEmotes extends AbstractEmotes {
   updatePersonalEmotes({providerId, pro, emotes}) {
     if (!pro) return;
 
-    const providerIdStr = String(providerId);
-    let personalEmotes = this.emotes.get(providerIdStr);
+    let personalEmotes = this.emotes.get(providerId);
     if (!personalEmotes) {
       personalEmotes = new Map();
-      this.emotes.set(providerIdStr, personalEmotes);
+      this.emotes.set(providerId, personalEmotes);
     }
 
     let updated = false;

--- a/src/modules/emotes/personal-emotes.js
+++ b/src/modules/emotes/personal-emotes.js
@@ -43,7 +43,7 @@ class PersonalEmotes extends AbstractEmotes {
   getEmotes(user) {
     if (!user) return [];
 
-    const emotes = this.emotes.get(user.id);
+    const emotes = this.emotes.get(String(user.id));
     if (!emotes) return [];
 
     return [...emotes.values()];
@@ -52,7 +52,7 @@ class PersonalEmotes extends AbstractEmotes {
   getEligibleEmote(code, user) {
     if (!user) return null;
 
-    const emotes = this.emotes.get(user.id);
+    const emotes = this.emotes.get(String(user.id));
     if (!emotes) return null;
 
     return emotes.get(code);
@@ -104,10 +104,11 @@ class PersonalEmotes extends AbstractEmotes {
   updatePersonalEmotes({providerId, pro, emotes}) {
     if (!pro) return;
 
-    let personalEmotes = this.emotes.get(providerId);
+    const providerIdStr = String(providerId);
+    let personalEmotes = this.emotes.get(providerIdStr);
     if (!personalEmotes) {
       personalEmotes = new Map();
-      this.emotes.set(providerId, personalEmotes);
+      this.emotes.set(providerIdStr, personalEmotes);
     }
 
     let updated = false;

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -306,16 +306,21 @@ export default {
 
   getSlateEmoteMapHook() {
     let hook;
+
     try {
       const node = searchReactParents(
         getReactInstance(document.querySelector(CHAT_WYSIWYG_INPUT_EDITOR)),
         (n) => {
-          if (!Array.isArray(n.pendingProps?.emotes)) return false;
+          if (!Array.isArray(n.pendingProps?.emotes)) {
+            return false;
+          }
+
           const h = n.memoizedState?.next;
-          return h?.queue?.dispatch != null && typeof h.memoizedState === 'object' && !Array.isArray(h.memoizedState);
+          return h?.queue?.dispatch != null && h.memoizedState != null && !Array.isArray(h.memoizedState);
         },
         25
       );
+
       hook = node?.memoizedState.next;
     } catch (_) {}
 

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -305,15 +305,10 @@ export default {
   },
 
   getSlateEmoteMapHook() {
-    // The Slate editor component holds Twitch's emote token map as React state
-    // (the second useState hook, index 1). We find it by walking up the fiber
-    // tree from the editor DOM element.
-    let hook = null;
+    let hook;
     try {
-      const editorEl = document.querySelector(CHAT_WYSIWYG_INPUT_EDITOR);
-      if (editorEl == null) return null;
-      let node = searchReactParents(
-        getReactInstance(editorEl),
+      const node = searchReactParents(
+        getReactInstance(document.querySelector(CHAT_WYSIWYG_INPUT_EDITOR)),
         (n) => {
           if (!Array.isArray(n.pendingProps?.emotes)) return false;
           const h = n.memoizedState?.next;
@@ -321,10 +316,9 @@ export default {
         },
         25
       );
-      if (node != null) {
-        hook = node.memoizedState.next;
-      }
+      hook = node?.memoizedState.next;
     } catch (_) {}
+
     return hook;
   },
 

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -304,6 +304,30 @@ export default {
     return node;
   },
 
+  getSlateEmoteMapHook() {
+    // The Slate editor component holds Twitch's emote token map as React state
+    // (the second useState hook, index 1). We find it by walking up the fiber
+    // tree from the editor DOM element.
+    let hook = null;
+    try {
+      const editorEl = document.querySelector(CHAT_WYSIWYG_INPUT_EDITOR);
+      if (editorEl == null) return null;
+      let node = searchReactParents(
+        getReactInstance(editorEl),
+        (n) => {
+          if (!Array.isArray(n.pendingProps?.emotes)) return false;
+          const h = n.memoizedState?.next;
+          return h?.queue?.dispatch != null && typeof h.memoizedState === 'object' && !Array.isArray(h.memoizedState);
+        },
+        25
+      );
+      if (node != null) {
+        hook = node.memoizedState.next;
+      }
+    } catch (_) {}
+    return hook;
+  },
+
   getClipsBroadcasterInfo() {
     let broadcaster;
     try {


### PR DESCRIPTION
## Summary

- **`injectEmoteSets` now calls `forceUpdate()`** after updating the emote set so Twitch re-renders the autocomplete provider immediately when emotes are added in real-time (newly added channel emotes, 7TV emotes, etc.)
- **Added `__typename: 'Emote'` and `assetType`** to injected BTTV emote objects — Twitch's Slate WYSIWYG editor gates inline emote rendering on these fields being present; without them every BTTV emote showed as plain text
- **`syncSlateEmoteMap()`** — Twitch builds an internal emote token map as React state at editor initialization and never rebuilds it when new emotes arrive later (personal emotes via socket, dynamically added 7TV/channel emotes). After each `injectEmoteSets()` call we now dispatch missing tokens into that hook so late-loading emotes render immediately without a page refresh
- **Fixed `twitchComponentDidUpdate` spreading `prevProps`** incorrectly as iterable args instead of passing it as a single argument

## Root causes

1. `forceUpdate()` was never called after mutating the autocomplete emote array, so React never re-rendered the provider
2. Twitch's Slate plugin checks `emote.__typename === 'Emote'` before rendering inline images — BTTV emotes lacked this field
3. Twitch's Slate editor caches the emote token map at mount time; emotes loaded after mount (personal emotes, live 7TV/channel additions) were invisible to the Slate plugin until a full page reload
4. `prevProps` was spread as function args (`...prevProps`) instead of passed directly, which would throw on Twitch's native `componentDidUpdate`

## Test plan

- [ ] Type a BTTV global emote (e.g. `COGGERS`) — renders as image inline in chat input ✓
- [ ] Type a BTTV personal emote (e.g. `motnahP`) — renders as image inline in chat input ✓
- [ ] Add a new channel emote in real-time — renders in chat input without page refresh ✓
- [ ] Type a newly added 7TV channel emote — renders in chat input without page refresh ✓

Closes #5968

🤖 Generated with [Claude Code](https://claude.com/claude-code)