### PR TITLE
qol: persist autocomplete menu for arguments

### DIFF
--- a/src/common/components/Autocomplete.jsx
+++ b/src/common/components/Autocomplete.jsx
@@ -46,12 +46,12 @@ const AutocompleteListRow = React.memo(function AutocompleteListRow({
   renderRow,
   isSelected,
   isActive,
-  onCompleteItem,
+  handleCompleteResultItem,
   onHoverIndex,
 }) {
   return renderRow({
     item,
-    onClick: () => onCompleteItem(item),
+    onClick: () => handleCompleteResultItem(item),
     selected: isSelected,
     active: isActive,
     onMouseOver: () => onHoverIndex(index),
@@ -60,7 +60,7 @@ const AutocompleteListRow = React.memo(function AutocompleteListRow({
 
 function Autocomplete({
   chatInputQuerySelector,
-  onComplete,
+  handleCompleteResult,
   getChatInputPartialInput,
   renderRow,
   computeItems,
@@ -123,34 +123,37 @@ function Autocomplete({
     navigationMode.current = NavigationModeTypes.ARROW_KEYS;
   }, [open]);
 
-  const updateAutocompleteSuggestions = useCallback(async () => {
-    const value = getChatInputPartialInput();
+  const updateAutocompleteSuggestions = useCallback(
+    async (newValue = null) => {
+      const value = newValue ?? getChatInputPartialInput();
 
-    if (value === lastValueRef.current) {
-      return;
-    }
+      if (value === lastValueRef.current) {
+        return;
+      }
 
-    lastValueRef.current = value;
+      lastValueRef.current = value;
 
-    const requestId = ++updateAutocompleteSuggestionsRequestId.current;
+      const requestId = ++updateAutocompleteSuggestionsRequestId.current;
 
-    if (value == null) {
-      itemsRef.current = [];
-      setPartialInput('');
-    } else {
-      setPartialInput(value);
-      itemsRef.current = (await computeItems(value)).slice(0, MAX_ITEMS_SHOWN);
-    }
+      if (value == null) {
+        itemsRef.current = [];
+        setPartialInput('');
+      } else {
+        setPartialInput(value);
+        itemsRef.current = (await computeItems(value)).slice(0, MAX_ITEMS_SHOWN);
+      }
 
-    if (requestId !== updateAutocompleteSuggestionsRequestId.current) {
-      return;
-    }
+      if (requestId !== updateAutocompleteSuggestionsRequestId.current) {
+        return;
+      }
 
-    setItems(itemsRef.current);
-    handleSelectedChange(0, true);
+      setItems(itemsRef.current);
+      handleSelectedChange(0, true);
 
-    itemsRef.current.length > 0 ? handleOpen() : handleClose();
-  }, [getChatInputPartialInput, computeItems, handleOpen, close, handleSelectedChange]);
+      itemsRef.current.length > 0 ? handleOpen() : handleClose();
+    },
+    [getChatInputPartialInput, computeItems, handleOpen, close, handleSelectedChange]
+  );
 
   useEffect(() => {
     updateAutocompleteSuggestionsRef.current = updateAutocompleteSuggestions;
@@ -186,11 +189,16 @@ function Autocomplete({
 
   const handleComplete = useCallback(
     (item) => {
-      onComplete(item);
-      lastValueRef.current = null;
-      handleClose();
+      const completeResult = handleCompleteResult(item) ?? true;
+
+      if (completeResult.shouldClose === true) {
+        lastValueRef.current = null;
+        handleClose();
+      } else if (completeResult.newValue != null) {
+        updateAutocompleteSuggestionsRef.current(completeResult.newValue);
+      }
     },
-    [onComplete, handleClose]
+    [handleCompleteResult, handleClose]
   );
 
   const onHoverIndex = useCallback(
@@ -299,7 +307,7 @@ function Autocomplete({
             renderRow={renderRow}
             isSelected={selected === index}
             isActive={pendingCompleteIndex === index}
-            onCompleteItem={handleComplete}
+            handleCompleteResultItem={handleComplete}
             onHoverIndex={onHoverIndex}
           />
         ))}

--- a/src/common/components/Autocomplete.jsx
+++ b/src/common/components/Autocomplete.jsx
@@ -40,12 +40,25 @@ function travelDown(currentSelection, rowCount) {
   return newSelection;
 }
 
+// Returns the index of the whitespace-delimited word the caret sits in, where
+// word 0 is the input itself (e.g. the command name). Callers that render
+// arguments map argument N to word index N + 1.
+function getFocusedWordIndex(value, caretPosition) {
+  if (value == null || caretPosition == null) {
+    return 0;
+  }
+
+  const beforeCaret = value.slice(0, caretPosition);
+  return Math.max(0, beforeCaret.split(/\s+/).length - 1);
+}
+
 const AutocompleteListRow = React.memo(function AutocompleteListRow({
   item,
   index,
   renderRow,
   isSelected,
   isActive,
+  focusedWordIndex,
   handleCompleteResultItem,
   onHoverIndex,
 }) {
@@ -54,6 +67,7 @@ const AutocompleteListRow = React.memo(function AutocompleteListRow({
     onClick: () => handleCompleteResultItem(item),
     selected: isSelected,
     active: isActive,
+    focusedWordIndex,
     onMouseOver: () => onHoverIndex(index),
   });
 });
@@ -61,7 +75,9 @@ const AutocompleteListRow = React.memo(function AutocompleteListRow({
 function Autocomplete({
   chatInputQuerySelector,
   handleCompleteResult,
+  onComplete,
   getChatInputPartialInput,
+  getChatInputCaretPosition,
   renderRow,
   computeItems,
   getItemKey,
@@ -84,6 +100,7 @@ function Autocomplete({
   const updateAutocompleteSuggestionsRef = useRef(null);
   const updateAutocompleteSuggestionsRequestId = useRef(0);
   const [pendingCompleteIndex, setPendingCompleteIndex] = useState(null);
+  const [focusedWordIndex, setFocusedWordIndex] = useState(0);
 
   const handleMouseMove = useCallback(() => {
     navigationMode.current = NavigationModeTypes.MOUSE;
@@ -124,8 +141,15 @@ function Autocomplete({
   }, [open]);
 
   const updateAutocompleteSuggestions = useCallback(
-    async (newValue = null) => {
+    async (newValue = null, newCaretPosition = null) => {
       const value = newValue ?? getChatInputPartialInput();
+      const caretPosition = newCaretPosition ?? getChatInputCaretPosition?.();
+
+      // Track which argument the caret sits in even when the text itself hasn't
+      // changed (e.g. the user moved the caret between arguments), so the row can
+      // highlight the focused argument. The expensive item recompute below is
+      // still skipped when only the caret moved.
+      setFocusedWordIndex(getFocusedWordIndex(value, caretPosition));
 
       if (value === lastValueRef.current) {
         return;
@@ -152,7 +176,7 @@ function Autocomplete({
 
       itemsRef.current.length > 0 ? handleOpen() : handleClose();
     },
-    [getChatInputPartialInput, computeItems, handleOpen, close, handleSelectedChange]
+    [getChatInputPartialInput, getChatInputCaretPosition, computeItems, handleOpen, close, handleSelectedChange]
   );
 
   useEffect(() => {
@@ -189,16 +213,21 @@ function Autocomplete({
 
   const handleComplete = useCallback(
     (item) => {
-      const completeResult = handleCompleteResult(item) ?? true;
+      const completeResult = (handleCompleteResult ?? onComplete)?.(item);
 
-      if (completeResult.shouldClose === true) {
-        lastValueRef.current = null;
-        handleClose();
-      } else if (completeResult.newValue != null) {
-        updateAutocompleteSuggestionsRef.current(completeResult.newValue);
+      // Completers may return {newValue, shouldClose}. When the completion still
+      // leaves arguments to fill (shouldClose === false), recompute against the
+      // new value so the menu stays open. A void return (legacy onComplete) or
+      // shouldClose closes the menu, as before.
+      if (completeResult?.shouldClose === false && completeResult.newValue != null) {
+        updateAutocompleteSuggestionsRef.current(completeResult.newValue, completeResult.newValue.length);
+        return;
       }
+
+      lastValueRef.current = null;
+      handleClose();
     },
-    [handleCompleteResult, handleClose]
+    [handleCompleteResult, onComplete, handleClose]
   );
 
   const onHoverIndex = useCallback(
@@ -307,6 +336,7 @@ function Autocomplete({
             renderRow={renderRow}
             isSelected={selected === index}
             isActive={pendingCompleteIndex === index}
+            focusedWordIndex={focusedWordIndex}
             handleCompleteResultItem={handleComplete}
             onHoverIndex={onHoverIndex}
           />

--- a/src/common/components/AutocompleteRow.module.css
+++ b/src/common/components/AutocompleteRow.module.css
@@ -28,7 +28,7 @@
 
 .selected {
   color: var(--mantine-primary-color-filled);
-  background-color: var(--mantine-primary-color-light-hover);
+  background-color: var(--mantine-primary-color-light);
   --bttv-dimmed-active-color: var(--mantine-primary-color-filled-hover);
 }
 
@@ -41,12 +41,12 @@
 }
 
 .selected .subtitle {
-  color: var(--mantine-primary-color-filled) !important;
+  color: var(--mantine-primary-color-light) !important;
 }
 
 .active,
 .row:active {
-  background-color: var(--mantine-primary-color-light-active);
+  background-color: var(--mantine-primary-color-light-hover);
   transition-property: background-color, color;
   transition-duration: 0.1s;
   transition-timing-function: ease-in-out;

--- a/src/modules/command_autocomplete/components/CommandRow.jsx
+++ b/src/modules/command_autocomplete/components/CommandRow.jsx
@@ -1,8 +1,9 @@
 import React, {useMemo} from 'react';
+import classNames from 'classnames';
 import AutocompleteRow from '../../../common/components/AutocompleteRow.jsx';
 import NightbotLogoIcon from '../../../common/components/NightbotLogoIcon.jsx';
 import styles from './CommandRow.module.css';
-import {CommandProviders} from '../../../constants.js';
+import {CommandProviders, CommandAutocompleteArgumentTypes} from '../../../constants.js';
 import cdn from '../../../utils/cdn.js';
 
 const LogoByCommandProvider = {
@@ -11,7 +12,7 @@ const LogoByCommandProvider = {
   [CommandProviders.STREAMELEMENTS]: cdn.url('/assets/logos/streamelements_logo.png'),
 };
 
-function CommandRow({item, active, selected, onMouseOver, onClick}) {
+function CommandRow({item, active, selected, focusedWordIndex, onMouseOver, onClick}) {
   const leadingElement = useMemo(() => {
     if (item.provider === CommandProviders.NIGHTBOT) {
       return <NightbotLogoIcon className={styles.nightbotLogo} />;
@@ -25,18 +26,43 @@ function CommandRow({item, active, selected, onMouseOver, onClick}) {
     return null;
   }, [item.provider]);
 
-  const title = useMemo(() => {
-    if (item.arguments.length === 0) {
-      return item.name;
+  // Combine the command name and its argument placeholders into a single string,
+  // then split on whitespace so the word positions line up with the caret's
+  // focusedWordIndex (which is measured against the chat input the same way).
+  // This handles multi-word command names like "!commands add" — each word is
+  // highlighted only while the caret sits on it.
+  const titleWords = useMemo(() => {
+    const argumentText = item.arguments.map((argument) => `[${argument.name.toLowerCase()}]`).join(' ');
+    const fullText = argumentText.length > 0 ? `${item.name} ${argumentText}` : item.name;
+    return fullText.split(/\s+/);
+  }, [item.name, item.arguments]);
+
+  // A phrase argument soaks up the rest of the message, so it's always the last
+  // argument (and therefore the last word). Once the caret reaches or passes it,
+  // pin the highlight to it instead of letting the focus fall off the end as the
+  // user keeps typing words into the phrase.
+  const highlightedWordIndex = useMemo(() => {
+    const lastArgument = item.arguments[item.arguments.length - 1];
+    if (lastArgument?.type !== CommandAutocompleteArgumentTypes.PHRASE) {
+      return focusedWordIndex;
     }
 
-    const argumentText = item.arguments.map((argument) => `[${argument.name.toLowerCase()}]`).join(' ');
-    return (
-      <React.Fragment>
-        {item.name} <span className={styles.arguments}>{argumentText}</span>
-      </React.Fragment>
-    );
-  }, [item.name, item.arguments]);
+    const phraseWordIndex = titleWords.length - 1;
+    return Math.min(focusedWordIndex, phraseWordIndex);
+  }, [item.arguments, titleWords, focusedWordIndex]);
+
+  const title = useMemo(
+    () =>
+      titleWords.map((word, index) => (
+        <React.Fragment key={index}>
+          {index > 0 ? ' ' : null}
+          <span className={classNames(styles.word, {[styles.focusedWord]: index === highlightedWordIndex})}>
+            {word}
+          </span>
+        </React.Fragment>
+      )),
+    [titleWords, highlightedWordIndex]
+  );
 
   return (
     <AutocompleteRow
@@ -51,5 +77,10 @@ function CommandRow({item, active, selected, onMouseOver, onClick}) {
 }
 
 export default React.memo(CommandRow, (prev, next) => {
-  return prev.item === next.item && prev.selected === next.selected && prev.active === next.active;
+  return (
+    prev.item === next.item &&
+    prev.selected === next.selected &&
+    prev.active === next.active &&
+    prev.focusedWordIndex === next.focusedWordIndex
+  );
 });

--- a/src/modules/command_autocomplete/components/CommandRow.jsx
+++ b/src/modules/command_autocomplete/components/CommandRow.jsx
@@ -81,6 +81,7 @@ export default React.memo(CommandRow, (prev, next) => {
     prev.item === next.item &&
     prev.selected === next.selected &&
     prev.active === next.active &&
+    prev.index === next.index &&
     prev.focusedWordIndex === next.focusedWordIndex
   );
 });

--- a/src/modules/command_autocomplete/components/CommandRow.module.css
+++ b/src/modules/command_autocomplete/components/CommandRow.module.css
@@ -18,7 +18,13 @@
   object-fit: cover;
 }
 
-.arguments {
+/* Every word is dimmed except the one the caret is currently on. */
+.word {
   color: var(--bttv-dimmed-active-color, var(--mantine-color-dimmed));
   font-weight: 400;
+}
+
+.focusedWord {
+  color: inherit;
+  font-weight: 600;
 }

--- a/src/modules/command_autocomplete/components/CommandRow.module.css
+++ b/src/modules/command_autocomplete/components/CommandRow.module.css
@@ -18,13 +18,19 @@
   object-fit: cover;
 }
 
-/* Every word is dimmed except the one the caret is currently on. */
+/* Every word is dimmed except the one the caret is currently on. The dimmed
+ * (normal-weight) words carry a touch of letter-spacing so they take up roughly
+ * the same width as their bold form; the focused word drops the spacing back to
+ * 0 when it goes bold, so toggling the weight doesn't shift the text. */
 .word {
+  display: inline-block;
   color: var(--bttv-dimmed-active-color, var(--mantine-color-dimmed));
   font-weight: 400;
+  letter-spacing: 0.4px;
 }
 
 .focusedWord {
   color: inherit;
   font-weight: 600;
+  letter-spacing: 0;
 }

--- a/src/modules/command_autocomplete/twitch/Autocomplete.jsx
+++ b/src/modules/command_autocomplete/twitch/Autocomplete.jsx
@@ -98,6 +98,15 @@ function getChatInputPartialCommand() {
   return value;
 }
 
+function getChatInputCaretPosition() {
+  const element = document.querySelector(CHAT_INPUT);
+  if (element == null) {
+    return null;
+  }
+
+  return twitch.getChatInputCaretOffset(null, element);
+}
+
 function normalizeCommandInput(input) {
   const normalizedInput = input.toLowerCase();
 
@@ -311,6 +320,7 @@ class CommandAutocomplete {
         fullWidthOnSmallScreens={false}
         chatInputQuerySelector={CHAT_TEXT_AREA}
         getChatInputPartialInput={getChatInputPartialCommand}
+        getChatInputCaretPosition={getChatInputCaretPosition}
         computeItems={this.computeItems.bind(this)}
         getItemKey={getItemKey}
         handleCompleteResult={replaceChatInputPartialCommand}

--- a/src/modules/command_autocomplete/twitch/Autocomplete.jsx
+++ b/src/modules/command_autocomplete/twitch/Autocomplete.jsx
@@ -7,6 +7,7 @@ import {
   UserLevels,
   CommandProviders,
   COMMAND_PREFIX,
+  CommandAutocompleteArgumentTypes,
 } from '../../../constants.js';
 import domObserver from '../../../observers/dom.js';
 import settings from '../../../settings.js';
@@ -94,20 +95,11 @@ function getChatInputPartialCommand() {
     return null;
   }
 
-  const caret = twitch.getChatInputCaretOffset(value, element);
-  if (caret == null) {
-    return null;
-  }
-
-  // The command is the first word. Match it in full regardless of where the
-  // caret sits within it, but bail out once the caret moves past it into an
-  // argument.
-  const command = value.trim().split(/\s+/)[0];
-  return caret > command.length ? null : command;
+  return value;
 }
 
 function normalizeCommandInput(input) {
-  const normalizedInput = input.trim().toLowerCase();
+  const normalizedInput = input.toLowerCase();
 
   const searchTerm = normalizedInput.startsWith(COMMAND_PREFIX)
     ? normalizedInput.slice(COMMAND_PREFIX.length)
@@ -122,11 +114,31 @@ function getMatchingCommands(commands, partialInput) {
     return commands;
   }
 
-  if (searchTerm.length >= 3) {
-    return commands.filter((command) => command.name.toLowerCase().slice(COMMAND_PREFIX.length).includes(searchTerm));
-  }
+  return commands.filter((command) => {
+    const normalizedInputTrimmed = normalizedInput.toLowerCase();
+    const normalizedSearchTerm = searchTerm.toLowerCase();
+    const normalizedCommandName = command.name.toLowerCase();
 
-  return commands.filter((command) => command.name.toLowerCase().startsWith(normalizedInput));
+    if (normalizedCommandName.startsWith(normalizedInputTrimmed)) {
+      return true;
+    }
+
+    if (normalizedInputTrimmed.startsWith(normalizedCommandName)) {
+      if (command.arguments.some((argument) => argument.type === CommandAutocompleteArgumentTypes.PHRASE)) {
+        return true;
+      }
+
+      const textAfterCommand = normalizedInputTrimmed.slice(normalizedCommandName.length);
+      const textArgumentCount = textAfterCommand.trimStart().split(/\s+/).length;
+      const commandArgumentCount = command.arguments?.length ?? 0;
+
+      if (textArgumentCount <= commandArgumentCount) {
+        return true;
+      }
+    }
+
+    return normalizedCommandName.includes(normalizedSearchTerm);
+  });
 }
 
 function getItemKey(item) {
@@ -134,7 +146,9 @@ function getItemKey(item) {
 }
 
 function replaceChatInputPartialCommand(command) {
-  twitch.setChatInputValue(`${command.name} `);
+  const newValue = `${command.name} `;
+  twitch.setChatInputValue(newValue);
+  return {newValue, shouldClose: command.arguments?.length === 0};
 }
 
 let currentCommands = [];
@@ -299,7 +313,7 @@ class CommandAutocomplete {
         getChatInputPartialInput={getChatInputPartialCommand}
         computeItems={this.computeItems.bind(this)}
         getItemKey={getItemKey}
-        onComplete={replaceChatInputPartialCommand}
+        handleCompleteResult={replaceChatInputPartialCommand}
         renderRow={(props) => <CommandRow {...props} />}
       />
     );

--- a/src/modules/command_autocomplete/youtube/Autocomplete.jsx
+++ b/src/modules/command_autocomplete/youtube/Autocomplete.jsx
@@ -16,13 +16,27 @@ import {getAutocompleteSuggestions} from '../../../actions/autocomplete.js';
 import {getCurrentChannel} from '../../../utils/channel.js';
 import watcher from '../../../watcher.js';
 import {getProSettingValue} from '../../../utils/pro.js';
-import {getYoutubeChatInputPartialCommand, setYoutubeChatInputValue} from '../../../utils/youtube.js';
+import {
+  getCaretOffsetInContentEditable,
+  getYoutubeChatInputPartialCommand,
+  setYoutubeChatInputValue,
+  YOUTUBE_CHAT_CONTENTEDITABLE_SELECTOR,
+} from '../../../utils/youtube.js';
 import HTTPError from '../../../utils/http-error.js';
 
 const CHAT_TEXT_AREA = '#input-container';
 
 function getChatInputPartialCommand() {
   return getYoutubeChatInputPartialCommand(COMMAND_PREFIX);
+}
+
+function getChatInputCaretPosition() {
+  const element = document.querySelector(YOUTUBE_CHAT_CONTENTEDITABLE_SELECTOR);
+  if (element == null) {
+    return null;
+  }
+
+  return getCaretOffsetInContentEditable(element);
 }
 
 function normalizeCommandInput(input) {
@@ -218,6 +232,7 @@ class CommandAutocomplete {
       <Autocomplete
         chatInputQuerySelector={CHAT_TEXT_AREA}
         getChatInputPartialInput={getChatInputPartialCommand}
+        getChatInputCaretPosition={getChatInputCaretPosition}
         computeItems={this.computeItems.bind(this)}
         getItemKey={getItemKey}
         handleCompleteResult={replaceChatInputPartialCommand}

--- a/src/modules/command_autocomplete/youtube/Autocomplete.jsx
+++ b/src/modules/command_autocomplete/youtube/Autocomplete.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import Autocomplete from '../../../common/components/Autocomplete.jsx';
-import {SettingIds, ShadowDOMComponentIds, UserLevels, COMMAND_PREFIX} from '../../../constants.js';
+import {
+  SettingIds,
+  ShadowDOMComponentIds,
+  UserLevels,
+  COMMAND_PREFIX,
+  CommandAutocompleteArgumentTypes,
+} from '../../../constants.js';
 import domObserver from '../../../observers/dom.js';
 import settings from '../../../settings.js';
 import shadowDom from '../../shadow_dom/index.js';
@@ -20,7 +26,7 @@ function getChatInputPartialCommand() {
 }
 
 function normalizeCommandInput(input) {
-  const normalizedInput = input.trim().toLowerCase();
+  const normalizedInput = input.toLowerCase();
 
   const searchTerm = normalizedInput.startsWith(COMMAND_PREFIX)
     ? normalizedInput.slice(COMMAND_PREFIX.length)
@@ -35,11 +41,31 @@ function getMatchingCommands(commands, partialInput) {
     return commands;
   }
 
-  if (searchTerm.length >= 3) {
-    return commands.filter((command) => command.name.toLowerCase().slice(COMMAND_PREFIX.length).includes(searchTerm));
-  }
+  return commands.filter((command) => {
+    const normalizedInputTrimmed = normalizedInput.toLowerCase();
+    const normalizedSearchTerm = searchTerm.toLowerCase();
+    const normalizedCommandName = command.name.toLowerCase();
 
-  return commands.filter((command) => command.name.toLowerCase().startsWith(normalizedInput));
+    if (normalizedCommandName.startsWith(normalizedInputTrimmed)) {
+      return true;
+    }
+
+    if (normalizedInputTrimmed.startsWith(normalizedCommandName)) {
+      if (command.arguments.some((argument) => argument.type === CommandAutocompleteArgumentTypes.PHRASE)) {
+        return true;
+      }
+
+      const textAfterCommand = normalizedInputTrimmed.slice(normalizedCommandName.length);
+      const textArgumentCount = textAfterCommand.trimStart().split(/\s+/).length;
+      const commandArgumentCount = command.arguments?.length ?? 0;
+
+      if (textArgumentCount <= commandArgumentCount) {
+        return true;
+      }
+    }
+
+    return normalizedCommandName.includes(normalizedSearchTerm);
+  });
 }
 
 function getItemKey(item) {
@@ -47,7 +73,9 @@ function getItemKey(item) {
 }
 
 function replaceChatInputPartialCommand(command) {
-  setYoutubeChatInputValue(`${command.name} `);
+  const newValue = `${command.name} `;
+  setYoutubeChatInputValue(newValue);
+  return {newValue, shouldClose: command.arguments?.length === 0};
 }
 
 let currentCommands = [];
@@ -192,7 +220,7 @@ class CommandAutocomplete {
         getChatInputPartialInput={getChatInputPartialCommand}
         computeItems={this.computeItems.bind(this)}
         getItemKey={getItemKey}
-        onComplete={replaceChatInputPartialCommand}
+        handleCompleteResult={replaceChatInputPartialCommand}
         renderRow={(props) => <CommandRow {...props} />}
       />
     );

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -681,39 +681,6 @@ export default {
     return element.textContent.replace(/\uFEFF/g, '');
   },
 
-  getChatInputCaretOffset(fullText = null, element = null) {
-    element = element ?? document.querySelector(CHAT_INPUT);
-    if (element == null) {
-      return null;
-    }
-
-    // Legacy textarea
-    const {value: currentValue, selectionStart} = element;
-    if (currentValue != null && typeof selectionStart === 'number') {
-      return selectionStart;
-    }
-
-    // The chat input is a contenteditable. Measure the caret offset in the same
-    // (textContent) space as getChatInputValue by walking a DOM range from the
-    // start of the input to the caret, so emotes/void nodes count consistently.
-    // Slate keeps the FEFF markers out of its model, but they appear in the DOM,
-    // so strip them just like getChatInputValue does.
-    const selection = element.ownerDocument.getSelection();
-    if (selection != null && selection.rangeCount > 0 && element.contains(selection.focusNode)) {
-      const range = element.ownerDocument.createRange();
-      range.selectNodeContents(element);
-      range.setEnd(selection.focusNode, selection.focusOffset);
-      return range.toString().replace(/\uFEFF/g, '').length;
-    }
-
-    // No live selection (e.g. the input isn't focused); fall back to the end.
-    if (fullText == null) {
-      fullText = this.getChatInputValue(element);
-    }
-
-    return fullText != null ? fullText.length : null;
-  },
-
   setChatInputValue(text, shouldFocus = true) {
     const element = document.querySelector(CHAT_INPUT);
 

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -681,6 +681,39 @@ export default {
     return element.textContent.replace(/\uFEFF/g, '');
   },
 
+  getChatInputCaretOffset(fullText = null, element = null) {
+    element = element ?? document.querySelector(CHAT_INPUT);
+    if (element == null) {
+      return null;
+    }
+
+    // Legacy textarea
+    const {value: currentValue, selectionStart} = element;
+    if (currentValue != null && typeof selectionStart === 'number') {
+      return selectionStart;
+    }
+
+    // The chat input is a contenteditable. Measure the caret offset in the same
+    // (textContent) space as getChatInputValue by walking a DOM range from the
+    // start of the input to the caret, so emotes/void nodes count consistently.
+    // Slate keeps the FEFF markers out of its model, but they appear in the DOM,
+    // so strip them just like getChatInputValue does.
+    const selection = element.ownerDocument.getSelection();
+    if (selection != null && selection.rangeCount > 0 && element.contains(selection.focusNode)) {
+      const range = element.ownerDocument.createRange();
+      range.selectNodeContents(element);
+      range.setEnd(selection.focusNode, selection.focusOffset);
+      return range.toString().replace(/\uFEFF/g, '').length;
+    }
+
+    // No live selection (e.g. the input isn't focused); fall back to the end.
+    if (fullText == null) {
+      fullText = this.getChatInputValue(element);
+    }
+
+    return fullText != null ? fullText.length : null;
+  },
+
   setChatInputValue(text, shouldFocus = true) {
     const element = document.querySelector(CHAT_INPUT);
 

--- a/src/utils/youtube.js
+++ b/src/utils/youtube.js
@@ -38,28 +38,16 @@ export function getYoutubeChatInputPartialCommand(commandPrefix = '!') {
     return null;
   }
 
-  const caret = getCaretOffsetInContentEditable(element);
-  if (caret == null) {
-    return null;
-  }
-
   const value = element.innerText;
   if (value == null) {
     return null;
   }
 
-  const {value: focusedWord} = findFocusedWord(value, caret);
-  const firstWord = value.trim().split(/\s+/)[0];
-
-  if (caret > firstWord.length) {
+  if (!value.startsWith(commandPrefix)) {
     return null;
   }
 
-  if (!focusedWord.startsWith(commandPrefix)) {
-    return null;
-  }
-
-  return focusedWord;
+  return value;
 }
 
 export function setYoutubeChatInputValue(text, shouldFocus = true) {


### PR DESCRIPTION
## Summary

Keeps the command autocomplete menu open while the user is still filling in a command's arguments, instead of closing it the moment the command name is completed.

Previously the menu matched only the command name (and bailed out as soon as the caret moved past it), so once you completed `!shoutout ` the menu disappeared and gave no further guidance on what arguments the command expects. Now the menu persists for as long as the typed input still maps to a known command that has arguments left to fill.

## Changes

- **`common/components/Autocomplete.jsx`** — `onComplete` is replaced by `handleCompleteResult`, which can return `{newValue, shouldClose}`. When a completion still leaves arguments to fill (`shouldClose: false`), the menu recomputes against `newValue` and stays open instead of closing. `updateAutocompleteSuggestions` now accepts an explicit value so the post-completion recompute doesn't depend on reading the (asynchronously updated) input.
- **`command_autocomplete/twitch/Autocomplete.jsx`** & **`command_autocomplete/youtube/Autocomplete.jsx`** — matching no longer stops at the command name. `getMatchingCommands` keeps a command in the list when the input starts with the command name and the number of typed arguments doesn't exceed the command's declared argument count (or the command takes a free-form `phrase`). `replaceChatInputPartialCommand` returns `shouldClose` based on whether the command takes any arguments.
- **`utils/twitch.js`** & **`utils/youtube.js`** — removes the now-unused `getChatInputCaretOffset` caret-measurement helpers, since matching is driven by the input value rather than caret position.

## Testing

- Complete a no-argument command → menu closes as before.
- Complete a command with arguments (e.g. `!shoutout`) → menu stays open while typing the argument(s) and closes once all declared arguments are filled.
- Verified on both Twitch and YouTube chat inputs.
