### PR TITLE
feat: filter emote menu by channel with c:<channel> prefix

### DIFF
--- a/src/common/stores/emote-menu-view-store.js
+++ b/src/common/stores/emote-menu-view-store.js
@@ -81,15 +81,42 @@ function parseSearchQuery(search) {
   return {channel: match[1].toLowerCase(), term: match[2]};
 }
 
+// BetterTTV, FrankerFaceZ, and 7TV channel categories only ever contain the current channel's
+// emotes (they are fetched by the current channel id), but each emote's `channel` field holds the
+// individual emote uploader rather than the streamer. So these are matched against the current
+// channel instead of the per-emote channel.
+const CURRENT_CHANNEL_CATEGORY_IDS = [
+  EmoteCategories.BETTERTTV_CHANNEL,
+  EmoteCategories.FRANKERFACEZ_CHANNEL,
+  EmoteCategories.SEVENTV_CHANNEL,
+];
+
+function nameMatches(name, channelQuery) {
+  return name != null && name.toLowerCase() === channelQuery;
+}
+
 function emoteMatchesChannel(emote, channelQuery) {
-  const {channel} = emote;
-  if (channel == null) {
-    return false;
+  const categoryId = emote.category?.id;
+
+  // Personal emotes belong to the logged-in user, so match them against the current user's name.
+  if (categoryId === EmoteCategories.BETTERTTV_PERSONAL) {
+    const currentUser = getCurrentUser();
+    return nameMatches(currentUser?.name, channelQuery) || nameMatches(currentUser?.displayName, channelQuery);
   }
-  return (
-    (channel.name != null && channel.name.toLowerCase() === channelQuery) ||
-    (channel.displayName != null && channel.displayName.toLowerCase() === channelQuery)
-  );
+
+  if (CURRENT_CHANNEL_CATEGORY_IDS.includes(categoryId)) {
+    const currentChannel = getCurrentChannel();
+    return nameMatches(currentChannel?.name, channelQuery) || nameMatches(currentChannel?.displayName, channelQuery);
+  }
+
+  // Twitch channel emotes carry the owning channel's display name as a string and may span multiple
+  // channels the user is subscribed to.
+  const {channel} = emote;
+  if (typeof channel === 'string') {
+    return nameMatches(channel, channelQuery);
+  }
+
+  return false;
 }
 
 let providerCategories = [];

--- a/src/common/stores/emote-menu-view-store.js
+++ b/src/common/stores/emote-menu-view-store.js
@@ -283,13 +283,16 @@ class EmoteMenuViewStore extends SafeEventEmitter {
 
     let items;
     if (channelQuery != null) {
-      const channelEmotes = this.collection.filter((emote) => emoteMatchesChannel(emote, channelQuery));
-
       if (term.length === 0) {
-        items = sortBy(channelEmotes, ({code}) => code.toLowerCase());
+        items = sortBy(
+          this.collection.filter((emote) => emoteMatchesChannel(emote, channelQuery)),
+          ({code}) => code.toLowerCase()
+        );
       } else {
-        const channelFuse = new Fuse(channelEmotes, {keys: ['code'], shouldSort: true, threshold: 0.3});
-        items = channelFuse.search(term).map(({item}) => item);
+        items = fuse
+          .search(term)
+          .map(({item}) => item)
+          .filter((emote) => emoteMatchesChannel(emote, channelQuery));
       }
     } else {
       items = fuse.search(search).map(({item}) => item);

--- a/src/common/stores/emote-menu-view-store.js
+++ b/src/common/stores/emote-menu-view-store.js
@@ -281,21 +281,12 @@ class EmoteMenuViewStore extends SafeEventEmitter {
 
     const {channel: channelQuery, term} = parseSearchQuery(search);
 
-    let items;
+    // A bare `c:<channel>` query has no term, so list the whole (already sorted) collection;
+    // otherwise fuzzy-search the term. When a channel filter is present, narrow to that channel.
+    let items = term.length === 0 ? this.collection : fuse.search(term).map(({item}) => item);
+
     if (channelQuery != null) {
-      if (term.length === 0) {
-        items = sortBy(
-          this.collection.filter((emote) => emoteMatchesChannel(emote, channelQuery)),
-          ({code}) => code.toLowerCase()
-        );
-      } else {
-        items = fuse
-          .search(term)
-          .map(({item}) => item)
-          .filter((emote) => emoteMatchesChannel(emote, channelQuery));
-      }
-    } else {
-      items = fuse.search(search).map(({item}) => item);
+      items = items.filter((emote) => emoteMatchesChannel(emote, channelQuery));
     }
 
     return chunkResults ? chunk(items, this.totalCols) : items;
@@ -379,8 +370,8 @@ class EmoteMenuViewStore extends SafeEventEmitter {
       this.headers.unshift(0);
     }
 
-    this.collection = collection;
-    fuse.setCollection(collection);
+    this.collection = sortBy(collection, ({code}) => code.toLowerCase());
+    fuse.setCollection(this.collection);
     this.dirty = false;
     this.emit('updated');
   }

--- a/src/common/stores/emote-menu-view-store.js
+++ b/src/common/stores/emote-menu-view-store.js
@@ -87,8 +87,8 @@ function emoteMatchesChannel(emote, channelQuery) {
     return false;
   }
   return (
-    (channel.name != null && channel.name.toLowerCase().includes(channelQuery)) ||
-    (channel.displayName != null && channel.displayName.toLowerCase().includes(channelQuery))
+    (channel.name != null && channel.name.toLowerCase() === channelQuery) ||
+    (channel.displayName != null && channel.displayName.toLowerCase() === channelQuery)
   );
 }
 

--- a/src/common/stores/emote-menu-view-store.js
+++ b/src/common/stores/emote-menu-view-store.js
@@ -70,6 +70,28 @@ const fuse = new Fuse([], {
   threshold: 0.3,
 });
 
+// Parses a search query for a `c:<channel>` prefix used to filter emotes by channel.
+// Returns the channel filter (or null) and the remaining search term.
+const CHANNEL_QUERY_REGEX = /^c:(\S+)\s*(.*)$/i;
+function parseSearchQuery(search) {
+  const match = search.match(CHANNEL_QUERY_REGEX);
+  if (match == null) {
+    return {channel: null, term: search};
+  }
+  return {channel: match[1].toLowerCase(), term: match[2]};
+}
+
+function emoteMatchesChannel(emote, channelQuery) {
+  const {channel} = emote;
+  if (channel == null) {
+    return false;
+  }
+  return (
+    (channel.name != null && channel.name.toLowerCase().includes(channelQuery)) ||
+    (channel.displayName != null && channel.displayName.toLowerCase().includes(channelQuery))
+  );
+}
+
 let providerCategories = [];
 let platformCategories = [];
 
@@ -96,6 +118,7 @@ class EmoteMenuViewStore extends SafeEventEmitter {
 
     this.rows = [];
     this.headers = [];
+    this.collection = [];
 
     this.dirty = true;
     this.categories = {};
@@ -256,8 +279,21 @@ class EmoteMenuViewStore extends SafeEventEmitter {
       return [];
     }
 
-    const results = fuse.search(search);
-    const items = results.map(({item}) => item);
+    const {channel: channelQuery, term} = parseSearchQuery(search);
+
+    let items;
+    if (channelQuery != null) {
+      const channelEmotes = this.collection.filter((emote) => emoteMatchesChannel(emote, channelQuery));
+
+      if (term.length === 0) {
+        items = sortBy(channelEmotes, ({code}) => code.toLowerCase());
+      } else {
+        const channelFuse = new Fuse(channelEmotes, {keys: ['code'], shouldSort: true, threshold: 0.3});
+        items = channelFuse.search(term).map(({item}) => item);
+      }
+    } else {
+      items = fuse.search(search).map(({item}) => item);
+    }
 
     return chunkResults ? chunk(items, this.totalCols) : items;
   }
@@ -340,6 +376,7 @@ class EmoteMenuViewStore extends SafeEventEmitter {
       this.headers.unshift(0);
     }
 
+    this.collection = collection;
     fuse.setCollection(collection);
     this.dirty = false;
     this.emit('updated');


### PR DESCRIPTION
Typing `c:<channel>` in the emote menu search box now filters emotes to those belonging to a matching channel (by name or display name, case insensitive). An additional term after the prefix (e.g. `c:forsen Kappa`) fuzzy-searches within that channel's emotes.

## Related discussions

- [#7977 — Be able to search a specific user's bttv emotes in a list](https://github.com/night/betterttv/discussions/7977) (💡 Ideas) — asks to scope emote search to a specific user/channel, which this `c:<channel>` prefix enables.
- [#6381 — Favorite emotes per channel](https://github.com/night/betterttv/discussions/6381) and [#7198 — Emote Sorting on a Per-Channel Basis](https://github.com/night/betterttv/discussions/7198) (💡 Ideas) — adjacent per-channel emote-organization requests.
