### PR TITLE
Fix command autocomplete dropping fast keystrokes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         "remove-files-webpack-plugin": "1.5.0",
         "safe-regex2": "5.1.1",
         "semver": "7.8.2",
-        "slate": "^0.124.1",
         "terser-webpack-plugin": "5.6.1",
         "twemoji": "14.0.2",
         "virtual-module-webpack-plugin": "0.4.1",
@@ -12438,12 +12437,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/slate": {
-      "version": "0.124.1",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.124.1.tgz",
-      "integrity": "sha512-ii7DwezgvbLAyKtHBIunjTR1kzbNfYLCUKLMzJELlbTZkvHzX4DzN7HKIwcakf6dPxO6AoeT/P7kHOcyTym/hA==",
-      "license": "MIT"
     },
     "node_modules/sockjs": {
       "version": "0.3.24",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "safe-regex2": "5.1.1",
     "semver": "7.8.2",
     "terser-webpack-plugin": "5.6.1",
-    "slate": "^0.124.1",
     "twemoji": "14.0.2",
     "virtual-module-webpack-plugin": "0.4.1",
     "webpack": "5.107.2",

--- a/src/modules/command_autocomplete/twitch/Autocomplete.jsx
+++ b/src/modules/command_autocomplete/twitch/Autocomplete.jsx
@@ -78,15 +78,10 @@ function getCurrentUserLevel() {
   return UserLevels.EVERYONE;
 }
 
-function findFocusedWord(value, selectionStart = 0) {
-  const subString = value.substring(0, selectionStart);
-  const focusedWords = subString.split(/\s+/);
-  const focusedWord = focusedWords[focusedWords.length - 1];
-  return focusedWord;
-}
-
 function getChatInputPartialCommand() {
-  const value = twitch.getChatInputValue();
+  const element = document.querySelector(CHAT_TEXT_AREA);
+  const value = twitch.getChatInputValue(element);
+
   if (value == null) {
     return null;
   }
@@ -95,22 +90,16 @@ function getChatInputPartialCommand() {
     return null;
   }
 
-  const caret = twitch.getChatInputCaretOffset(value);
+  const caret = twitch.getChatInputCaretOffset(value, element);
   if (caret == null) {
     return null;
   }
 
-  const firstWord = value.trim().split(/\s+/)[0];
-  if (caret > firstWord.length) {
-    return null;
-  }
-
-  const focusedWord = findFocusedWord(value, caret);
-  if (!focusedWord.startsWith(COMMAND_PREFIX)) {
-    return null;
-  }
-
-  return focusedWord;
+  // The command is the first word. Match it in full regardless of where the
+  // caret sits within it, but bail out once the caret moves past it into an
+  // argument.
+  const command = value.trim().split(/\s+/)[0];
+  return caret > command.length ? null : command;
 }
 
 function normalizeCommandInput(input) {

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -1,6 +1,5 @@
 import cookies from 'cookies-js';
 import gql from 'graphql-tag';
-import {Editor} from 'slate';
 import {getCurrentChannel, setCurrentChannel} from './channel.js';
 import debug from './debug.js';
 import {getCurrentUser, setCurrentUser} from './user.js';
@@ -661,61 +660,58 @@ export default {
     return chatInputEditor?.memoizedProps?.value?.editor ?? chatInputEditor?.stateNode?.state?.slateEditor;
   },
 
-  getChatInputValue() {
-    const element = document.querySelector(CHAT_INPUT);
+  getChatInputValue(element = null) {
+    element = element ?? document.querySelector(CHAT_INPUT);
 
-    // deprecated
+    if (element == null) {
+      return null;
+    }
+
+    // Legacy textarea
     const {value: currentValue} = element;
     if (currentValue != null) {
       return currentValue;
     }
 
-    const chatInput = this.getChatInput(element);
-    if (chatInput == null) {
-      return null;
-    }
-
-    return chatInput.memoizedProps.value;
+    // The chat input is a contenteditable Slate editor. Reading its textContent
+    // stays up to date as the user types (the browser mutates the DOM directly),
+    // unlike the React-controlled value which is committed asynchronously and
+    // lags behind fast keystrokes. Slate pads void/empty nodes with U+FEFF
+    // markers, so strip them out.
+    return element.textContent.replace(/\uFEFF/g, '');
   },
 
-  getChatInputCaretOffset(fullText = null) {
-    const element = document.querySelector(CHAT_INPUT);
+  getChatInputCaretOffset(fullText = null, element = null) {
+    element = element ?? document.querySelector(CHAT_INPUT);
     if (element == null) {
       return null;
     }
 
+    // Legacy textarea
     const {value: currentValue, selectionStart} = element;
     if (currentValue != null && typeof selectionStart === 'number') {
       return selectionStart;
     }
 
-    const chatInputEditor = this.getChatInputEditor(element);
+    // The chat input is a contenteditable. Measure the caret offset in the same
+    // (textContent) space as getChatInputValue by walking a DOM range from the
+    // start of the input to the caret, so emotes/void nodes count consistently.
+    // Slate keeps the FEFF markers out of its model, but they appear in the DOM,
+    // so strip them just like getChatInputValue does.
+    const selection = element.ownerDocument.getSelection();
+    if (selection != null && selection.rangeCount > 0 && element.contains(selection.focusNode)) {
+      const range = element.ownerDocument.createRange();
+      range.selectNodeContents(element);
+      range.setEnd(selection.focusNode, selection.focusOffset);
+      return range.toString().replace(/\uFEFF/g, '').length;
+    }
 
+    // No live selection (e.g. the input isn't focused); fall back to the end.
     if (fullText == null) {
-      fullText = this.getChatInputValue();
+      fullText = this.getChatInputValue(element);
     }
 
-    if (chatInputEditor == null) {
-      return fullText != null ? fullText.length : null;
-    }
-
-    let derived = null;
-
-    try {
-      const focus = chatInputEditor.selection.focus;
-      const start = Editor.start(chatInputEditor, []);
-      derived = Editor.string(chatInputEditor, {anchor: start, focus}).length;
-    } catch (_) {}
-
-    if (derived == null) {
-      return fullText != null ? fullText.length : null;
-    }
-
-    if (fullText != null && derived > fullText.length) {
-      return fullText.length;
-    }
-
-    return derived;
+    return fullText != null ? fullText.length : null;
   },
 
   setChatInputValue(text, shouldFocus = true) {


### PR DESCRIPTION
## Problem

Command autocomplete drops keystrokes when a key is pressed very quickly — the typed character never registers in the suggestion lookup.

## Root cause

The Twitch chat input is a contenteditable Slate editor. `getChatInputValue` read its value from the React-controlled `value` prop (`memoizedProps.value`), which is committed **asynchronously**. The autocomplete refreshes suggestions on `keyup`; on a fast keystroke that `keyup` runs before React commits the new value, so `getChatInputValue()` returns a **stale** string and the keystroke is lost.

Measured live, reading at each `keyup` while typing `!ban` quickly — the React prop stays empty the whole burst while the DOM's `textContent` is always correct:

| keyup | `memoizedProps.value` | `textContent` |
|------|------|------|
| `!` | `""` | `"!"` |
| `b` | `""` | `"!b"` |
| `a` | `""` | `"!ba"` |
| `n` | `""` | `"!ban"` |

## Fix

- **`getChatInputValue`** reads the input element's `textContent`, which the browser updates **synchronously** as the user types. It already includes emotes (verified to reproduce `memoizedProps.value` exactly for mixed text + emote + mention). Slate pads void/empty nodes with `U+FEFF` markers, which are stripped.
- **`getChatInputCaretOffset`** now measures the caret with a **DOM range** from the start of the input to the selection, so the offset is in the same `textContent` space as `getChatInputValue`. Previously it used `Editor.string`, which counts emote/void nodes as zero-length — inconsistent with the value string whenever an emote precedes the caret. (Verified: for `Kappa !ban`, the range offset is `10`/value-length, vs `5` from the old Slate offset.)
- The command word is matched **in full regardless of caret position** within it — editing the middle of e.g. `!hello` still autocompletes against the whole word rather than just the text before the caret. (The caret is still used to bail out when it's past the command word, i.e. editing an argument.)
- The command autocomplete resolves the chat element once and passes it to both helpers.
- This was the last use of the `slate` package's `Editor` API, so the **`slate` dependency is removed**.

## Trade-off

`textContent` lags by ~one frame immediately after a programmatic `setChatInputValue` (the DOM re-renders on the next frame), whereas the React prop updated synchronously. Consumers that set-then-read (emote menu, tab completion) only do so across separate, human-paced events, so a frame always elapses in between — verified the DOM catches up within one `requestAnimationFrame`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)