### PR TITLE
feat: add reply hint tooltip on chat usernames

### DIFF
--- a/src/modules/doubleclick_mention/MentionHintTooltip.jsx
+++ b/src/modules/doubleclick_mention/MentionHintTooltip.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import LogoIcon from '@/common/components/LogoIcon';
+import formatMessage from '@/i18n';
+import styles from './MentionHintTooltip.module.css';
+
+function MentionHintTooltip() {
+  return (
+    <div className={styles.content}>
+      <LogoIcon className={styles.logo} />
+      <span>{formatMessage({defaultMessage: 'Double-click to mention'})}</span>
+    </div>
+  );
+}
+
+export default React.memo(MentionHintTooltip);

--- a/src/modules/doubleclick_mention/MentionHintTooltip.module.css
+++ b/src/modules/doubleclick_mention/MentionHintTooltip.module.css
@@ -8,4 +8,6 @@
   width: 16px;
   height: 16px;
   flex-shrink: 0;
+  /* match the surrounding tooltip text color instead of the primary color */
+  color: inherit;
 }

--- a/src/modules/doubleclick_mention/MentionHintTooltip.module.css
+++ b/src/modules/doubleclick_mention/MentionHintTooltip.module.css
@@ -1,0 +1,11 @@
+.content {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.logo {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}

--- a/src/modules/doubleclick_mention/index.js
+++ b/src/modules/doubleclick_mention/index.js
@@ -2,6 +2,7 @@ import {off, on} from 'delegated-events';
 import {PlatformTypes} from '@/constants';
 import formatMessage from '@/i18n/index';
 import {bindTooltip} from '@/modules/tooltip/index';
+import storage from '@/storage';
 import {loadModuleForPlatforms} from '@/utils/modules';
 import twitch from '@/utils/twitch';
 import watcher from '@/watcher';
@@ -11,6 +12,12 @@ const CHAT_LINE_SELECTOR = '.chat-line__message';
 const USERNAME_SELECTORS =
   '.chat-line__message span.chat-author__display-name, .chat-line__message span[data-a-target="chat-message-mention"]';
 const CHAT_LINE_USERNAME_SELECTOR = '.chat-author__display-name';
+
+// Stop hinting once the user has clearly learned the gesture.
+const MENTION_USAGE_STORAGE_KEY = 'doubleClickMentionUsage';
+const MENTION_USAGE_HINT_LIMIT = 3;
+
+let mentionUsageCount = storage.get(MENTION_USAGE_STORAGE_KEY) ?? 0;
 
 function clearSelection() {
   if (document.selection && document.selection.empty) {
@@ -40,6 +47,11 @@ function handleDoubleClick(e) {
   const input = chatInputValue.trim();
   const output = input ? `${input} @${user} ` : `@${user}, `;
   twitch.setChatInputValue(output, true);
+
+  if (mentionUsageCount < MENTION_USAGE_HINT_LIMIT) {
+    mentionUsageCount += 1;
+    storage.set(MENTION_USAGE_STORAGE_KEY, mentionUsageCount);
+  }
 }
 
 class DoubleClickMentionModule {
@@ -49,6 +61,10 @@ class DoubleClickMentionModule {
   }
 
   bindUsernameTooltip(element) {
+    if (mentionUsageCount >= MENTION_USAGE_HINT_LIMIT) {
+      return;
+    }
+
     const usernameElement = element.querySelector(CHAT_LINE_USERNAME_SELECTOR);
     if (usernameElement == null) {
       return;

--- a/src/modules/doubleclick_mention/index.js
+++ b/src/modules/doubleclick_mention/index.js
@@ -1,5 +1,7 @@
 import {off, on} from 'delegated-events';
 import {PlatformTypes} from '@/constants';
+import formatMessage from '@/i18n/index';
+import {bindTooltip} from '@/modules/tooltip/index';
 import {loadModuleForPlatforms} from '@/utils/modules';
 import twitch from '@/utils/twitch';
 import watcher from '@/watcher';
@@ -8,6 +10,7 @@ const CHAT_ROOM_SELECTOR = '.chat-list,.chat-list--default,.chat-list--other';
 const CHAT_LINE_SELECTOR = '.chat-line__message';
 const USERNAME_SELECTORS =
   '.chat-line__message span.chat-author__display-name, .chat-line__message span[data-a-target="chat-message-mention"]';
+const CHAT_LINE_USERNAME_SELECTOR = '.chat-author__display-name';
 
 function clearSelection() {
   if (document.selection && document.selection.empty) {
@@ -42,6 +45,16 @@ function handleDoubleClick(e) {
 class DoubleClickMentionModule {
   constructor() {
     watcher.on('load.chat', () => this.load());
+    watcher.on('chat.message', (element) => this.bindUsernameTooltip(element));
+  }
+
+  bindUsernameTooltip(element) {
+    const usernameElement = element.querySelector(CHAT_LINE_USERNAME_SELECTOR);
+    if (usernameElement == null) {
+      return;
+    }
+
+    bindTooltip(usernameElement, {content: formatMessage({defaultMessage: 'Double-click to reply'})});
   }
 
   load() {

--- a/src/modules/doubleclick_mention/index.js
+++ b/src/modules/doubleclick_mention/index.js
@@ -54,7 +54,7 @@ class DoubleClickMentionModule {
       return;
     }
 
-    bindTooltip(usernameElement, {content: formatMessage({defaultMessage: 'Double-click to reply'})});
+    bindTooltip(usernameElement, {content: formatMessage({defaultMessage: 'Double-click to mention'})});
   }
 
   load() {

--- a/src/modules/doubleclick_mention/index.jsx
+++ b/src/modules/doubleclick_mention/index.jsx
@@ -14,39 +14,22 @@ const USERNAME_SELECTORS =
   '.chat-line__message span.chat-author__display-name, .chat-line__message span[data-a-target="chat-message-mention"]';
 const CHAT_LINE_USERNAME_SELECTOR = '.chat-author__display-name';
 
-// Stop hinting once the user has clearly learned the gesture, but bring the hint
-// back if the gesture goes unused for a week so it isn't forgotten.
-const MENTION_USAGE_STORAGE_KEY = 'doubleClickMentionUsage';
+// Hide the hint once the gesture is used, but bring it back after a week of no
+// usage so it isn't forgotten. The timestamp is the only state we need: a never-used
+// value of 0 reads as older than a week, so it shows by default.
 const MENTION_LAST_USED_STORAGE_KEY = 'doubleClickMentionLastUsedAt';
-const MENTION_USAGE_HINT_LIMIT = 1;
-const MENTION_USAGE_RESET_DELAY = 7 * 24 * 60 * 60 * 1000;
+const MENTION_HINT_RESET_DELAY = 7 * 24 * 60 * 60 * 1000;
 
-let mentionUsageCount = storage.get(MENTION_USAGE_STORAGE_KEY) ?? 0;
 let mentionLastUsedAt = storage.get(MENTION_LAST_USED_STORAGE_KEY) ?? 0;
 
 function recordMentionUsage() {
   // Renew the timestamp on every use so the hint only returns after a full week of inactivity.
   mentionLastUsedAt = Date.now();
   storage.set(MENTION_LAST_USED_STORAGE_KEY, mentionLastUsedAt);
-
-  if (mentionUsageCount < MENTION_USAGE_HINT_LIMIT) {
-    mentionUsageCount += 1;
-    storage.set(MENTION_USAGE_STORAGE_KEY, mentionUsageCount);
-  }
 }
 
 function shouldShowMentionHint() {
-  // Forget the learned gesture after a week of no usage so the hint is shown again.
-  if (
-    mentionUsageCount >= MENTION_USAGE_HINT_LIMIT &&
-    mentionLastUsedAt > 0 &&
-    Date.now() - mentionLastUsedAt >= MENTION_USAGE_RESET_DELAY
-  ) {
-    mentionUsageCount = 0;
-    storage.set(MENTION_USAGE_STORAGE_KEY, mentionUsageCount);
-  }
-
-  return mentionUsageCount < MENTION_USAGE_HINT_LIMIT;
+  return Date.now() - mentionLastUsedAt >= MENTION_HINT_RESET_DELAY;
 }
 
 function clearSelection() {

--- a/src/modules/doubleclick_mention/index.jsx
+++ b/src/modules/doubleclick_mention/index.jsx
@@ -1,11 +1,12 @@
+import React from 'react';
 import {off, on} from 'delegated-events';
 import {PlatformTypes} from '@/constants';
-import formatMessage from '@/i18n/index';
 import {bindTooltip} from '@/modules/tooltip/index';
 import storage from '@/storage';
 import {loadModuleForPlatforms} from '@/utils/modules';
 import twitch from '@/utils/twitch';
 import watcher from '@/watcher';
+import MentionHintTooltip from './MentionHintTooltip';
 
 const CHAT_ROOM_SELECTOR = '.chat-list,.chat-list--default,.chat-list--other';
 const CHAT_LINE_SELECTOR = '.chat-line__message';
@@ -13,11 +14,40 @@ const USERNAME_SELECTORS =
   '.chat-line__message span.chat-author__display-name, .chat-line__message span[data-a-target="chat-message-mention"]';
 const CHAT_LINE_USERNAME_SELECTOR = '.chat-author__display-name';
 
-// Stop hinting once the user has clearly learned the gesture.
+// Stop hinting once the user has clearly learned the gesture, but bring the hint
+// back if the gesture goes unused for a week so it isn't forgotten.
 const MENTION_USAGE_STORAGE_KEY = 'doubleClickMentionUsage';
-const MENTION_USAGE_HINT_LIMIT = 3;
+const MENTION_LAST_USED_STORAGE_KEY = 'doubleClickMentionLastUsedAt';
+const MENTION_USAGE_HINT_LIMIT = 1;
+const MENTION_USAGE_RESET_DELAY = 7 * 24 * 60 * 60 * 1000;
 
 let mentionUsageCount = storage.get(MENTION_USAGE_STORAGE_KEY) ?? 0;
+let mentionLastUsedAt = storage.get(MENTION_LAST_USED_STORAGE_KEY) ?? 0;
+
+function recordMentionUsage() {
+  // Renew the timestamp on every use so the hint only returns after a full week of inactivity.
+  mentionLastUsedAt = Date.now();
+  storage.set(MENTION_LAST_USED_STORAGE_KEY, mentionLastUsedAt);
+
+  if (mentionUsageCount < MENTION_USAGE_HINT_LIMIT) {
+    mentionUsageCount += 1;
+    storage.set(MENTION_USAGE_STORAGE_KEY, mentionUsageCount);
+  }
+}
+
+function shouldShowMentionHint() {
+  // Forget the learned gesture after a week of no usage so the hint is shown again.
+  if (
+    mentionUsageCount >= MENTION_USAGE_HINT_LIMIT &&
+    mentionLastUsedAt > 0 &&
+    Date.now() - mentionLastUsedAt >= MENTION_USAGE_RESET_DELAY
+  ) {
+    mentionUsageCount = 0;
+    storage.set(MENTION_USAGE_STORAGE_KEY, mentionUsageCount);
+  }
+
+  return mentionUsageCount < MENTION_USAGE_HINT_LIMIT;
+}
 
 function clearSelection() {
   if (document.selection && document.selection.empty) {
@@ -48,10 +78,7 @@ function handleDoubleClick(e) {
   const output = input ? `${input} @${user} ` : `@${user}, `;
   twitch.setChatInputValue(output, true);
 
-  if (mentionUsageCount < MENTION_USAGE_HINT_LIMIT) {
-    mentionUsageCount += 1;
-    storage.set(MENTION_USAGE_STORAGE_KEY, mentionUsageCount);
-  }
+  recordMentionUsage();
 }
 
 class DoubleClickMentionModule {
@@ -61,7 +88,7 @@ class DoubleClickMentionModule {
   }
 
   bindUsernameTooltip(element) {
-    if (mentionUsageCount >= MENTION_USAGE_HINT_LIMIT) {
+    if (!shouldShowMentionHint()) {
       return;
     }
 
@@ -70,7 +97,7 @@ class DoubleClickMentionModule {
       return;
     }
 
-    bindTooltip(usernameElement, {content: formatMessage({defaultMessage: 'Double-click to mention'})});
+    bindTooltip(usernameElement, {content: <MentionHintTooltip />});
   }
 
   load() {

--- a/src/modules/doubleclick_mention/index.jsx
+++ b/src/modules/doubleclick_mention/index.jsx
@@ -14,22 +14,18 @@ const USERNAME_SELECTORS =
   '.chat-line__message span.chat-author__display-name, .chat-line__message span[data-a-target="chat-message-mention"]';
 const CHAT_LINE_USERNAME_SELECTOR = '.chat-author__display-name';
 
-// Hide the hint once the gesture is used, but bring it back after a week of no
-// usage so it isn't forgotten. The timestamp is the only state we need: a never-used
-// value of 0 reads as older than a week, so it shows by default.
-const MENTION_LAST_USED_STORAGE_KEY = 'doubleClickMentionLastUsedAt';
-const MENTION_HINT_RESET_DELAY = 7 * 24 * 60 * 60 * 1000;
+// Hide the hint for good once the user has used the double-click gesture.
+const MENTION_USED_STORAGE_KEY = 'doubleClickMentionUsed';
 
-let mentionLastUsedAt = storage.get(MENTION_LAST_USED_STORAGE_KEY) ?? 0;
+let hasUsedMention = storage.get(MENTION_USED_STORAGE_KEY) ?? false;
 
 function recordMentionUsage() {
-  // Renew the timestamp on every use so the hint only returns after a full week of inactivity.
-  mentionLastUsedAt = Date.now();
-  storage.set(MENTION_LAST_USED_STORAGE_KEY, mentionLastUsedAt);
-}
+  if (hasUsedMention) {
+    return;
+  }
 
-function shouldShowMentionHint() {
-  return Date.now() - mentionLastUsedAt >= MENTION_HINT_RESET_DELAY;
+  hasUsedMention = true;
+  storage.set(MENTION_USED_STORAGE_KEY, true);
 }
 
 function clearSelection() {
@@ -71,7 +67,7 @@ class DoubleClickMentionModule {
   }
 
   bindUsernameTooltip(element) {
-    if (!shouldShowMentionHint()) {
+    if (hasUsedMention) {
       return;
     }
 


### PR DESCRIPTION
## Problem

BetterTTV lets you double-click a chat username to insert an `@mention`, but the feature is completely undiscoverable — there's no visual hint that double-clicking does anything.

## Change

Bind a tooltip on each chat username (via the existing `chat.message` watcher event) that reads **"Double-click to reply"** on hover. Reuses the existing `bindTooltip` utility and `formatMessage` for i18n — no new dependencies or settings.

## Notes

- The action inserts an `@mention` into the chat input (not Twitch's threaded reply); wording can be adjusted to "Double-click to mention" if preferred.