### PR TITLE
fix: show command autocomplete argument names in the menu

### DIFF
--- a/src/common/components/AutocompleteRow.module.css
+++ b/src/common/components/AutocompleteRow.module.css
@@ -33,6 +33,7 @@
 
 .subtitle {
   min-width: 0;
+  margin-left: auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/common/components/AutocompleteRow.module.css
+++ b/src/common/components/AutocompleteRow.module.css
@@ -52,7 +52,8 @@
 }
 
 .title {
-  flex-shrink: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
   font-weight: 600;
 }
 

--- a/src/common/components/AutocompleteRow.module.css
+++ b/src/common/components/AutocompleteRow.module.css
@@ -29,7 +29,7 @@
 .selected {
   color: var(--mantine-primary-color-filled);
   background-color: var(--mantine-primary-color-light-hover);
-  --bttv-dimmed-active-color: var(--bttv-primary-color-dimmed);
+  --bttv-dimmed-active-color: var(--mantine-primary-color-dimmed);
 }
 
 .subtitle {

--- a/src/common/components/AutocompleteRow.module.css
+++ b/src/common/components/AutocompleteRow.module.css
@@ -29,7 +29,7 @@
 .selected {
   color: var(--mantine-primary-color-filled);
   background-color: var(--mantine-primary-color-light-hover);
-  --bttv-dimmed-active-color: var(--mantine-primary-color-dimmed);
+  --bttv-dimmed-active-color: var(--mantine-primary-color-filled-hover);
 }
 
 .subtitle {

--- a/src/common/components/AutocompleteRow.module.css
+++ b/src/common/components/AutocompleteRow.module.css
@@ -29,7 +29,7 @@
 .selected {
   color: var(--mantine-primary-color-filled);
   background-color: var(--mantine-primary-color-light-hover);
-  --bttv-dimmed-active-color: var(--mantine-primary-color-light-color);
+  --bttv-dimmed-active-color: var(--bttv-primary-color-dimmed);
 }
 
 .subtitle {

--- a/src/common/components/AutocompleteRow.module.css
+++ b/src/common/components/AutocompleteRow.module.css
@@ -29,6 +29,7 @@
 .selected {
   color: var(--mantine-primary-color-filled);
   background-color: var(--mantine-primary-color-light-hover);
+  --bttv-dimmed-active-color: var(--mantine-primary-color-light-color);
 }
 
 .subtitle {

--- a/src/modules/command_autocomplete/components/CommandRow.jsx
+++ b/src/modules/command_autocomplete/components/CommandRow.jsx
@@ -2,20 +2,13 @@ import React, {useMemo} from 'react';
 import AutocompleteRow from '../../../common/components/AutocompleteRow.jsx';
 import NightbotLogoIcon from '../../../common/components/NightbotLogoIcon.jsx';
 import styles from './CommandRow.module.css';
-import {CommandAutocompleteArgumentTypes, CommandProviders} from '../../../constants.js';
+import {CommandProviders} from '../../../constants.js';
 import cdn from '../../../utils/cdn.js';
-import formatMessage from '../../../i18n/index.js';
 
 const LogoByCommandProvider = {
   [CommandProviders.FOSSABOT]: cdn.url('/assets/logos/fossabot_logo.png'),
   [CommandProviders.MOOBOT]: cdn.url('/assets/logos/moobot_logo.png'),
   [CommandProviders.STREAMELEMENTS]: cdn.url('/assets/logos/streamelements_logo.png'),
-};
-
-export const ArgumentDisplayTextByArgumentType = {
-  [CommandAutocompleteArgumentTypes.WORD]: formatMessage({defaultMessage: '[word]'}),
-  [CommandAutocompleteArgumentTypes.PHRASE]: formatMessage({defaultMessage: '[phrase]'}),
-  [CommandAutocompleteArgumentTypes.USER]: formatMessage({defaultMessage: '[user]'}),
 };
 
 function CommandRow({item, active, selected, onMouseOver, onClick}) {
@@ -34,7 +27,7 @@ function CommandRow({item, active, selected, onMouseOver, onClick}) {
 
   const subtitle = useMemo(() => {
     if (item.arguments.length > 0) {
-      return item.arguments.map((argument) => ArgumentDisplayTextByArgumentType[argument.type]).join(' ');
+      return item.arguments.map((argument) => `[${argument.name.toLowerCase()}]`).join(' ');
     }
 
     return null;

--- a/src/modules/command_autocomplete/components/CommandRow.jsx
+++ b/src/modules/command_autocomplete/components/CommandRow.jsx
@@ -32,9 +32,9 @@ function CommandRow({item, active, selected, onMouseOver, onClick}) {
 
     const argumentText = item.arguments.map((argument) => `[${argument.name.toLowerCase()}]`).join(' ');
     return (
-      <>
+      <React.Fragment>
         {item.name} <span className={styles.arguments}>{argumentText}</span>
-      </>
+      </React.Fragment>
     );
   }, [item.name, item.arguments]);
 

--- a/src/modules/command_autocomplete/components/CommandRow.jsx
+++ b/src/modules/command_autocomplete/components/CommandRow.jsx
@@ -25,19 +25,23 @@ function CommandRow({item, active, selected, onMouseOver, onClick}) {
     return null;
   }, [item.provider]);
 
-  const subtitle = useMemo(() => {
-    if (item.arguments.length > 0) {
-      return item.arguments.map((argument) => `[${argument.name.toLowerCase()}]`).join(' ');
+  const title = useMemo(() => {
+    if (item.arguments.length === 0) {
+      return item.name;
     }
 
-    return null;
-  }, [item.arguments]);
+    const argumentText = item.arguments.map((argument) => `[${argument.name.toLowerCase()}]`).join(' ');
+    return (
+      <>
+        {item.name} <span className={styles.arguments}>{argumentText}</span>
+      </>
+    );
+  }, [item.name, item.arguments]);
 
   return (
     <AutocompleteRow
       leading={leadingElement}
-      title={item.name}
-      subtitle={subtitle}
+      title={title}
       active={active}
       selected={selected}
       onMouseOver={onMouseOver}

--- a/src/modules/command_autocomplete/components/CommandRow.module.css
+++ b/src/modules/command_autocomplete/components/CommandRow.module.css
@@ -19,6 +19,6 @@
 }
 
 .arguments {
-  color: var(--mantine-color-dimmed);
+  color: var(--bttv-dimmed-active-color, var(--mantine-color-dimmed));
   font-weight: 400;
 }

--- a/src/modules/command_autocomplete/components/CommandRow.module.css
+++ b/src/modules/command_autocomplete/components/CommandRow.module.css
@@ -19,6 +19,6 @@
 }
 
 .arguments {
-  color: var(--bttv-dimmed-active-color, var(--mantine-primary-color-light));
+  color: var(--bttv-dimmed-active-color, var(--mantine-color-dimmed));
   font-weight: 400;
 }

--- a/src/modules/command_autocomplete/components/CommandRow.module.css
+++ b/src/modules/command_autocomplete/components/CommandRow.module.css
@@ -17,3 +17,8 @@
   border-radius: var(--mantine-radius-md);
   object-fit: cover;
 }
+
+.arguments {
+  color: var(--mantine-color-dimmed);
+  font-weight: 400;
+}

--- a/src/modules/command_autocomplete/components/CommandRow.module.css
+++ b/src/modules/command_autocomplete/components/CommandRow.module.css
@@ -19,6 +19,6 @@
 }
 
 .arguments {
-  color: var(--bttv-dimmed-active-color, var(--mantine-color-dimmed));
+  color: var(--bttv-dimmed-active-color, var(--mantine-primary-color-light));
   font-weight: 400;
 }

--- a/src/modules/shadow_dom/ThemeProvider.jsx
+++ b/src/modules/shadow_dom/ThemeProvider.jsx
@@ -20,6 +20,7 @@ import {
   mergeMantineTheme,
   getThemeColor,
   alpha,
+  darken,
   Loader,
 } from '@mantine/core';
 import badgeStyles from './styles/badge.module.css';
@@ -155,7 +156,6 @@ const resolver = (theme) => ({
     '--mantine-color-default-border': 'var(--mantine-color-gray-0)',
     '--mantine-color-default-border': 'var(--mantine-color-dark-9)',
     '--mantine-primary-color-light-active': alpha(getThemeColor(theme.primaryColor, theme), 0.3),
-    '--bttv-primary-color-dimmed': 'var(--mantine-primary-color-light-color)',
   },
   dark: {
     '--mantine-color-text': 'var(--mantine-color-dark-0)',
@@ -165,6 +165,7 @@ const resolver = (theme) => ({
     '--mantine-color-body-secondary': 'var(--mantine-color-dark-9)',
     '--mantine-color-body': 'var(--mantine-color-dark-8)',
     '--mantine-color-body-inverse': 'var(--mantine-color-dark-0)',
+    '--mantine-primary-color-dimmed': darken(getThemeColor(theme.primaryColor, theme), 0.1),
   },
   light: {
     '--mantine-color-text': 'var(--mantine-color-gray-9)',
@@ -173,6 +174,7 @@ const resolver = (theme) => ({
     '--mantine-color-default-border': 'var(--mantine-color-gray-3)',
     '--mantine-color-body-secondary': 'var(--mantine-color-gray-0)',
     '--mantine-color-body-inverse': 'var(--mantine-color-gray-9)',
+    '--mantine-primary-color-dimmed': darken(getThemeColor(theme.primaryColor, theme), 0.1),
   },
 });
 

--- a/src/modules/shadow_dom/ThemeProvider.jsx
+++ b/src/modules/shadow_dom/ThemeProvider.jsx
@@ -18,8 +18,6 @@ import {
   Radio,
   Switch,
   mergeMantineTheme,
-  getThemeColor,
-  darken,
   Loader,
 } from '@mantine/core';
 import badgeStyles from './styles/badge.module.css';
@@ -171,7 +169,6 @@ const resolver = (theme) => ({
     '--mantine-color-default-border': 'var(--mantine-color-gray-3)',
     '--mantine-color-body-secondary': 'var(--mantine-color-gray-0)',
     '--mantine-color-body-inverse': 'var(--mantine-color-gray-9)',
-    '--mantine-primary-color-dimmed': darken(getThemeColor(theme.primaryColor, theme), 0.1),
   },
 });
 

--- a/src/modules/shadow_dom/ThemeProvider.jsx
+++ b/src/modules/shadow_dom/ThemeProvider.jsx
@@ -19,7 +19,6 @@ import {
   Switch,
   mergeMantineTheme,
   getThemeColor,
-  alpha,
   darken,
   Loader,
 } from '@mantine/core';
@@ -155,7 +154,6 @@ const resolver = (theme) => ({
     '--mantine-color-text': 'var(--mantine-color-dark-0)',
     '--mantine-color-default-border': 'var(--mantine-color-gray-0)',
     '--mantine-color-default-border': 'var(--mantine-color-dark-9)',
-    '--mantine-primary-color-light-active': alpha(getThemeColor(theme.primaryColor, theme), 0.3),
   },
   dark: {
     '--mantine-color-text': 'var(--mantine-color-dark-0)',
@@ -165,7 +163,6 @@ const resolver = (theme) => ({
     '--mantine-color-body-secondary': 'var(--mantine-color-dark-9)',
     '--mantine-color-body': 'var(--mantine-color-dark-8)',
     '--mantine-color-body-inverse': 'var(--mantine-color-dark-0)',
-    '--mantine-primary-color-dimmed': darken(getThemeColor(theme.primaryColor, theme), 0.1),
   },
   light: {
     '--mantine-color-text': 'var(--mantine-color-gray-9)',

--- a/src/modules/shadow_dom/ThemeProvider.jsx
+++ b/src/modules/shadow_dom/ThemeProvider.jsx
@@ -155,6 +155,7 @@ const resolver = (theme) => ({
     '--mantine-color-default-border': 'var(--mantine-color-gray-0)',
     '--mantine-color-default-border': 'var(--mantine-color-dark-9)',
     '--mantine-primary-color-light-active': alpha(getThemeColor(theme.primaryColor, theme), 0.3),
+    '--bttv-primary-color-dimmed': 'var(--mantine-primary-color-light-color)',
   },
   dark: {
     '--mantine-color-text': 'var(--mantine-color-dark-0)',


### PR DESCRIPTION
## Summary
Display each command argument in the autocomplete menu as its **lowercased name in brackets** (e.g. `[new title]`, `[search|url]`, `[user]`, `[!command]`) instead of the generic argument type, using the names provided by the BetterTTV API.

The argument hints are grouped with the command name in the row title (in a recolored span) rather than shown as a separate subtitle, and `AutocompleteRow` subtitles are now always right-justified. Long titles wrap instead of overflowing.

Examples:
- `!commands add` → name followed by `[!command] [response]`
- `!title` → `[new title]`
- `!songs request` → `[search|url]`
- `!permit` → `[user]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)