### PR TITLE
fix: show legacy emote menu button in moderator view

### DIFF
--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -17,8 +17,12 @@ const CHAT_INPUT = '.chat-input';
 
 // For legacy button
 const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID = 'bttv-legacy-emote-picker-button-container';
-const CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR =
-  '.chat-input div[data-test-selector="chat-input-buttons-container"] div:has(button[data-a-target="chat-settings"])';
+// Keyed on the test-selector (not `.chat-input`) so the dom observer fires when the button
+// row itself mounts. In moderator view it mounts after `load.chat`, so observing `.chat-input`
+// would miss it.
+const CHAT_INPUT_BUTTONS_CONTAINER_SELECTOR = 'div[data-test-selector="chat-input-buttons-container"]';
+const CHAT_SEND_BUTTON_SELECTOR = 'button[data-a-target="chat-send-button"]';
+const CHAT_SETTINGS_BUTTON_SELECTOR = 'button[data-a-target="chat-settings"]';
 
 const BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID = 'bttv-emote-picker-button-container';
 const EMOTE_PICKER_BUTTON_SELECTOR = 'button[data-a-target="emote-picker-button"]';
@@ -79,28 +83,37 @@ function loadLegacyButton() {
     return;
   }
 
-  const chatSettingsContainer = document.querySelector(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR);
-  if (chatSettingsContainer == null) {
+  const buttonsContainer = document.querySelector(CHAT_INPUT_BUTTONS_CONTAINER_SELECTOR);
+  if (buttonsContainer == null) {
     return;
   }
 
+  // The controls group (chat settings in regular chat, shield mode in moderator view) is the
+  // button group right before the send button.
+  const sendButtonContainer = buttonsContainer.querySelector(`div:has(${CHAT_SEND_BUTTON_SELECTOR})`);
+  const controlsContainer = sendButtonContainer?.previousElementSibling;
+  if (controlsContainer == null) {
+    return;
+  }
+
+  // Anchor after the last native button in the controls group.
+  const buttonContainers = [...controlsContainer.children].filter((child) => child.querySelector('button') != null);
+  const lastButtonContainer = buttonContainers[buttonContainers.length - 1];
+  if (lastButtonContainer == null) {
+    return;
+  }
+
+  // In regular chat the moderator shield mode button shares the row with the chat settings
+  // button, leaving no room for the emote menu button, so hide it. Moderator view has no
+  // chat settings button and enough room, so the shield mode button stays visible there.
   const chatInput = document.querySelector(CHAT_INPUT);
-  if (chatInput != null) {
+  if (chatInput != null && controlsContainer.querySelector(CHAT_SETTINGS_BUTTON_SELECTOR) != null) {
     chatInput.classList.add(styles.hideShieldModeButton);
   }
 
   const buttonContainer = document.createElement('div');
   buttonContainer.setAttribute('id', LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
-
-  const chatSettingsButtonContainer = chatSettingsContainer.querySelector(
-    'div:has(button[data-a-target="chat-settings"])'
-  );
-
-  if (chatSettingsButtonContainer == null) {
-    return;
-  }
-
-  chatSettingsButtonContainer.after(buttonContainer);
+  lastButtonContainer.after(buttonContainer);
 
   const button = document.createElement('button');
   button.classList.add(styles.button);
@@ -199,7 +212,7 @@ function loadEmoteMenu(onMount, onError) {
 
 class EmoteMenuModule {
   constructor() {
-    domObserver.on(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR, (node, isConnected) => {
+    domObserver.on(CHAT_INPUT_BUTTONS_CONTAINER_SELECTOR, (node, isConnected) => {
       if (!isConnected) {
         return;
       }


### PR DESCRIPTION
Fixes #8048

### Problem

With the BTTV emote menu enabled but **not** set to replace Twitch's native menu (the separate/"legacy" button), the button never appeared in **moderator view** (`twitch.tv/moderator/<channel>`). It only worked in regular chat, or if the user opted to replace the native emote menu.

The button anchored itself to the native **chat settings** button, which moderator view doesn't render, so `loadLegacyButton` bailed out early. The dom observer was also keyed on `.chat-input`, so it never re-ran once the button row mounted late in moderator view.

### Fix

- Anchor the button to the controls group immediately before the **send** button (present in both regular and moderator chat) and insert it after the last native button in that group — chat settings in regular chat, shield mode in moderator view.
- Key the dom observer on the chat-input buttons container `data-test-selector` instead of `.chat-input`, so it fires when that row mounts (in moderator view it mounts after `load.chat`).
- Only hide the moderator shield-mode button when the chat settings button shares the row (regular chat, where space is tight). Moderator view has room, so the shield-mode button stays visible.

### Testing

Verified live at `twitch.tv/moderator/vasp` and a regular channel:

- **Moderator view:** button now appears between the shield-mode button and the send button; shield-mode button remains visible; send button is not clipped.
- **Regular chat:** unchanged — button appears after the chat settings button, shield-mode hidden as before (#7950).

🤖 Generated with [Claude Code](https://claude.com/claude-code)