### PR TITLE
fix: resolve emojis-by-slug virtual module on Windows

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -84,7 +84,7 @@ function emojisVirtualModulePlugin() {
   return {
     name: 'bttv-emojis-by-slug',
     async resolveId(id, importer) {
-      if (id.endsWith('emojis-by-slug.json') && importer?.includes(path.join('modules', 'emotes'))) {
+      if (id.endsWith('emojis-by-slug.json') && importer?.replace(/\\/g, '/').includes('modules/emotes')) {
         return VIRTUAL_ID;
       }
       return null;


### PR DESCRIPTION
## Problem

On Windows, `path.join('modules', 'emotes')` produces `modules\emotes` (backslashes), but Vite normalizes all importer paths to forward slashes internally. This caused the `resolveId` check in `emojisVirtualModulePlugin` to never match, resulting in a "Module not found" error for `emojis-by-slug.json` when running the dev server on Windows.

## Fix

Normalize the importer path to forward slashes before the `includes()` check so it works on both Windows and Unix.