### PR TITLE
feat: select first command argument on autocomplete completion

### DIFF
--- a/src/modules/command_autocomplete/twitch/Autocomplete.jsx
+++ b/src/modules/command_autocomplete/twitch/Autocomplete.jsx
@@ -12,7 +12,7 @@ import domObserver from '../../../observers/dom.js';
 import settings from '../../../settings.js';
 import shadowDom from '../../shadow_dom/index.js';
 import twitch, {CHAT_INPUT} from '../../../utils/twitch.js';
-import CommandRow from '../components/CommandRow.jsx';
+import CommandRow, {ArgumentDisplayTextByArgumentType} from '../components/CommandRow.jsx';
 import useAuthStore from '../../../stores/auth.js';
 import {getAutocompleteSuggestions} from '../../../actions/autocomplete.js';
 import {getCurrentChannel} from '../../../utils/channel.js';
@@ -134,7 +134,22 @@ function getItemKey(item) {
 }
 
 function replaceChatInputPartialCommand(command) {
-  twitch.setChatInputValue(`${command.name} `);
+  const firstArgument = command.arguments?.[0];
+  const placeholder = firstArgument != null ? ArgumentDisplayTextByArgumentType[firstArgument.type] : null;
+
+  // No arguments to fill in: drop the caret after the command and a trailing space.
+  if (placeholder == null) {
+    twitch.setChatInputValue(`${command.name} `);
+    return;
+  }
+
+  // Insert the first argument placeholder (e.g. `!shoutout [user]`) and select it
+  // so the next keystroke replaces the placeholder.
+  const prefix = `${command.name} `;
+  twitch.setChatInputValue(`${prefix}${placeholder}`, true, {
+    start: prefix.length,
+    end: prefix.length + placeholder.length,
+  });
 }
 
 let currentCommands = [];

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -112,6 +112,18 @@ export const SelectionTypes = {
   END: 3,
 };
 
