### PR TITLE
qol: migrate icons to Hugeicons Pro with Font Awesome fallback

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@hugeicons-pro:registry=https://npm.hugeicons.com/
+//npm.hugeicons.com/:_authToken=${HUGEICONS_TOKEN}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@fortawesome/fontawesome-svg-core": "7.2.0",
         "@fortawesome/free-brands-svg-icons": "7.2.0",
         "@fortawesome/free-solid-svg-icons": "7.2.0",
+        "@hugeicons-pro/core-solid-rounded": "^4.2.0",
         "@mantine/core": "^9.3.0",
         "@mantine/hooks": "^9.3.0",
         "@mantine/modals": "^9.3.0",
@@ -2314,6 +2315,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@hugeicons-pro/core-solid-rounded": {
+      "version": "4.2.0",
+      "resolved": "https://npm.hugeicons.com/@hugeicons-pro/core-solid-rounded/-/core-solid-rounded-4.2.0.tgz",
+      "integrity": "sha512-PbN1gPVm16/TEdgjQ9RnD4MvkoqtPZfWo02RV5KN1wJmvUx++Q+7MBUn/JFq3NU3/iJcJi4Fk8MutP0VDdlRKA==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -113,5 +113,8 @@
     },
     "brace-expansion@>=5.0.0 <5.0.6": "^5.0.6",
     "uuid@<11.1.1": "^11.1.1"
+  },
+  "optionalDependencies": {
+    "@hugeicons-pro/core-solid-rounded": "^4.2.0"
   }
 }

--- a/src/common/components/Autocomplete.jsx
+++ b/src/common/components/Autocomplete.jsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import useDomObserver from '../hooks/DomObserver.jsx';
 import formatMessage from '../../i18n/index.js';
 import Icon from './Icon.jsx';
-import {faArrowDown, faArrowTurnDown, faArrowUp} from '@fortawesome/free-solid-svg-icons';
+import {faArrowDown, faArrowTurnDown, faArrowUp} from '../icons/index.js';
 import {Kbd, Text} from '@mantine/core';
 import Scrollbar from './Scrollbar.jsx';
 

--- a/src/common/components/Emote.jsx
+++ b/src/common/components/Emote.jsx
@@ -5,7 +5,7 @@ import {EmoteTypeFlags, SettingIds} from '../../constants.js';
 import {hasFlag} from '../../utils/flags.js';
 import {createSrcSet, createSrc, DEFAULT_SIZES} from '../../utils/image.js';
 import styles from './Emote.module.css';
