### PR TITLE
Fix separate emote menu button missing in mod view

### DIFF
--- a/src/modules/emote_menu/twitch/EmoteMenu.jsx
+++ b/src/modules/emote_menu/twitch/EmoteMenu.jsx
@@ -17,8 +17,10 @@ const CHAT_INPUT = '.chat-input';
 
 // For legacy button
 const LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID = 'bttv-legacy-emote-picker-button-container';
-const CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR =
-  '.chat-input div[data-test-selector="chat-input-buttons-container"] div:has(button[data-a-target="chat-settings"])';
+const CHAT_INPUT_BUTTONS_CONTAINER_SELECTOR = '.chat-input div[data-test-selector="chat-input-buttons-container"]';
+const CHAT_SETTINGS_BUTTON_SELECTOR = 'button[data-a-target="chat-settings"]';
+const CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR = `div:has(${CHAT_SETTINGS_BUTTON_SELECTOR})`;
+const CHAT_SEND_BUTTON_SELECTOR = 'button[data-a-target="chat-send-button"]';
 
 const BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID = 'bttv-emote-picker-button-container';
 const EMOTE_PICKER_BUTTON_SELECTOR = 'button[data-a-target="emote-picker-button"]';
@@ -79,28 +81,37 @@ function loadLegacyButton() {
     return;
   }
 
-  const chatSettingsContainer = document.querySelector(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR);
-  if (chatSettingsContainer == null) {
+  const buttonsContainer = document.querySelector(CHAT_INPUT_BUTTONS_CONTAINER_SELECTOR);
+  if (buttonsContainer == null) {
     return;
-  }
-
-  const chatInput = document.querySelector(CHAT_INPUT);
-  if (chatInput != null) {
-    chatInput.classList.add(styles.hideShieldModeButton);
   }
 
   const buttonContainer = document.createElement('div');
   buttonContainer.setAttribute('id', LEGACY_BTTV_EMOTE_PICKER_BUTTON_CONTAINER_ID);
 
-  const chatSettingsButtonContainer = chatSettingsContainer.querySelector(
-    'div:has(button[data-a-target="chat-settings"])'
-  );
+  const chatSettingsButtonContainer = buttonsContainer.querySelector(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR);
 
-  if (chatSettingsButtonContainer == null) {
-    return;
+  if (chatSettingsButtonContainer != null) {
+    // Regular chat: place the button alongside the chat settings button.
+    chatSettingsButtonContainer.after(buttonContainer);
+  } else {
+    // Moderator view doesn't expose a chat settings button, so place the button next to the
+    // send button instead.
+    const chatSendButton = buttonsContainer.querySelector(CHAT_SEND_BUTTON_SELECTOR);
+    const chatSendButtonContainer = [...buttonsContainer.children].find((child) => child.contains(chatSendButton));
+    if (chatSendButtonContainer == null) {
+      return;
+    }
+    buttonsContainer.insertBefore(buttonContainer, chatSendButtonContainer);
   }
 
-  chatSettingsButtonContainer.after(buttonContainer);
+  // In regular chat the moderator shield mode button shares the row with the chat settings
+  // button, leaving no room for the emote menu button, so hide it. Moderator view has no chat
+  // settings button and enough room, so the shield mode button stays visible there.
+  const chatInput = document.querySelector(CHAT_INPUT);
+  if (chatInput != null && chatSettingsButtonContainer != null) {
+    chatInput.classList.add(styles.hideShieldModeButton);
+  }
 
   const button = document.createElement('button');
   button.classList.add(styles.button);
@@ -199,7 +210,7 @@ function loadEmoteMenu(onMount, onError) {
 
 class EmoteMenuModule {
   constructor() {
-    domObserver.on(CHAT_SETTINGS_BUTTON_CONTAINER_SELECTOR, (node, isConnected) => {
+    domObserver.on(CHAT_INPUT_BUTTONS_CONTAINER_SELECTOR, (node, isConnected) => {
       if (!isConnected) {
         return;
       }


### PR DESCRIPTION
Fixes #8048

### Problem

With the BTTV emote menu enabled but **not** set to replace Twitch's native menu (the separate "legacy" button), the button never appeared in **moderator view** (`twitch.tv/moderator/<channel>`). It only worked in regular chat, or if the user opted to replace the native emote menu.

The button anchored itself to the native **chat settings** button, which moderator view doesn't render, so `loadLegacyButton` bailed out early.

### Fix

- Anchor to the chat input **buttons container** instead. Keep the existing placement next to the chat settings button in regular chat; fall back to placing the button next to the **send button** in moderator view (where there's no chat settings button).
- Point the dom observer at the buttons container so the button is also re-added when that row re-renders.
- Only hide the moderator **shield mode** button when the chat settings button shares the row (regular chat), where space is tight. Moderator view has room, so the shield mode button stays visible.

Builds on the approach from #8049 (the shield-mode-visible refinement), reworked so the button reliably mounts in moderator view.

### Testing

Verified live with the dev extension across every view × emote-menu setting:

| View | Separate button | Replace native | Off |
|------|-----------------|----------------|-----|
| Moderator view | ✅ next to CHAT, shield stays visible, native picker separate | ✅ replaces native | ✅ none |
| Channel | ✅ next to chat settings | ✅ replaces native | ✅ none |
| Popout | ✅ next to chat settings | ✅ replaces native | ✅ none |
| Dashboard (stream manager) | ✅ next to CHAT | ✅ replaces native | ✅ none |

🤖 Generated with [Claude Code](https://claude.com/claude-code)