+// Sets the chat input to `text` and selects its [start, end) character range.
+// The text is inserted through Slate rather than the controlled value setters
+// (which apply asynchronously) so the range lands on the real content instead of
+// stale/empty content, which would otherwise corrupt the next keystrokes. Slate's
+// onChange keeps Twitch's value in sync; the value is one text node (path [0, 0]).
+function setSlateEditorValueWithSelection(editor, text, start, end) {
+  editor.select({anchor: editor.start([]), focus: editor.end([])});
+  editor.insertText(text);
+  editor.select({anchor: {path: [0, 0], offset: start}, focus: {path: [0, 0], offset: end}});
+  editor.onChange?.();
+}
+
 export default {
   async getUserProfilePicture(userId = null) {
     const currentUser = getCurrentUser();
@@ -714,25 +726,24 @@ export default {
     return fullText != null ? fullText.length : null;
   },
 
-  setChatInputValue(text, shouldFocus = true) {
+  // `selection` optionally describes the caret/selection to leave behind, as
+  // {start, end} character offsets into `text`. Defaults to a collapsed caret at
+  // the end of the text.
+  setChatInputValue(text, shouldFocus = true, selection = null) {
     const element = document.querySelector(CHAT_INPUT);
 
+    const selectionStart = selection?.start ?? text.length;
+    const selectionEnd = selection?.end ?? text.length;
+    const isRangeSelection = selectionStart !== selectionEnd;
+
     // deprecated
-    const {value: currentValue, selectionStart} = element;
+    const {value: currentValue} = element;
     if (currentValue != null) {
       element.value = text;
       element.dispatchEvent(new Event('input', {bubbles: true}));
+      getReactInstance(element)?.memoizedProps?.onChange?.({target: element});
 
-      const instance = getReactInstance(element);
-      if (instance) {
-        const props = instance.memoizedProps;
-        if (props && props.onChange) {
-          props.onChange({target: element});
-        }
-      }
-
-      const selectionEnd = selectionStart + text.length;
-      element.setSelectionRange(selectionEnd, selectionEnd);
+      element.setSelectionRange(selectionStart, selectionEnd);
 
       if (shouldFocus) {
         element.focus();
@@ -745,24 +756,33 @@ export default {
       return;
     }
 
-    chatInput.memoizedProps.value = text;
-    chatInput.memoizedProps.setInputValue(text);
-    chatInput.memoizedProps.onValueUpdate(text);
+    const chatInputEditor = shouldFocus ? this.getChatInputEditor(element) : null;
 
-    if (shouldFocus) {
-      const chatInputEditor = this.getChatInputEditor(element);
+    // A range selection goes through Slate (which also syncs the value via
+    // onChange), so skip the controlled setters here — they apply asynchronously
+    // and the range would land on stale content.
+    const useSlateSelection = isRangeSelection && typeof chatInputEditor?.select === 'function';
 
-      // TODO: remove after legacy slate is gone
-      if (chatInputEditor != null && 'setSelectionRange' in chatInputEditor) {
-        chatInputEditor.focus();
-        chatInputEditor.setSelectionRange(text.length);
-        // setSelection seems missing now, so we can't set selection
-      } else if (chatInputEditor != null && 'setSelection' in chatInputEditor) {
-        element.focus();
-        chatInputEditor.setSelection(text.length);
-      } else {
-        element.focus();
-      }
+    if (!useSlateSelection) {
+      chatInput.memoizedProps.value = text;
+      chatInput.memoizedProps.setInputValue(text);
+      chatInput.memoizedProps.onValueUpdate(text);
+    }
+
+    if (!shouldFocus) {
+      return;
+    }
+
+    // TODO: remove setSelectionRange branch after legacy slate is gone
+    const isLegacySlate = chatInputEditor != null && 'setSelectionRange' in chatInputEditor;
+    (isLegacySlate ? chatInputEditor : element).focus();
+
+    if (useSlateSelection) {
+      setSlateEditorValueWithSelection(chatInputEditor, text, selectionStart, selectionEnd);
+    } else if (isLegacySlate) {
+      chatInputEditor.setSelectionRange(selectionEnd);
+    } else if (chatInputEditor != null && 'setSelection' in chatInputEditor) {
+      chatInputEditor.setSelection(selectionEnd);
     }
   },
 


### PR DESCRIPTION
## What

When completing a chatbot command that takes arguments via the command autocomplete, the first argument placeholder is now inserted **and selected**, so the next keystroke replaces it.

- `!shoutout` → completes to `!shoutout [user]` with `[user]` selected → typing immediately overwrites it.
- Commands with **no** arguments are unchanged: `!command ` with the caret at the end.

Only the first argument is inserted (commands can have several — `[user]`/`[word]`/`[phrase]`); the placeholder text is reused from `ArgumentDisplayTextByArgumentType` so it stays consistent with the autocomplete row subtitle. Twitch only for now.

## How

`twitch.setChatInputValue(text, shouldFocus, selection?)` gains an optional `selection` (`{start, end}` character offsets into `text`). When a range is requested, it's applied through Slate rather than the controlled value setters.

This matters because Twitch's chat input is a controlled Slate editor whose value prop reaches `editor.children` **asynchronously**. Setting the value and then selecting `[start, end)` immediately lands the range on stale (usually empty) content — an invalid selection that corrupts the next keystrokes (e.g. inserting newlines). A raw DOM selection doesn't work either: the controlled re-render collapses it back to a caret.

So for the range case we drive everything through Slate synchronously — `select-all → insertText(text) → select(range)` — which populates the content before selecting and keeps Twitch's value in sync via `onChange`. Collapsed-caret callers (emote menu, tab completion, mod cards, no-arg commands) are unchanged.

## Testing

Verified live on `twitch.tv/popout/<channel>/chat`: after completion the input shows `!shoutout [user]` as a single block with a valid selection over `[user]`, and a keystroke replaces it cleanly (`!shoutout x`) with no extra blocks/newlines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)