-import {faLock} from '@fortawesome/free-solid-svg-icons';
+import {faLock} from '../icons/index.js';
 import settings from '../../settings.js';
 
 export default function Emote({emote, className, locked, sizes = DEFAULT_SIZES, animating = false}) {

--- a/src/common/components/Icon.jsx
+++ b/src/common/components/Icon.jsx
@@ -1,7 +1,33 @@
 import React from 'react';
 
+// Renders an icon from either Hugeicons Pro (an array of [tag, attrs] tuples on a
+// 24x24 viewBox) or Font Awesome (an object whose `icon` field is [width, height, …, path]).
+// The icon source is chosen at build time (see src/common/icons), so both shapes must render.
 function Icon({icon, size = 16, className}) {
-  if (icon?.icon == null) {
+  if (icon == null) {
+    return null;
+  }
+
+  // Hugeicons: array of ['path', {d, fill, key}] tuples.
+  if (Array.isArray(icon)) {
+    return (
+      <svg
+        fill="none"
+        viewBox="0 0 24 24"
+        width={size}
+        height={size}
+        aria-hidden="true"
+        focusable="false"
+        className={className}>
+        {icon.map(([Tag, {key, ...attrs}], i) => (
+          <Tag key={key ?? i} {...attrs} />
+        ))}
+      </svg>
+    );
+  }
+
+  // Font Awesome fallback.
+  if (icon.icon == null) {
     return null;
   }
 

--- a/src/common/icons/index.fontawesome.js
+++ b/src/common/icons/index.fontawesome.js
@@ -1,0 +1,35 @@
+// Font Awesome icon set. This is the fallback icon source used when the Hugeicons Pro
+// optional dependency (@hugeicons-pro/core-solid-rounded) is not installed. Webpack swaps
+// ./index.hugeicons.js for this module at build time (see webpack.config.js).
+//
+// Keep these exports in sync with ./index.hugeicons.js.
+export {
+  faArrowDown,
+  faArrowLeft,
+  faArrowTurnDown,
+  faArrowUp,
+  faBars,
+  faBasketballBall,
+  faBox,
+  faCheckCircle,
+  faClock,
+  faClose,
+  faCog,
+  faFlag,
+  faHeart,
+  faHeartBroken,
+  faIceCream,
+  faLeaf,
+  faLightbulb,
+  faLock,
+  faPaintBrush,
+  faPlane,
+  faScroll,
+  faSmileWink,
+  faStar,
+  faTrash,
+  faUnlock,
+  faUser,
+  faUserGear,
+} from '@fortawesome/free-solid-svg-icons';
+export {faTwitch, faYoutube} from '@fortawesome/free-brands-svg-icons';

--- a/src/common/icons/index.hugeicons.js
+++ b/src/common/icons/index.hugeicons.js
@@ -7,6 +7,9 @@
 //
 // Exports keep the `fa*` names the codebase already used to minimize churn; each maps to
 // the closest Hugeicons solid equivalent.
+//
+// The Pro package is an optional dependency, so it may be unresolved at lint/build time (e.g.
+// CI without the registry token); webpack swaps this module for the Font Awesome fallback then.
 import {
   Airplane01Icon,
   ArrowDown01Icon,
@@ -37,6 +40,7 @@ import {
   UserSettings01Icon,
   WinkIcon,
   YoutubeIcon,
+  // eslint-disable-next-line import/no-unresolved
 } from '@hugeicons-pro/core-solid-rounded';
 
 export const faLock = LockIcon;

--- a/src/common/icons/index.hugeicons.js
+++ b/src/common/icons/index.hugeicons.js
@@ -1,0 +1,70 @@
+// Hugeicons Pro (solid rounded) icon set. This is the default icon source.
+//
+// At build time, if the `@hugeicons-pro/core-solid-rounded` optional dependency is not
+// installed (e.g. a contributor without a Pro license, or CI without the registry token),
+// webpack swaps this module for ./index.fontawesome.js via NormalModuleReplacementPlugin.
+// Both modules expose the same exports, so the rest of the codebase is source-agnostic.
+//
+// Exports keep the `fa*` names the codebase already used to minimize churn; each maps to
+// the closest Hugeicons solid equivalent.
+import {
+  Airplane01Icon,
+  ArrowDown01Icon,
+  ArrowLeft01Icon,
+  ArrowTurnBackwardIcon,
+  ArrowUp01Icon,
+  BasketballIcon,
+  Cancel01Icon,
+  CheckmarkCircle02Icon,
+  Clock01Icon,
+  Delete02Icon,
+  FavouriteIcon,
+  Flag02Icon,
+  GraduationScrollIcon,
+  HeartbreakIcon,
+  IceCream01Icon,
+  Idea01Icon,
+  Leaf01Icon,
+  LockIcon,
+  Menu01Icon,
+  Package01Icon,
+  PaintBrush01Icon,
+  Settings01Icon,
+  SquareUnlock01Icon,
+  StarIcon,
+  TwitchIcon,
+  UserIcon,
+  UserSettings01Icon,
+  WinkIcon,
+  YoutubeIcon,
+} from '@hugeicons-pro/core-solid-rounded';
+
+export const faLock = LockIcon;
+export const faUnlock = SquareUnlock01Icon;
+export const faArrowUp = ArrowUp01Icon;
+export const faArrowDown = ArrowDown01Icon;
+export const faArrowTurnDown = ArrowTurnBackwardIcon;
+export const faArrowLeft = ArrowLeft01Icon;
+export const faTrash = Delete02Icon;
+export const faCog = Settings01Icon;
+export const faScroll = GraduationScrollIcon;
+export const faUser = UserIcon;
+export const faUserGear = UserSettings01Icon;
+export const faClose = Cancel01Icon;
+export const faPaintBrush = PaintBrush01Icon;
+export const faCheckCircle = CheckmarkCircle02Icon;
+export const faBars = Menu01Icon;
+export const faStar = StarIcon;
+export const faSmileWink = WinkIcon;
+export const faLeaf = Leaf01Icon;
+export const faIceCream = IceCream01Icon;
+export const faBasketballBall = BasketballIcon;
+export const faPlane = Airplane01Icon;
+export const faBox = Package01Icon;
+export const faHeart = FavouriteIcon;
+export const faHeartBroken = HeartbreakIcon;
+export const faFlag = Flag02Icon;
+export const faClock = Clock01Icon;
+export const faLightbulb = Idea01Icon;
+export const faTwitch = TwitchIcon;
+export const faYoutube = YoutubeIcon;

--- a/src/common/icons/index.js
+++ b/src/common/icons/index.js
@@ -1,0 +1,4 @@
+// Central icon registry. Re-exports the Hugeicons Pro set by default; webpack replaces
+// the underlying module with the Font Awesome fallback at build time when Hugeicons Pro
+// is not installed. Import icons from here instead of from a vendor package directly.
+export * from './index.hugeicons.js';

--- a/src/modules/emote_menu/components/Icons.jsx
+++ b/src/modules/emote_menu/components/Icons.jsx
@@ -12,9 +12,10 @@ import {
   faPlane,
   faSmileWink,
   faStar,
+  faTwitch,
   faUnlock,
-} from '@fortawesome/free-solid-svg-icons';
-import {faTwitch, faYoutube} from '@fortawesome/free-brands-svg-icons';
+  faYoutube,
+} from '../../../common/icons/index.js';
 import classNames from 'classnames';
 import React from 'react';
 import styles from './Icons.module.css';

--- a/src/modules/settings/components/PageHeader.jsx
+++ b/src/modules/settings/components/PageHeader.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import useAuthStore from '../../../stores/auth.js';
 import {useShallow} from 'zustand/react/shallow';
 import Icon from '../../../common/components/Icon.jsx';
-import {faBars} from '@fortawesome/free-solid-svg-icons';
+import {faBars} from '../../../common/icons/index.js';
 
 const PageHeader = React.forwardRef(({className, leftContent, onClose}, ref) => {
   const {setSidenavOpen} = useContext(PageContext);

--- a/src/modules/settings/components/Promotion.jsx
+++ b/src/modules/settings/components/Promotion.jsx
@@ -6,7 +6,7 @@ import {ActionIcon, Button, Image, Title} from '@mantine/core';
 import {PageContext} from '../contexts/PageContext.jsx';
 import {SettingPanelIds} from '../stores/SettingStore.jsx';
 import Icon from '../../../common/components/Icon.jsx';
-import {faClose, faPaintBrush} from '@fortawesome/free-solid-svg-icons';
+import {faClose, faPaintBrush} from '../../../common/icons/index.js';
 import formatMessage from '../../../i18n/index.js';
 import storage from '../../../storage.js';
 import NightbotLogoIcon from '../../../common/components/NightbotLogoIcon.jsx';

--- a/src/modules/settings/components/SettingColorRadio.jsx
+++ b/src/modules/settings/components/SettingColorRadio.jsx
@@ -5,7 +5,7 @@ import styles from './SettingColorRadio.module.css';
 import SettingWrapper from './SettingWrapper.jsx';
 import usePortalRef from '../../../common/hooks/PortalRef.jsx';
 import Icon from '../../../common/components/Icon.jsx';
-import {faCheckCircle} from '@fortawesome/free-solid-svg-icons';
+import {faCheckCircle} from '../../../common/icons/index.js';
 
 function SettingColorRadio({
   value,

--- a/src/modules/settings/components/SettingKeywords.jsx
+++ b/src/modules/settings/components/SettingKeywords.jsx
@@ -15,7 +15,7 @@ import {
   TextInput,
 } from '@mantine/core';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
-import {faTrash} from '@fortawesome/free-solid-svg-icons';
+import {faTrash} from '../../../common/icons/index.js';
 import styles from './SettingKeywords.module.css';
 import {KeywordTypes} from '../../../utils/keywords.js';
 import formatMessage from '../../../i18n/index.js';

--- a/src/modules/settings/components/SettingsModal.jsx
+++ b/src/modules/settings/components/SettingsModal.jsx
@@ -15,7 +15,7 @@ import PageHeader from './PageHeader.jsx';
 import {PageContext} from '../contexts/PageContext.jsx';
 import BlacklistKeywords from '../pages/BlacklistKeywords.jsx';
 import {AnimatePresence, motion, usePresenceData} from 'framer-motion';
-import {faArrowLeft} from '@fortawesome/free-solid-svg-icons';
+import {faArrowLeft} from '../../../common/icons/index.js';
 import Icon from '../../../common/components/Icon.jsx';
 import formatMessage from '../../../i18n/index.js';
 

--- a/src/modules/settings/components/SideNavigation.jsx
+++ b/src/modules/settings/components/SideNavigation.jsx
@@ -3,7 +3,7 @@ import {useShallow} from 'zustand/react/shallow';
 import styles from './SideNavigation.module.css';
 import AnimatedLogo from './AnimatedLogo.jsx';
 import {ActionIcon, Avatar, Button, Overlay, Tooltip, useMantineTheme} from '@mantine/core';
-import {faArrowLeft, faCog, faScroll, faUser, faUserGear} from '@fortawesome/free-solid-svg-icons';
+import {faArrowLeft, faCog, faScroll, faUser, faUserGear} from '../../../common/icons/index.js';
 import {PageTypes} from '../../../constants.js';
 import classNames from 'classnames';
 import formatMessage from '../../../i18n/index.js';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,21 @@ import VirtualModulesPlugin from 'webpack-virtual-modules';
 
 dotenv.config();
 
-const git = createRequire(import.meta.url)('git-rev-sync');
+const require = createRequire(import.meta.url);
+const git = require('git-rev-sync');
 const {EnvironmentPlugin, optimize} = webpack;
+
+// Hugeicons Pro is an optional dependency. When it isn't installed (e.g. a contributor
+// without a Pro license, or CI without the registry token), fall back to Font Awesome by
+// swapping the icon source module at build time.
+function hugeiconsAvailable() {
+  try {
+    require.resolve('@hugeicons-pro/core-solid-rounded');
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function convertEmojiToolkitCodePointToChar(codePoint) {
   if (codePoint.includes('-')) {
@@ -84,6 +97,11 @@ export default async (env, argv) => {
   const OAUTH2_CLIENT_ID = process.env.OAUTH2_CLIENT_ID ?? '69df8fd87facce5d303ec889';
   const OAUTH2_REDIRECT_URI = process.env.OAUTH2_REDIRECT_URI ?? 'https://betterttv.com/extension/callback';
   const SOCKET_ENDPOINT = process.env.SOCKET_ENDPOINT ?? 'wss://sockets.betterttv.net/ws';
+
+  const HUGEICONS = hugeiconsAvailable();
+  if (!HUGEICONS) {
+    console.warn('[icons] @hugeicons-pro/core-solid-rounded not installed; falling back to Font Awesome icons.');
+  }
 
   const {version} = JSON.parse(await fs.readFile('./package.json'));
   const emotes = JSON.parse(await fs.readFile('./node_modules/emoji-toolkit/emoji.json'));
@@ -218,6 +236,14 @@ export default async (env, argv) => {
     },
     devtool: PROD ? 'hidden-source-map' : 'eval',
     plugins: [
+      ...(HUGEICONS
+        ? []
+        : [
+            new webpack.NormalModuleReplacementPlugin(
+              /icons[/\\]index\.hugeicons\.js$/,
+              path.resolve('./src/common/icons/index.fontawesome.js')
+            ),
+          ]),
       new webpack.BannerPlugin({
         banner: (await fs.readFile('LICENSE')).toString(),
         entryOnly: true,


### PR DESCRIPTION
## Summary

Migrates all icons to **Hugeicons Pro (solid rounded)**, with a transparent fallback to **Font Awesome** when the Pro package isn't installed.

Icons now resolve through a central registry at `src/common/icons` instead of importing `@fortawesome/*` directly across components. The registry has two interchangeable implementations exposing the same exports:

- `index.hugeicons.js` — default; maps each icon to its Hugeicons Pro solid equivalent.
- `index.fontawesome.js` — fallback; backed by `@fortawesome`.

## How the fallback works

Two independent layers ensure builds never break without a Pro license:

1. **Install:** `@hugeicons-pro/core-solid-rounded` is an `optionalDependency`, so a tokenless `npm install` (CI, or contributors without a license) doesn't hard-fail.
2. **Build:** `webpack.config.js` checks whether the Pro package resolves; if not, a `NormalModuleReplacementPlugin` swaps `index.hugeicons.js` → `index.fontawesome.js` and logs a warning.

The shared `Icon` component now renders both icon shapes (Hugeicons path-tuple arrays and Font Awesome `{icon:[…]}` objects).

## Setup note

`.npmrc` points the `@hugeicons-pro` scope at the private registry and reads the license token from the `HUGEICONS_TOKEN` environment variable — **no secret is committed**. To install the Pro package, set `HUGEICONS_TOKEN` in your environment before `npm install`. Without it, the build falls back to Font Awesome.

## Verification

- ✅ Build with the Pro package installed → uses Hugeicons (tree-shaken to only the icons in use).
- ✅ Build with the package absent → logs the fallback warning and compiles successfully with Font Awesome.
- ✅ `npm run lint` (eslint + prettier) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)