### PR TITLE
feat: add emote info modal on emote click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@mantine/hooks": "^9.4.0",
         "@mantine/modals": "^9.4.0",
         "@sentry/browser": "10.60.0",
+        "@tanstack/react-query": "^5.101.0",
         "@twemoji/api": "17.0.3",
         "classnames": "2.5.1",
         "cookies-js": "1.2.3",
@@ -1615,9 +1616,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1635,9 +1633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1655,9 +1650,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1675,9 +1667,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1695,9 +1684,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1715,9 +1701,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2177,6 +2160,30 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.1.tgz",
+      "integrity": "sha512-Y6Y92dkXtNqx67m2pMSxUsA3zOCwv862JexZRP8/EPwvKXMPu9m8rv43spiXWzOUIggQ3SQApttALStzhA8B4g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.1.tgz",
+      "integrity": "sha512-ZnONUuQKJe1bJMStXUL1s5uKN9FcfC28j5cK+iDZcdSHtUv1wtin1cGc/Oewhf2Oc4eKY7lggtpvT/AbMmhHew==",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@twemoji/api": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@mantine/hooks": "^9.5.1",
         "@mantine/modals": "^9.5.1",
         "@sentry/browser": "10.70.0",
+        "@tanstack/react-query": "^5.101.0",
         "@twemoji/api": "17.0.3",
         "classnames": "2.5.1",
         "cookies-js": "1.2.3",
@@ -3701,6 +3702,32 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@twemoji/api": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@mantine/hooks": "^9.4.0",
     "@mantine/modals": "^9.4.0",
     "@sentry/browser": "10.60.0",
+    "@tanstack/react-query": "^5.101.0",
     "@twemoji/api": "17.0.3",
     "classnames": "2.5.1",
     "cookies-js": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@mantine/hooks": "^9.5.1",
     "@mantine/modals": "^9.5.1",
     "@sentry/browser": "10.70.0",
+    "@tanstack/react-query": "^5.101.0",
     "@twemoji/api": "17.0.3",
     "classnames": "2.5.1",
     "cookies-js": "1.2.3",

--- a/src/actions/emotes.js
+++ b/src/actions/emotes.js
@@ -11,3 +11,20 @@ export async function getFrankerFaceZGlobalEmotes() {
 export async function getFrankerFaceZChannelEmotes(provider, userId) {
   return api.get(`cached/frankerfacez/users/${provider}/${userId}`);
 }
+
+export async function getEmoteDetails(emoteId) {
+  return api.get(`emotes/${emoteId}`);
+}
+
+export async function addSharedEmote(emoteId, userId, emoteSetId) {
+  // emoteSetId defaults to the user's id, which is their default channel emote set
+  return api.put(`emotes/${emoteId}/shared/${userId}/${emoteSetId ?? userId}`);
+}
+
+export async function addPersonalEmote(emoteId, userId) {
+  return api.put(`emotes/${emoteId}/personal/${userId}`);
+}
+
+export async function searchSharedEmotes(query) {
+  return api.get('emotes/shared/search', {searchParams: {query, offset: 0, limit: 12}});
+}

--- a/src/common/utils/modal.jsx
+++ b/src/common/utils/modal.jsx
@@ -10,6 +10,7 @@ import styles from './Modal.module.css';
 
 const DEFAULT_LOADING_TIMEOUT = 500;
 const DEFAULT_SUCCESS_TIMEOUT = 1000;
+const MODAL_TRANSITION_DURATION = 100;
 
 const DEFAULT_CONFIRM_PROPS = {
   size: 'lg',
@@ -35,7 +36,7 @@ export function openConfirmModal({title, description, onConfirm, ...props}) {
     title,
     centered: true,
     closeButtonProps: {size: 'xl', radius: 'md'},
-    transitionProps: {transition: 'pop', duration: 100},
+    transitionProps: {transition: 'pop', duration: MODAL_TRANSITION_DURATION},
     radius: 'lg',
     size: 'lg',
     withinPortal: false,
@@ -88,7 +89,7 @@ export function openModal({title, description, ...props}) {
     title,
     centered: true,
     closeButtonProps: {size: 'xl', radius: 'md'},
-    transitionProps: {transition: 'pop', duration: 100},
+    transitionProps: {transition: 'pop', duration: MODAL_TRANSITION_DURATION},
     radius: 'lg',
     size: 'lg',
     withinPortal: false,

--- a/src/common/utils/modal.jsx
+++ b/src/common/utils/modal.jsx
@@ -11,6 +11,7 @@ import styles from './Modal.module.css';
 
 const DEFAULT_LOADING_TIMEOUT = 500;
 const DEFAULT_SUCCESS_TIMEOUT = 1000;
+const MODAL_TRANSITION_DURATION = 100;
 
 const DEFAULT_CONFIRM_PROPS = {
   size: 'lg',
@@ -36,7 +37,7 @@ export function openConfirmModal({title, description, onConfirm, ...props}) {
     title,
     centered: true,
     closeButtonProps: {size: 'xl', radius: 'md'},
-    transitionProps: {transition: 'pop', duration: 100},
+    transitionProps: {transition: 'pop', duration: MODAL_TRANSITION_DURATION},
     radius: 'lg',
     size: 'lg',
     withinPortal: false,
@@ -89,7 +90,7 @@ export function openModal({title, description, ...props}) {
     title,
     centered: true,
     closeButtonProps: {size: 'xl', radius: 'md'},
-    transitionProps: {transition: 'pop', duration: 100},
+    transitionProps: {transition: 'pop', duration: MODAL_TRANSITION_DURATION},
     radius: 'lg',
     size: 'lg',
     withinPortal: false,

--- a/src/constants.js
+++ b/src/constants.js
@@ -171,6 +171,11 @@ export const EmoteProviders = {
   SEVENTV: 'seventv',
 };
 
+export const EmoteAddDestinations = {
+  CHANNEL: 'channel',
+  PERSONAL: 'personal',
+};
+
 export const EmoteCategories = {
   BETTERTTV_GLOBAL: 'bttv-global',
   BETTERTTV_CHANNEL: 'bttv-channel',
@@ -335,6 +340,7 @@ export const EMOTE_MENU_GRID_ROW_HEIGHT = 36;
 export const EMOTE_MENU_GRID_HEIGHT = 300;
 
 export const EMOTE_CATEGORIES_ORDER_STORAGE_KEY = 'emote-categories-order';
+export const LAST_EMOTE_ADD_DESTINATION_STORAGE_KEY = 'last-emote-add-destination';
 
 export const BadgeTypes = {
   DEVELOPER: 1,
@@ -349,6 +355,7 @@ export const ShadowDOMComponentIds = {
   EMOTE_MENU: 'emote-menu',
   COMMAND_AUTOCOMPLETE: 'command-autocomplete',
   TOOLTIP_CONTROLLER: 'tooltip-controller',
+  EMOTE_MODAL_CONTROLLER: 'emote-modal-controller',
 };
 
 export const DEFAULT_HIGHLIGHT_COLOR = '#ff0000';

--- a/src/constants.js
+++ b/src/constants.js
@@ -177,6 +177,11 @@ export const EmoteProviders = {
   SEVENTV: 'seventv',
 };
 
+export const EmoteAddDestinations = {
+  CHANNEL: 'channel',
+  PERSONAL: 'personal',
+};
+
 export const EmoteCategories = {
   BETTERTTV_GLOBAL: 'bttv-global',
   BETTERTTV_CHANNEL: 'bttv-channel',
@@ -348,6 +353,7 @@ export const EMOTE_MENU_GRID_ROW_HEIGHT = 36;
 export const EMOTE_MENU_GRID_HEIGHT = 300;
 
 export const EMOTE_CATEGORIES_ORDER_STORAGE_KEY = 'emote-categories-order';
+export const LAST_EMOTE_ADD_DESTINATION_STORAGE_KEY = 'last-emote-add-destination';
 
 export const BadgeTypes = {
   DEVELOPER: 1,
@@ -362,6 +368,7 @@ export const ShadowDOMComponentIds = {
   EMOTE_MENU: 'emote-menu',
   COMMAND_AUTOCOMPLETE: 'command-autocomplete',
   TOOLTIP_CONTROLLER: 'tooltip-controller',
+  EMOTE_MODAL_CONTROLLER: 'emote-modal-controller',
 };
 
 export const DEFAULT_HIGHLIGHT_COLOR = '#ff0000';

--- a/src/modules/emote_modal/EmoteAlternativesContent.jsx
+++ b/src/modules/emote_modal/EmoteAlternativesContent.jsx
@@ -1,0 +1,106 @@
+import {Button, RadioCard, RadioGroup, Text} from '@mantine/core';
+import {faCheckCircle} from '@fortawesome/free-solid-svg-icons';
+import {useQuery} from '@tanstack/react-query';
+import React, {useCallback, useState} from 'react';
+import Icon from '@/common/components/Icon';
+import {EmoteAddDestinations} from '@/constants';
+import formatMessage from '@/i18n/index';
+import cdn from '@/utils/cdn';
+import useEmoteAdd, {useCloseAfterAdd} from './useEmoteAdd';
+import {addLoaderType, searchSharedEmotesQuery} from './utils';
+import styles from './EmoteModal.module.css';
+
+function AlternativesList({emote, destination, results, selected, onSelect}) {
+  // results is null until the search resolves; render nothing until then so the empty-state message
+  // doesn't briefly flash the "Select an alternative" heading before it
+  if (results == null) {
+    return null;
+  }
+
+  if (results.length === 0) {
+    return (
+      <Text className={styles.emptyAlternatives}>
+        {formatMessage({defaultMessage: 'No BetterTTV emotes found for "{code}".'}, {code: emote.code})}
+      </Text>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      <Text size="md">
+        {destination === EmoteAddDestinations.PERSONAL
+          ? formatMessage({defaultMessage: 'Select an alternative emote to add to your personal emotes'})
+          : formatMessage({defaultMessage: 'Select an alternative emote to add to your channel emotes'})}
+      </Text>
+      <RadioGroup value={selected ?? ''} onChange={onSelect}>
+        <div className={styles.grid}>
+          {results.map((alternative) => (
+            <RadioCard key={alternative.id} value={alternative.id} className={styles.altTile}>
+              <img className={styles.altImage} src={cdn.emoteUrl(alternative.id, '3x')} alt={alternative.code} />
+              <Icon icon={faCheckCircle} className={styles.altCheck} />
+            </RadioCard>
+          ))}
+        </div>
+      </RadioGroup>
+    </React.Fragment>
+  );
+}
+
+export default function EmoteAlternativesContent({emote, destination, initialResults, onClose, onBack}) {
+  const [selected, setSelected] = useState(null);
+  const {add, reset, mutationFor} = useEmoteAdd();
+  const addMutation = mutationFor(destination);
+  useCloseAfterAdd(addMutation, onClose);
+
+  // initialResults are prefetched on the detail page before navigating here, so the list renders on
+  // the first frame instead of flashing an empty/loading state
+  const {data} = useQuery({...searchSharedEmotesQuery(emote.code), initialData: initialResults ?? undefined});
+  const results = data ?? null;
+  // default to the first alternative so the user can add right away
+  const selectedId = selected ?? results?.[0]?.id ?? null;
+
+  const handleSelect = useCallback(
+    (value) => {
+      setSelected(value);
+      reset();
+    },
+    [reset]
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (selectedId == null) {
+      return;
+    }
+
+    add(selectedId, destination, onClose);
+  }, [add, selectedId, destination, onClose]);
+
+  return (
+    <React.Fragment>
+      <div className={styles.content}>
+        <AlternativesList
+          emote={emote}
+          destination={destination}
+          results={results}
+          selected={selectedId}
+          onSelect={handleSelect}
+        />
+      </div>
+      <div className={styles.footer}>
+        <Button variant="elevated" size="lg" onClick={onBack}>
+          {formatMessage({defaultMessage: 'Back'})}
+        </Button>
+        <Button
+          variant="elevated"
+          color="contrast"
+          size="lg"
+          loading={!addMutation.isIdle}
+          loaderProps={{type: addLoaderType(addMutation)}}
+          disabled={selectedId == null}
+          onClick={handleConfirm}>
+          {formatMessage({defaultMessage: 'Confirm'})}
+        </Button>
+      </div>
+    </React.Fragment>
+  );
+}

--- a/src/modules/emote_modal/EmoteAlternativesContent.jsx
+++ b/src/modules/emote_modal/EmoteAlternativesContent.jsx
@@ -1,0 +1,106 @@
+import {faCheckCircle} from '@fortawesome/free-solid-svg-icons';
+import {Button, RadioCard, RadioGroup, Text} from '@mantine/core';
+import {useQuery} from '@tanstack/react-query';
+import React, {useCallback, useState} from 'react';
+import Icon from '@/common/components/Icon';
+import {EmoteAddDestinations} from '@/constants';
+import formatMessage from '@/i18n/index';
+import cdn from '@/utils/cdn';
+import styles from './EmoteModal.module.css';
+import useEmoteAdd, {useCloseAfterAdd} from './useEmoteAdd';
+import {addLoaderType, searchSharedEmotesQuery} from './utils';
+
+function AlternativesList({emote, destination, results, selected, onSelect}) {
+  // results is null until the search resolves; render nothing until then so the empty-state message
+  // doesn't briefly flash the "Select an alternative" heading before it
+  if (results == null) {
+    return null;
+  }
+
+  if (results.length === 0) {
+    return (
+      <Text className={styles.emptyAlternatives}>
+        {formatMessage({defaultMessage: 'No BetterTTV emotes found for "{code}".'}, {code: emote.code})}
+      </Text>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      <Text size="md">
+        {destination === EmoteAddDestinations.PERSONAL
+          ? formatMessage({defaultMessage: 'Select an alternative emote to add to your personal emotes'})
+          : formatMessage({defaultMessage: 'Select an alternative emote to add to your channel emotes'})}
+      </Text>
+      <RadioGroup value={selected ?? ''} onChange={onSelect}>
+        <div className={styles.grid}>
+          {results.map((alternative) => (
+            <RadioCard key={alternative.id} value={alternative.id} className={styles.altTile}>
+              <img className={styles.altImage} src={cdn.emoteUrl(alternative.id, '3x')} alt={alternative.code} />
+              <Icon icon={faCheckCircle} className={styles.altCheck} />
+            </RadioCard>
+          ))}
+        </div>
+      </RadioGroup>
+    </React.Fragment>
+  );
+}
+
+export default function EmoteAlternativesContent({emote, destination, initialResults, onClose, onBack}) {
+  const [selected, setSelected] = useState(null);
+  const {add, reset, mutationFor} = useEmoteAdd();
+  const addMutation = mutationFor(destination);
+  useCloseAfterAdd(addMutation, onClose);
+
+  // initialResults are prefetched on the detail page before navigating here, so the list renders on
+  // the first frame instead of flashing an empty/loading state
+  const {data} = useQuery({...searchSharedEmotesQuery(emote.code), initialData: initialResults ?? undefined});
+  const results = data ?? null;
+  // default to the first alternative so the user can add right away
+  const selectedId = selected ?? results?.[0]?.id ?? null;
+
+  const handleSelect = useCallback(
+    (value) => {
+      setSelected(value);
+      reset();
+    },
+    [reset]
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (selectedId == null) {
+      return;
+    }
+
+    add(selectedId, destination, onClose);
+  }, [add, selectedId, destination, onClose]);
+
+  return (
+    <React.Fragment>
+      <div className={styles.content}>
+        <AlternativesList
+          emote={emote}
+          destination={destination}
+          results={results}
+          selected={selectedId}
+          onSelect={handleSelect}
+        />
+      </div>
+      <div className={styles.footer}>
+        <Button variant="elevated" size="lg" onClick={onBack}>
+          {formatMessage({defaultMessage: 'Back'})}
+        </Button>
+        <Button
+          variant="elevated"
+          color="contrast"
+          size="lg"
+          loading={!addMutation.isIdle}
+          loaderProps={{type: addLoaderType(addMutation)}}
+          disabled={selectedId == null}
+          onClick={handleConfirm}>
+          {formatMessage({defaultMessage: 'Confirm'})}
+        </Button>
+      </div>
+    </React.Fragment>
+  );
+}

--- a/src/modules/emote_modal/EmoteModal.module.css
+++ b/src/modules/emote_modal/EmoteModal.module.css
@@ -1,0 +1,185 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-top: 1px solid var(--mantine-color-default-border);
+  padding: 16px;
+}
+
+.metadata {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.metadataRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: nowrap;
+}
+
+.metadataLabel {
+  font-size: var(--mantine-font-size-md);
+  color: var(--mantine-color-dimmed);
+}
+
+.metadataValue {
+  font-size: var(--mantine-font-size-md);
+  font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.emptyAlternatives {
+  font-size: var(--mantine-font-size-md);
+  color: var(--mantine-color-dimmed);
+  text-align: center;
+}
+
+.altTile {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  padding: 8px;
+  border: none;
+  border-radius: var(--mantine-radius-lg);
+  background-color: var(--mantine-color-body-secondary);
+  /* keep a transparent outline so selecting only transitions its color (the default outline color
+     would otherwise flash dark while the transition runs) */
+  outline: 4px solid transparent;
+  cursor: pointer;
+  transition:
+    outline-color 100ms ease-in-out,
+    background-color 120ms ease;
+}
+
+.altTile:hover {
+  background-color: var(--mantine-primary-color-light-hover);
+}
+
+.altTile[data-checked='true'] {
+  background-color: var(--mantine-primary-color-light-hover);
+  outline-color: var(--mantine-primary-color-3);
+}
+
+.altImage {
+  max-width: 100%;
+  max-height: 56px;
+  object-fit: contain;
+}
+
+.altCheck {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 100%;
+  background-color: inherit;
+  color: var(--mantine-primary-color-3);
+  opacity: 0;
+  scale: 0;
+  transition:
+    opacity 100ms ease-in-out,
+    scale 100ms ease-in-out;
+}
+
+.altTile[data-checked='true'] .altCheck {
+  opacity: 1;
+  scale: 1;
+}
+
+.addButtonGroup {
+  display: inline-flex;
+}
+
+/* square icon button for the add-destination menu */
+.menuChevron {
+  width: 36px;
+  min-width: 36px;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.menuDropdown {
+  padding: 2px;
+}
+
+/* a subtle, even gap inside the menu: the radius is the dropdown's radius minus the gap so the
+   rounded corners stay concentric, and the left padding is trimmed by the gap so the item's avatar
+   still lines up with the button's avatar. keep the row compact. */
+.menuItemButton {
+  --button-height: auto;
+  min-height: 0;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  /* Mantine reduces the section-side padding to (padding-x / 1.5) when there's a leftSection;
+     match that, then trim the 2px gap so the item's avatar lines up with the button's avatar */
+  padding-left: calc(var(--button-padding-x-lg) / 1.5 - 2px);
+  border-radius: calc(var(--mantine-radius-lg) - 2px);
+}
+
+.clickable {
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.1s ease-in-out;
+}
+
+.clickable:hover {
+  background-color: var(--color-background-interactable-hover);
+}
+
+.clickable:active {
+  background-color: var(--color-background-interactable-active);
+}
+
+.title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.titleLogo {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}
+
+.imageWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: var(--mantine-radius-md);
+  border: 1px solid var(--mantine-color-default-border);
+  background-color: var(--mantine-color-body-secondary);
+  padding: 24px;
+  min-height: 160px;
+  line-height: 0;
+}
+
+.image {
+  display: block;
+  max-width: 100%;
+  max-height: 128px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  image-rendering: auto;
+}

--- a/src/modules/emote_modal/EmoteModalContent.jsx
+++ b/src/modules/emote_modal/EmoteModalContent.jsx
@@ -1,0 +1,234 @@
+import {Avatar, Button, Popover, Text} from '@mantine/core';
+import {useDisclosure} from '@mantine/hooks';
+import {faChevronDown} from '@fortawesome/free-solid-svg-icons';
+import {useDismiss, useFloating, useInteractions} from '@floating-ui/react';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
+import {DateTime} from 'luxon';
+import React, {useCallback, useState} from 'react';
+import {useShallow} from 'zustand/react/shallow';
+import Icon from '@/common/components/Icon';
+import usePortalRef from '@/common/hooks/PortalRef';
+import {EmoteAddDestinations, EmoteCategories, EmoteProviders} from '@/constants';
+import formatMessage from '@/i18n/index';
+import useAuthStore from '@/stores/auth';
+import {getCurrentChannel} from '@/utils/channel';
+import {getEmoteImageType} from '@/utils/emote';
+import {createSrc} from '@/utils/image';
+import useEmoteAdd, {useCloseAfterAdd} from './useEmoteAdd';
+import {addLoaderType, addToLabel, getEmoteModalDetails, searchSharedEmotesQuery} from './utils';
+import styles from './EmoteModal.module.css';
+
+const GLOBAL_EMOTE_CATEGORY_IDS = [
+  EmoteCategories.BETTERTTV_GLOBAL,
+  EmoteCategories.FRANKERFACEZ_GLOBAL,
+  EmoteCategories.SEVENTV_GLOBAL,
+];
+
+function MetadataRow({label, children}) {
+  if (children == null) {
+    return null;
+  }
+
+  return (
+    <div className={styles.metadataRow}>
+      <Text className={styles.metadataLabel}>{label}</Text>
+      <Text className={styles.metadataValue}>{children}</Text>
+    </div>
+  );
+}
+
+export default function EmoteModalContent({emote, destination, onChangeDestination, onClose, onNeedsAlternative}) {
+  const currentUser = useAuthStore(useShallow((state) => state.user));
+  const [dimensions, setDimensions] = useState(null);
+  const [loadingAlternatives, setLoadingAlternatives] = useState(false);
+  const portalRef = usePortalRef();
+  const queryClient = useQueryClient();
+  const {add, reset, mutationFor} = useEmoteAdd();
+
+  const {data: details} = useQuery({
+    queryKey: ['emote-modal-details', emote.category?.provider, emote.id],
+    queryFn: () => getEmoteModalDetails(emote),
+  });
+
+  const [menuOpened, {close: closeMenu, toggle: toggleMenu}] = useDisclosure(false);
+  const {refs, context} = useFloating({open: menuOpened, onOpenChange: closeMenu});
+  // outside-press detection has to walk the composed path because we render inside a shadow DOM
+  const dismiss = useDismiss(context, {
+    outsidePress: (event) => {
+      const path = event.composedPath();
+      return !path.includes(refs.floating.current) && !path.includes(refs.reference.current);
+    },
+  });
+  const {getReferenceProps, getFloatingProps} = useInteractions([dismiss]);
+
+  const imageSrc = createSrc(emote.images, false, '4x');
+  const isBetterTTVEmote = emote.category?.provider === EmoteProviders.BETTERTTV;
+  const isEmoji = emote.category?.id === EmoteCategories.BETTERTTV_EMOJI;
+  const isBetterTTVGlobal = emote.category?.id === EmoteCategories.BETTERTTV_GLOBAL;
+  // emoji and BetterTTV global emotes are already available everywhere, so they can't be added
+  const addDisabled = isEmoji || isBetterTTVGlobal;
+  const otherDestination =
+    destination === EmoteAddDestinations.CHANNEL ? EmoteAddDestinations.PERSONAL : EmoteAddDestinations.CHANNEL;
+  const addMutation = mutationFor(destination);
+  useCloseAfterAdd(addMutation, onClose);
+
+  const handleImageLoad = useCallback((event) => {
+    const {naturalWidth, naturalHeight} = event.currentTarget;
+    if (naturalWidth > 0 && naturalHeight > 0) {
+      setDimensions({width: naturalWidth, height: naturalHeight});
+    }
+  }, []);
+
+  const handleAddTo = useCallback(
+    async (chosen) => {
+      closeMenu();
+      onChangeDestination(chosen);
+      reset();
+
+      if (!isBetterTTVEmote) {
+        // a non-BetterTTV emote can't be added directly — fetch the BetterTTV alternatives first (the
+        // button shows a loader) and hand them to the alternatives page so it renders them on its
+        // first frame (no empty/loading flash)
+        setLoadingAlternatives(true);
+        const alternatives = await queryClient.fetchQuery(searchSharedEmotesQuery(emote.code));
+        onNeedsAlternative(chosen, alternatives);
+        return;
+      }
+
+      add(emote.id, chosen, onClose);
+    },
+    [
+      closeMenu,
+      onChangeDestination,
+      reset,
+      isBetterTTVEmote,
+      queryClient,
+      emote.code,
+      emote.id,
+      onNeedsAlternative,
+      add,
+      onClose,
+    ]
+  );
+
+  const handleAddToSelected = useCallback(() => handleAddTo(destination), [handleAddTo, destination]);
+  const handleAddToOther = useCallback(() => handleAddTo(otherDestination), [handleAddTo, otherDestination]);
+  const handleMenuChange = useCallback(
+    (isOpen) => {
+      if (!isOpen) {
+        closeMenu();
+      }
+    },
+    [closeMenu]
+  );
+
+  const isGlobalEmote = GLOBAL_EMOTE_CATEGORY_IDS.includes(emote.category?.id);
+  const currentChannel = getCurrentChannel();
+  const createdAt = details?.createdAt != null ? DateTime.fromISO(details.createdAt) : null;
+  const channelName = isEmoji
+    ? formatMessage({defaultMessage: 'BetterTTV Emojis'})
+    : isGlobalEmote
+      ? formatMessage({defaultMessage: 'Global'})
+      : (currentChannel?.displayName ?? currentChannel?.name ?? null);
+  const uploadedBy = details?.user?.displayName ?? details?.user?.name ?? null;
+  const fileType = getEmoteImageType(emote);
+  const fileMetadata =
+    fileType != null && dimensions != null ? `${fileType} (${dimensions.width}x${dimensions.height})` : fileType;
+
+  const avatar = currentUser?.avatar != null ? <Avatar src={currentUser.avatar} size="md" /> : null;
+
+  return (
+    <React.Fragment>
+      <div className={styles.content}>
+        <div className={styles.imageWrapper}>
+          <img
+            className={styles.image}
+            src={imageSrc}
+            alt={formatMessage({defaultMessage: 'Emote {code}'}, {code: emote.code})}
+            onLoad={handleImageLoad}
+          />
+        </div>
+        <div className={styles.metadata}>
+          <MetadataRow label={formatMessage({defaultMessage: 'Channel'})}>{channelName}</MetadataRow>
+          <MetadataRow label={formatMessage({defaultMessage: 'Added On'})}>
+            {createdAt != null ? createdAt.toLocaleString(DateTime.DATE_MED) : null}
+          </MetadataRow>
+          <MetadataRow label={formatMessage({defaultMessage: 'Uploaded By'})}>{uploadedBy}</MetadataRow>
+          <MetadataRow label={formatMessage({defaultMessage: 'File Metadata'})}>{fileMetadata}</MetadataRow>
+        </div>
+      </div>
+      <div className={styles.footer}>
+        <Button variant="elevated" size="lg" onClick={onClose}>
+          {formatMessage({defaultMessage: 'Close'})}
+        </Button>
+        {addDisabled ? (
+          <div className={styles.addButtonGroup}>
+            <Button.Group>
+              <Button variant="elevated" color="contrast" size="lg" disabled leftSection={avatar}>
+                {addToLabel(destination)}
+              </Button>
+              <Button
+                variant="elevated"
+                color="contrast"
+                size="lg"
+                className={styles.menuChevron}
+                disabled
+                aria-label={formatMessage({defaultMessage: 'More add options'})}>
+                <Icon icon={faChevronDown} />
+              </Button>
+            </Button.Group>
+          </div>
+        ) : (
+          <Popover
+            radius="lg"
+            shadow="lg"
+            opened={menuOpened}
+            onChange={handleMenuChange}
+            position="bottom-end"
+            width="target"
+            closeOnClickOutside={false}
+            portalProps={{target: portalRef?.current}}>
+            <Popover.Target ref={refs.reference} {...getReferenceProps()}>
+              <div className={styles.addButtonGroup}>
+                <Button.Group>
+                  <Button
+                    variant="elevated"
+                    color="contrast"
+                    size="lg"
+                    loading={loadingAlternatives || !addMutation.isIdle}
+                    loaderProps={{type: addLoaderType(addMutation)}}
+                    leftSection={avatar}
+                    onClick={handleAddToSelected}>
+                    {addToLabel(destination)}
+                  </Button>
+                  <Button
+                    variant="elevated"
+                    color="contrast"
+                    size="lg"
+                    className={styles.menuChevron}
+                    disabled={loadingAlternatives || !addMutation.isIdle}
+                    onClick={toggleMenu}
+                    aria-label={formatMessage({defaultMessage: 'More add options'})}>
+                    <Icon icon={faChevronDown} />
+                  </Button>
+                </Button.Group>
+              </div>
+            </Popover.Target>
+            <Popover.Dropdown ref={refs.floating} {...getFloatingProps()} className={styles.menuDropdown}>
+              <Button
+                variant="subtle"
+                size="lg"
+                fullWidth
+                justify="start"
+                className={styles.menuItemButton}
+                leftSection={avatar}
+                onClick={handleAddToOther}>
+                {addToLabel(otherDestination)}
+              </Button>
+            </Popover.Dropdown>
+          </Popover>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}

--- a/src/modules/emote_modal/EmoteModalContent.jsx
+++ b/src/modules/emote_modal/EmoteModalContent.jsx
@@ -1,0 +1,234 @@
+import {useDismiss, useFloating, useInteractions} from '@floating-ui/react';
+import {faChevronDown} from '@fortawesome/free-solid-svg-icons';
+import {Avatar, Button, Popover, Text} from '@mantine/core';
+import {useDisclosure} from '@mantine/hooks';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
+import {DateTime} from 'luxon';
+import React, {useCallback, useState} from 'react';
+import {useShallow} from 'zustand/react/shallow';
+import Icon from '@/common/components/Icon';
+import usePortalRef from '@/common/hooks/PortalRef';
+import {EmoteAddDestinations, EmoteCategories, EmoteProviders} from '@/constants';
+import formatMessage from '@/i18n/index';
+import useAuthStore from '@/stores/auth';
+import {getCurrentChannel} from '@/utils/channel';
+import {getEmoteImageType} from '@/utils/emote';
+import {createSrc} from '@/utils/image';
+import styles from './EmoteModal.module.css';
+import useEmoteAdd, {useCloseAfterAdd} from './useEmoteAdd';
+import {addLoaderType, addToLabel, getEmoteModalDetails, searchSharedEmotesQuery} from './utils';
+
+const GLOBAL_EMOTE_CATEGORY_IDS = [
+  EmoteCategories.BETTERTTV_GLOBAL,
+  EmoteCategories.FRANKERFACEZ_GLOBAL,
+  EmoteCategories.SEVENTV_GLOBAL,
+];
+
+function MetadataRow({label, children}) {
+  if (children == null) {
+    return null;
+  }
+
+  return (
+    <div className={styles.metadataRow}>
+      <Text className={styles.metadataLabel}>{label}</Text>
+      <Text className={styles.metadataValue}>{children}</Text>
+    </div>
+  );
+}
+
+export default function EmoteModalContent({emote, destination, onChangeDestination, onClose, onNeedsAlternative}) {
+  const currentUser = useAuthStore(useShallow((state) => state.user));
+  const [dimensions, setDimensions] = useState(null);
+  const [loadingAlternatives, setLoadingAlternatives] = useState(false);
+  const portalRef = usePortalRef();
+  const queryClient = useQueryClient();
+  const {add, reset, mutationFor} = useEmoteAdd();
+
+  const {data: details} = useQuery({
+    queryKey: ['emote-modal-details', emote.category?.provider, emote.id],
+    queryFn: () => getEmoteModalDetails(emote),
+  });
+
+  const [menuOpened, {close: closeMenu, toggle: toggleMenu}] = useDisclosure(false);
+  const {refs, context} = useFloating({open: menuOpened, onOpenChange: closeMenu});
+  // outside-press detection has to walk the composed path because we render inside a shadow DOM
+  const dismiss = useDismiss(context, {
+    outsidePress: (event) => {
+      const path = event.composedPath();
+      return !path.includes(refs.floating.current) && !path.includes(refs.reference.current);
+    },
+  });
+  const {getReferenceProps, getFloatingProps} = useInteractions([dismiss]);
+
+  const imageSrc = createSrc(emote.images, false, '4x');
+  const isBetterTTVEmote = emote.category?.provider === EmoteProviders.BETTERTTV;
+  const isEmoji = emote.category?.id === EmoteCategories.BETTERTTV_EMOJI;
+  const isBetterTTVGlobal = emote.category?.id === EmoteCategories.BETTERTTV_GLOBAL;
+  // emoji and BetterTTV global emotes are already available everywhere, so they can't be added
+  const addDisabled = isEmoji || isBetterTTVGlobal;
+  const otherDestination =
+    destination === EmoteAddDestinations.CHANNEL ? EmoteAddDestinations.PERSONAL : EmoteAddDestinations.CHANNEL;
+  const addMutation = mutationFor(destination);
+  useCloseAfterAdd(addMutation, onClose);
+
+  const handleImageLoad = useCallback((event) => {
+    const {naturalWidth, naturalHeight} = event.currentTarget;
+    if (naturalWidth > 0 && naturalHeight > 0) {
+      setDimensions({width: naturalWidth, height: naturalHeight});
+    }
+  }, []);
+
+  const handleAddTo = useCallback(
+    async (chosen) => {
+      closeMenu();
+      onChangeDestination(chosen);
+      reset();
+
+      if (!isBetterTTVEmote) {
+        // a non-BetterTTV emote can't be added directly — fetch the BetterTTV alternatives first (the
+        // button shows a loader) and hand them to the alternatives page so it renders them on its
+        // first frame (no empty/loading flash)
+        setLoadingAlternatives(true);
+        const alternatives = await queryClient.fetchQuery(searchSharedEmotesQuery(emote.code));
+        onNeedsAlternative(chosen, alternatives);
+        return;
+      }
+
+      add(emote.id, chosen, onClose);
+    },
+    [
+      closeMenu,
+      onChangeDestination,
+      reset,
+      isBetterTTVEmote,
+      queryClient,
+      emote.code,
+      emote.id,
+      onNeedsAlternative,
+      add,
+      onClose,
+    ]
+  );
+
+  const handleAddToSelected = useCallback(() => handleAddTo(destination), [handleAddTo, destination]);
+  const handleAddToOther = useCallback(() => handleAddTo(otherDestination), [handleAddTo, otherDestination]);
+  const handleMenuChange = useCallback(
+    (isOpen) => {
+      if (!isOpen) {
+        closeMenu();
+      }
+    },
+    [closeMenu]
+  );
+
+  const isGlobalEmote = GLOBAL_EMOTE_CATEGORY_IDS.includes(emote.category?.id);
+  const currentChannel = getCurrentChannel();
+  const createdAt = details?.createdAt != null ? DateTime.fromISO(details.createdAt) : null;
+  const channelName = isEmoji
+    ? formatMessage({defaultMessage: 'BetterTTV Emojis'})
+    : isGlobalEmote
+      ? formatMessage({defaultMessage: 'Global'})
+      : (currentChannel?.displayName ?? currentChannel?.name ?? null);
+  const uploadedBy = details?.user?.displayName ?? details?.user?.name ?? null;
+  const fileType = getEmoteImageType(emote);
+  const fileMetadata =
+    fileType != null && dimensions != null ? `${fileType} (${dimensions.width}x${dimensions.height})` : fileType;
+
+  const avatar = currentUser?.avatar != null ? <Avatar src={currentUser.avatar} size="md" /> : null;
+
+  return (
+    <React.Fragment>
+      <div className={styles.content}>
+        <div className={styles.imageWrapper}>
+          <img
+            className={styles.image}
+            src={imageSrc}
+            alt={formatMessage({defaultMessage: 'Emote {code}'}, {code: emote.code})}
+            onLoad={handleImageLoad}
+          />
+        </div>
+        <div className={styles.metadata}>
+          <MetadataRow label={formatMessage({defaultMessage: 'Channel'})}>{channelName}</MetadataRow>
+          <MetadataRow label={formatMessage({defaultMessage: 'Added On'})}>
+            {createdAt != null ? createdAt.toLocaleString(DateTime.DATE_MED) : null}
+          </MetadataRow>
+          <MetadataRow label={formatMessage({defaultMessage: 'Uploaded By'})}>{uploadedBy}</MetadataRow>
+          <MetadataRow label={formatMessage({defaultMessage: 'File Metadata'})}>{fileMetadata}</MetadataRow>
+        </div>
+      </div>
+      <div className={styles.footer}>
+        <Button variant="elevated" size="lg" onClick={onClose}>
+          {formatMessage({defaultMessage: 'Close'})}
+        </Button>
+        {addDisabled ? (
+          <div className={styles.addButtonGroup}>
+            <Button.Group>
+              <Button variant="elevated" color="contrast" size="lg" disabled leftSection={avatar}>
+                {addToLabel(destination)}
+              </Button>
+              <Button
+                variant="elevated"
+                color="contrast"
+                size="lg"
+                className={styles.menuChevron}
+                disabled
+                aria-label={formatMessage({defaultMessage: 'More add options'})}>
+                <Icon icon={faChevronDown} />
+              </Button>
+            </Button.Group>
+          </div>
+        ) : (
+          <Popover
+            radius="lg"
+            shadow="lg"
+            opened={menuOpened}
+            onChange={handleMenuChange}
+            position="bottom-end"
+            width="target"
+            closeOnClickOutside={false}
+            portalProps={{target: portalRef?.current}}>
+            <Popover.Target ref={refs.reference} {...getReferenceProps()}>
+              <div className={styles.addButtonGroup}>
+                <Button.Group>
+                  <Button
+                    variant="elevated"
+                    color="contrast"
+                    size="lg"
+                    loading={loadingAlternatives || !addMutation.isIdle}
+                    loaderProps={{type: addLoaderType(addMutation)}}
+                    leftSection={avatar}
+                    onClick={handleAddToSelected}>
+                    {addToLabel(destination)}
+                  </Button>
+                  <Button
+                    variant="elevated"
+                    color="contrast"
+                    size="lg"
+                    className={styles.menuChevron}
+                    disabled={loadingAlternatives || !addMutation.isIdle}
+                    onClick={toggleMenu}
+                    aria-label={formatMessage({defaultMessage: 'More add options'})}>
+                    <Icon icon={faChevronDown} />
+                  </Button>
+                </Button.Group>
+              </div>
+            </Popover.Target>
+            <Popover.Dropdown ref={refs.floating} {...getFloatingProps()} className={styles.menuDropdown}>
+              <Button
+                variant="subtle"
+                size="lg"
+                fullWidth
+                justify="start"
+                className={styles.menuItemButton}
+                leftSection={avatar}
+                onClick={handleAddToOther}>
+                {addToLabel(otherDestination)}
+              </Button>
+            </Popover.Dropdown>
+          </Popover>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}

--- a/src/modules/emote_modal/EmoteModalController.jsx
+++ b/src/modules/emote_modal/EmoteModalController.jsx
@@ -1,0 +1,42 @@
+import {useCallback, useEffect} from 'react';
+import openEmoteModal from './openEmoteModal';
+
+export const EMOTE_MODAL_MARKER_ATTRIBUTE = 'data-bttv-emote-modal';
+
+function getEmoteModalElement(target) {
+  if (target == null || !(target instanceof Element)) {
+    return null;
+  }
+
+  return target.closest(`[${EMOTE_MODAL_MARKER_ATTRIBUTE}]`);
+}
+
+export default function EmoteModalController() {
+  const handleClick = useCallback((event) => {
+    const element = getEmoteModalElement(event.target);
+    if (element == null) {
+      return;
+    }
+
+    const config = element.__bttvEmoteModal;
+    if (config == null || config.emote == null) {
+      return;
+    }
+
+    // stop the click from reaching Twitch's own emote/viewer card handlers
+    event.preventDefault();
+    event.stopPropagation();
+
+    openEmoteModal(config.emote);
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('click', handleClick, true);
+
+    return () => {
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, [handleClick]);
+
+  return null;
+}

--- a/src/modules/emote_modal/EmoteModalRouter.jsx
+++ b/src/modules/emote_modal/EmoteModalRouter.jsx
@@ -1,0 +1,75 @@
+import React, {useCallback, useState} from 'react';
+import {EmoteAddDestinations, LAST_EMOTE_ADD_DESTINATION_STORAGE_KEY} from '@/constants';
+import storage from '@/storage';
+import EmoteAlternativesContent from './EmoteAlternativesContent';
+import EmoteModalContent from './EmoteModalContent';
+import {addToLabel} from './utils';
+
+function getInitialDestination() {
+  return storage.get(LAST_EMOTE_ADD_DESTINATION_STORAGE_KEY) === EmoteAddDestinations.PERSONAL
+    ? EmoteAddDestinations.PERSONAL
+    : EmoteAddDestinations.CHANNEL;
+}
+
+// Renders the emote modal's pages inside a single modal, swapping between them with state so there
+// is no second modal/overlay (and no transition) when moving between pages. The chosen add
+// destination (channel/personal) is shared across pages and remembered for next time.
+export default function EmoteModalRouter({
+  emote,
+  detailTitle,
+  initialPage = 'detail',
+  onPageChange,
+  onClose,
+  onSetTitle,
+}) {
+  const [page, setPage] = useState(initialPage);
+  const [destination, setDestinationState] = useState(getInitialDestination);
+  // the alternatives, prefetched on the detail page, so the alternatives page has them immediately
+  const [alternatives, setAlternatives] = useState(null);
+
+  const setDestination = useCallback((value) => {
+    setDestinationState(value);
+    storage.set(LAST_EMOTE_ADD_DESTINATION_STORAGE_KEY, value);
+  }, []);
+
+  // each page sets the modal title as it's shown: the alternatives page shows the add destination
+  // (passed in, since the chosen value may not be in state yet), the detail page shows the emote
+  // (whose title is already set when the modal first opens)
+  const showAlternatives = useCallback(
+    (chosen, results) => {
+      setAlternatives(results ?? null);
+      onSetTitle(addToLabel(chosen));
+      setPage('alternatives');
+      onPageChange('alternatives');
+    },
+    [onSetTitle, onPageChange]
+  );
+
+  const showDetail = useCallback(() => {
+    onSetTitle(detailTitle);
+    setPage('detail');
+    onPageChange('detail');
+  }, [onSetTitle, detailTitle, onPageChange]);
+
+  if (page === 'alternatives') {
+    return (
+      <EmoteAlternativesContent
+        emote={emote}
+        destination={destination}
+        initialResults={alternatives}
+        onClose={onClose}
+        onBack={showDetail}
+      />
+    );
+  }
+
+  return (
+    <EmoteModalContent
+      emote={emote}
+      destination={destination}
+      onChangeDestination={setDestination}
+      onClose={onClose}
+      onNeedsAlternative={showAlternatives}
+    />
+  );
+}

--- a/src/modules/emote_modal/index.jsx
+++ b/src/modules/emote_modal/index.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {ShadowDOMComponentIds} from '@/constants';
+import shadowDOM from '@/modules/shadow_dom/index';
+import EmoteModalController, {EMOTE_MODAL_MARKER_ATTRIBUTE} from './EmoteModalController';
+import styles from './EmoteModal.module.css';
+
+export function bindEmoteModal(element, {emote}) {
+  element.__bttvEmoteModal = {emote};
+  element.classList.add(styles.clickable);
+
+  let emoteModalKey = element.getAttribute(EMOTE_MODAL_MARKER_ATTRIBUTE);
+
+  if (emoteModalKey == null || emoteModalKey.length === 0) {
+    emoteModalKey = crypto.randomUUID();
+    element.setAttribute(EMOTE_MODAL_MARKER_ATTRIBUTE, emoteModalKey);
+  }
+
+  if (!shadowDOM.isMounted(ShadowDOMComponentIds.EMOTE_MODAL_CONTROLLER)) {
+    shadowDOM.mount(ShadowDOMComponentIds.EMOTE_MODAL_CONTROLLER, <EmoteModalController />);
+  }
+}

--- a/src/modules/emote_modal/index.jsx
+++ b/src/modules/emote_modal/index.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {ShadowDOMComponentIds} from '@/constants';
+import shadowDOM from '@/modules/shadow_dom/index';
+import styles from './EmoteModal.module.css';
+import EmoteModalController, {EMOTE_MODAL_MARKER_ATTRIBUTE} from './EmoteModalController';
+
+export function bindEmoteModal(element, {emote}) {
+  element.__bttvEmoteModal = {emote};
+  element.classList.add(styles.clickable);
+
+  let emoteModalKey = element.getAttribute(EMOTE_MODAL_MARKER_ATTRIBUTE);
+
+  if (emoteModalKey == null || emoteModalKey.length === 0) {
+    emoteModalKey = crypto.randomUUID();
+    element.setAttribute(EMOTE_MODAL_MARKER_ATTRIBUTE, emoteModalKey);
+  }
+
+  if (!shadowDOM.isMounted(ShadowDOMComponentIds.EMOTE_MODAL_CONTROLLER)) {
+    shadowDOM.mount(ShadowDOMComponentIds.EMOTE_MODAL_CONTROLLER, <EmoteModalController />);
+  }
+}

--- a/src/modules/emote_modal/openEmoteModal.jsx
+++ b/src/modules/emote_modal/openEmoteModal.jsx
@@ -1,0 +1,68 @@
+import {modals} from '@mantine/modals';
+import React from 'react';
+import {openModal} from '@/common/utils/modal';
+import {EmoteProviders} from '@/constants';
+import cdn from '@/utils/cdn';
+import EmoteModalRouter from './EmoteModalRouter';
+import styles from './EmoteModal.module.css';
+
+const PROVIDER_LOGOS = {
+  [EmoteProviders.BETTERTTV]: cdn.url('/assets/logos/bttv_logo.png'),
+  [EmoteProviders.FRANKERFACEZ]: cdn.url('/assets/logos/ffz_logo.png'),
+  [EmoteProviders.SEVENTV]: cdn.url('/assets/logos/7tv_logo.png'),
+};
+
+function emoteTitle(emote) {
+  const providerLogo = PROVIDER_LOGOS[emote.category?.provider];
+  return (
+    <span className={styles.title}>
+      {providerLogo != null ? (
+        <img className={styles.titleLogo} src={providerLogo} alt={emote.category?.displayName} />
+      ) : null}
+      {emote.code}
+    </span>
+  );
+}
+
+export default function openEmoteModal(emote, restoreState = {}) {
+  // a single modal hosts every page; pages are swapped with state (see EmoteModalRouter) so there is
+  // no second modal opening/closing between them. The router updates the modal title per page.
+  const detailTitle = emoteTitle(emote);
+  // mirror the live page/title here so a reopen (after a sign-in/upgrade gate) lands on the same page
+  let currentPage = restoreState.page ?? 'detail';
+  let currentTitle = restoreState.title ?? detailTitle;
+
+  // opens the sign-in/upgrade gate modal and, once that modal has finished closing, reopens this
+  // emote modal on the page the user left off on — but only if they actually completed the gate
+  // (signed in / upgraded), not if they dismissed it
+  function openGateThenReopen(openGate) {
+    let completed = false;
+    const reopen = () => openEmoteModal(emote, {page: currentPage, title: currentTitle});
+    openGate({onExitTransitionEnd: () => completed && reopen()}, () => (completed = true));
+  }
+
+  const modalId = openModal({
+    title: currentTitle,
+    description: (
+      <EmoteModalRouter
+        emote={emote}
+        detailTitle={detailTitle}
+        initialPage={currentPage}
+        onPageChange={(page) => (currentPage = page)}
+        onClose={(openGate) => {
+          // a plain onClose()/onClick(event) just closes. When given a gate opener (sign-in /
+          // upgrade), open it once this modal's close transition has finished, so they don't overlap
+          if (typeof openGate === 'function') {
+            modals.updateModal({modalId, onExitTransitionEnd: () => openGateThenReopen(openGate)});
+          }
+          modals.close(modalId);
+        }}
+        onSetTitle={(title) => {
+          currentTitle = title;
+          modals.updateModal({modalId, title});
+        }}
+      />
+    ),
+  });
+  return modalId;
+}

--- a/src/modules/emote_modal/openEmoteModal.jsx
+++ b/src/modules/emote_modal/openEmoteModal.jsx
@@ -1,0 +1,68 @@
+import {modals} from '@mantine/modals';
+import React from 'react';
+import {openModal} from '@/common/utils/modal';
+import {EmoteProviders} from '@/constants';
+import cdn from '@/utils/cdn';
+import styles from './EmoteModal.module.css';
+import EmoteModalRouter from './EmoteModalRouter';
+
+const PROVIDER_LOGOS = {
+  [EmoteProviders.BETTERTTV]: cdn.url('/assets/logos/bttv_logo.png'),
+  [EmoteProviders.FRANKERFACEZ]: cdn.url('/assets/logos/ffz_logo.png'),
+  [EmoteProviders.SEVENTV]: cdn.url('/assets/logos/7tv_logo.png'),
+};
+
+function emoteTitle(emote) {
+  const providerLogo = PROVIDER_LOGOS[emote.category?.provider];
+  return (
+    <span className={styles.title}>
+      {providerLogo != null ? (
+        <img className={styles.titleLogo} src={providerLogo} alt={emote.category?.displayName} />
+      ) : null}
+      {emote.code}
+    </span>
+  );
+}
+
+export default function openEmoteModal(emote, restoreState = {}) {
+  // a single modal hosts every page; pages are swapped with state (see EmoteModalRouter) so there is
+  // no second modal opening/closing between them. The router updates the modal title per page.
+  const detailTitle = emoteTitle(emote);
+  // mirror the live page/title here so a reopen (after a sign-in/upgrade gate) lands on the same page
+  let currentPage = restoreState.page ?? 'detail';
+  let currentTitle = restoreState.title ?? detailTitle;
+
+  // opens the sign-in/upgrade gate modal and, once that modal has finished closing, reopens this
+  // emote modal on the page the user left off on — but only if they actually completed the gate
+  // (signed in / upgraded), not if they dismissed it
+  function openGateThenReopen(openGate) {
+    let completed = false;
+    const reopen = () => openEmoteModal(emote, {page: currentPage, title: currentTitle});
+    openGate({onExitTransitionEnd: () => completed && reopen()}, () => (completed = true));
+  }
+
+  const modalId = openModal({
+    title: currentTitle,
+    description: (
+      <EmoteModalRouter
+        emote={emote}
+        detailTitle={detailTitle}
+        initialPage={currentPage}
+        onPageChange={(page) => (currentPage = page)}
+        onClose={(openGate) => {
+          // a plain onClose()/onClick(event) just closes. When given a gate opener (sign-in /
+          // upgrade), open it once this modal's close transition has finished, so they don't overlap
+          if (typeof openGate === 'function') {
+            modals.updateModal({modalId, onExitTransitionEnd: () => openGateThenReopen(openGate)});
+          }
+          modals.close(modalId);
+        }}
+        onSetTitle={(title) => {
+          currentTitle = title;
+          modals.updateModal({modalId, title});
+        }}
+      />
+    ),
+  });
+  return modalId;
+}

--- a/src/modules/emote_modal/useEmoteAdd.js
+++ b/src/modules/emote_modal/useEmoteAdd.js
@@ -1,0 +1,67 @@
+import {useMutation} from '@tanstack/react-query';
+import {useCallback, useEffect} from 'react';
+import {addPersonalEmote, addSharedEmote} from '@/actions/emotes';
+import {openSignInModal, openSubscriptionUpgradeModal} from '@/common/utils/modal';
+import {EmoteAddDestinations} from '@/constants';
+import useAuthStore from '@/stores/auth';
+import {isUserPro} from '@/utils/pro';
+
+// Closes the modal a short while after an add settles, leaving the success/error icon on the button
+// long enough to read first. This delay is a deliberate pause (not a transition) — it mirrors
+// openConfirmModal's success timeout.
+export function useCloseAfterAdd(addMutation, onClose) {
+  const settled = addMutation.isSuccess || addMutation.isError;
+  useEffect(() => {
+    if (!settled) {
+      return undefined;
+    }
+    const timer = setTimeout(() => onClose(), 1000);
+    return () => clearTimeout(timer);
+  }, [settled, onClose]);
+}
+
+// Encapsulates adding an emote to a channel or personal set, including the sign-in gate and the
+// Pro gate for personal emotes. Returns the destination's mutation so callers can drive button state.
+export default function useEmoteAdd() {
+  const addChannel = useMutation({
+    mutationFn: ({emoteId, userId}) => addSharedEmote(emoteId, userId),
+  });
+
+  const addPersonal = useMutation({
+    mutationFn: ({emoteId, userId}) => addPersonalEmote(emoteId, userId),
+  });
+
+  // returns the live mutation (so callers see its pending/success state), so it isn't memoized
+  const mutationFor = (destination) => (destination === EmoteAddDestinations.PERSONAL ? addPersonal : addChannel);
+
+  const add = useCallback(
+    (emoteId, destination, onClose) => {
+      const {user} = useAuthStore.getState();
+      const isPersonal = destination === EmoteAddDestinations.PERSONAL;
+
+      // not signed in — close the emote modal, then prompt to sign in (once its close transition
+      // finishes, so the modals don't stack/overlap)
+      if (user == null) {
+        onClose(openSignInModal);
+        return;
+      }
+
+      // personal emotes are a Pro feature — close the emote modal, then prompt to upgrade
+      if (isPersonal && !isUserPro(user)) {
+        onClose(openSubscriptionUpgradeModal);
+        return;
+      }
+
+      const mutate = isPersonal ? addPersonal.mutate : addChannel.mutate;
+      mutate({emoteId, userId: user.id});
+    },
+    [addChannel.mutate, addPersonal.mutate]
+  );
+
+  const reset = useCallback(() => {
+    addChannel.reset();
+    addPersonal.reset();
+  }, [addChannel.reset, addPersonal.reset]);
+
+  return {add, mutationFor, reset};
+}

--- a/src/modules/emote_modal/utils.js
+++ b/src/modules/emote_modal/utils.js
@@ -1,0 +1,56 @@
+import {getEmoteDetails, searchSharedEmotes} from '@/actions/emotes';
+import {EmoteAddDestinations, EmoteProviders} from '@/constants';
+import formatMessage from '@/i18n/index';
+
+export function addToLabel(destination) {
+  return destination === EmoteAddDestinations.PERSONAL
+    ? formatMessage({defaultMessage: 'Add to Personal'})
+    : formatMessage({defaultMessage: 'Add to Channel'});
+}
+
+// maps an add mutation's state to the button's loader icon, so the spinner turns into a success or
+// error icon while it settles (mirroring openConfirmModal's confirm button)
+export function addLoaderType(mutation) {
+  if (mutation.isSuccess) {
+    return 'loaderIconSuccess';
+  }
+  if (mutation.isError) {
+    return 'loaderIconError';
+  }
+  return 'loaderIconIndicator';
+}
+
+// react-query options for finding BetterTTV emotes that share an emote's code. Used to both prefetch
+// the alternatives (before swapping to the alternatives page) and to render them, so they hit the
+// same cache entry. A failed search degrades to "no alternatives" rather than erroring the page.
+export function searchSharedEmotesQuery(code) {
+  return {
+    queryKey: ['shared-emote-search', code],
+    queryFn: async () => {
+      try {
+        const response = await searchSharedEmotes(code);
+        return Array.isArray(response) ? response : [];
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+// Resolves {createdAt, user} for the emote modal. BetterTTV is fetched from its API (the result is
+// cached by react-query); 7TV and FrankerFaceZ data is captured on the emote when it's loaded.
+export async function getEmoteModalDetails(emote) {
+  const provider = emote.category?.provider;
+
+  if (provider === EmoteProviders.BETTERTTV) {
+    const details = await getEmoteDetails(emote.id).catch(() => null);
+    return {createdAt: details?.createdAt ?? null, user: details?.user ?? null};
+  }
+
+  if (provider === EmoteProviders.SEVENTV) {
+    const createdAt = emote.metadata?.createdAt;
+    return {createdAt: createdAt != null ? new Date(createdAt).toISOString() : null, user: emote.channel ?? null};
+  }
+
+  return {createdAt: null, user: emote.channel ?? null};
+}

--- a/src/modules/emotes/emote.jsx
+++ b/src/modules/emotes/emote.jsx
@@ -7,6 +7,7 @@ import {getCanonicalEmoteId} from '@/utils/emote';
 import {hasFlag} from '@/utils/flags';
 import {createSrc, createSrcSet} from '@/utils/image';
 import {bindTooltip} from '@/modules/tooltip/index';
+import {bindEmoteModal} from '@/modules/emote_modal/index';
 
 export default class Emote {
   constructor({
@@ -100,6 +101,8 @@ export default class Emote {
       ),
       className: emoteTooltipStyles.emote,
     });
+
+    bindEmoteModal(container, {emote: this});
 
     return container;
   }

--- a/src/modules/emotes/emote.jsx
+++ b/src/modules/emotes/emote.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import EmoteTooltipContent from '@/common/components/EmoteTooltipContent';
 import emoteTooltipStyles from '@/common/components/EmoteTooltipContent.module.css';
 import {EmoteCategories, EmoteTypeFlags, SettingIds} from '@/constants';
+import {bindEmoteModal} from '@/modules/emote_modal/index';
 import {bindTooltip} from '@/modules/tooltip/index';
 import settings from '@/settings';
 import {getCanonicalEmoteId} from '@/utils/emote';
@@ -100,6 +101,8 @@ export default class Emote {
       ),
       className: emoteTooltipStyles.emote,
     });
+
+    bindEmoteModal(container, {emote: this});
 
     return container;
   }

--- a/src/modules/frankerfacez/channel-emotes.js
+++ b/src/modules/frankerfacez/channel-emotes.js
@@ -36,7 +36,7 @@ class FrankerFaceZChannelEmotes extends AbstractEmotes {
 
     getFrankerFaceZChannelEmotes(currentChannel.provider, currentChannel.id)
       .then((emotes) =>
-        emotes.forEach(({id, user, code, images, animated, modifier}) => {
+        emotes.forEach(({id, user, code, images, animated, modifier, imageType}) => {
           this.emotes.set(
             code,
             new Emote({
@@ -47,6 +47,7 @@ class FrankerFaceZChannelEmotes extends AbstractEmotes {
               images,
               animated,
               modifier,
+              metadata: {imageType},
             })
           );
         })

--- a/src/modules/frankerfacez/global-emotes.js
+++ b/src/modules/frankerfacez/global-emotes.js
@@ -33,7 +33,7 @@ class GlobalEmotes extends AbstractEmotes {
 
     getFrankerFaceZGlobalEmotes()
       .then((emotes) =>
-        emotes.forEach(({id, user, code, images, animated, modifier}) => {
+        emotes.forEach(({id, user, code, images, animated, modifier, imageType}) => {
           this.emotes.set(
             code,
             new Emote({
@@ -44,6 +44,7 @@ class GlobalEmotes extends AbstractEmotes {
               images,
               animated,
               modifier,
+              metadata: {imageType},
             })
           );
         })

--- a/src/modules/seventv/channel-emotes.js
+++ b/src/modules/seventv/channel-emotes.js
@@ -55,6 +55,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
         for (const {
           id,
           name: code,
+          timestamp,
           data: {
             listed,
             animated,
@@ -67,7 +68,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
             continue;
           }
 
-          this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url));
+          this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url, timestamp));
         }
 
         eventSource = new ReconnectingEventSource(
@@ -98,6 +99,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
       const {
         id,
         name: code,
+        timestamp,
         data: {
           listed,
           animated,
@@ -111,7 +113,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
         continue;
       }
 
-      this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url));
+      this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url, timestamp));
 
       watcher.emit(
         'chat.send_admin_message',
@@ -130,6 +132,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
       const {
         id,
         name: code,
+        timestamp,
         data: {
           listed,
           animated,
@@ -150,7 +153,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
         continue;
       }
 
-      this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url));
+      this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url, timestamp));
     }
 
     for (const {key, old_value: oldValue} of pulledItems) {

--- a/src/modules/seventv/channel-emotes.js
+++ b/src/modules/seventv/channel-emotes.js
@@ -65,6 +65,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
         for (const {
           id,
           name: code,
+          timestamp,
           data: {
             listed,
             animated,
@@ -77,7 +78,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
             continue;
           }
 
-          this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url));
+          this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url, timestamp));
         }
 
         eventSource = new ReconnectingEventSource(
@@ -108,6 +109,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
       const {
         id,
         name: code,
+        timestamp,
         data: {
           listed,
           animated,
@@ -121,7 +123,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
         continue;
       }
 
-      this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url));
+      this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url, timestamp));
 
       watcher.emit(
         'chat.send_admin_message',
@@ -140,6 +142,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
       const {
         id,
         name: code,
+        timestamp,
         data: {
           listed,
           animated,
@@ -160,7 +163,7 @@ class SevenTVChannelEmotes extends AbstractEmotes {
         continue;
       }
 
-      this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url));
+      this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url, timestamp));
     }
 
     for (const {key, old_value: oldValue} of pulledItems) {

--- a/src/modules/seventv/global-emotes.js
+++ b/src/modules/seventv/global-emotes.js
@@ -40,6 +40,7 @@ class SevenTVGlobalEmotes extends AbstractEmotes {
         for (const {
           id,
           name: code,
+          timestamp,
           data: {
             listed,
             animated,
@@ -52,7 +53,7 @@ class SevenTVGlobalEmotes extends AbstractEmotes {
             continue;
           }
 
-          this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url));
+          this.emotes.set(code, createEmote(id, code, animated, owner, category, isOverlay(flags), url, timestamp));
         }
       })
       .then(() => watcher.emit('emotes.updated'));

--- a/src/modules/seventv/utils.js
+++ b/src/modules/seventv/utils.js
@@ -5,7 +5,7 @@ function emoteUrl(url, version, static_ = false) {
   return `${url}/${version}${static_ ? '_static' : ''}.webp`;
 }
 
-export function createEmote(id, code, animated, owner, category, overlay, url) {
+export function createEmote(id, code, animated, owner, category, overlay, url, timestamp) {
   return new Emote({
     id,
     category,
@@ -26,6 +26,7 @@ export function createEmote(id, code, animated, owner, category, overlay, url) {
     },
     metadata: {
       isOverlay: overlay,
+      createdAt: timestamp,
     },
   });
 }

--- a/src/modules/shadow_dom/ThemeProvider.jsx
+++ b/src/modules/shadow_dom/ThemeProvider.jsx
@@ -1,4 +1,5 @@
 import React, {useMemo, useRef} from 'react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {DEFAULT_PRIMARY_COLOR, SettingIds} from '@/constants';
 import {
   ActionIcon,
@@ -17,6 +18,7 @@ import {
   Pill,
   Radio,
   Switch,
+  Tooltip,
   mergeMantineTheme,
   Loader,
 } from '@mantine/core';
@@ -34,6 +36,16 @@ import useProRequiredState from '@/common/hooks/ProRequiredState';
 import {LoaderIconError, LoaderIconIndicator, LoaderIconSuccess} from '@/common/components/LoaderIcon';
 import {PortalContext} from '@/common/contexts/PortalContext';
 import {useMounted} from '@mantine/hooks';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+      staleTime: 5 * 60 * 1000,
+    },
+  },
+});
 
 const mantineTheme = createTheme({
   primaryColor: DEFAULT_PRIMARY_COLOR,
@@ -144,6 +156,7 @@ const mantineTheme = createTheme({
         type: 'loaderIconIndicator',
       },
     }),
+    Tooltip: Tooltip.extend({defaultProps: {withArrow: true}}),
   },
 });
 
@@ -217,18 +230,20 @@ function ThemeProvider({children, ...props}) {
         withCssVariables={false}
         withGlobalClasses={false}
         {...props}>
-        <div ref={portalRef} id="bttv-shadow-dom-portal" />
-        {/* portalRef.current is not available during the initial render */}
-        {isMounted ? (
-          /* withinPortal:false must be the provider-level default, not just per-modal. The manager
-          renders a single persistent Modal whose per-modal props only apply while a modal is open,
-          so without this the closed Modal falls back to withinPortal:true (portaled) and the first
-          open flips it to inline — remounting the Transition already-open and skipping the enter
-          animation. Keeping it false in both states avoids that remount. */
-          <ModalsProvider modalProps={{withinPortal: false, portalProps: {target: portalRef.current}}}>
-            {children}
-          </ModalsProvider>
-        ) : null}
+        <QueryClientProvider client={queryClient}>
+          <div ref={portalRef} id="bttv-shadow-dom-portal" />
+          {/* portalRef.current is not available during the initial render */}
+          {isMounted ? (
+            /* withinPortal:false must be the provider-level default, not just per-modal. The manager
+            renders a single persistent Modal whose per-modal props only apply while a modal is open,
+            so without this the closed Modal falls back to withinPortal:true (portaled) and the first
+            open flips it to inline — remounting the Transition already-open and skipping the enter
+            animation. Keeping it false in both states avoids that remount. */
+            <ModalsProvider modalProps={{withinPortal: false, portalProps: {target: portalRef.current}}}>
+              {children}
+            </ModalsProvider>
+          ) : null}
+        </QueryClientProvider>
       </MantineProvider>
     </PortalContext.Provider>
   );

--- a/src/modules/shadow_dom/ThemeProvider.jsx
+++ b/src/modules/shadow_dom/ThemeProvider.jsx
@@ -18,11 +18,13 @@ import {
   Radio,
   Switch,
   TagsInput,
+  Tooltip,
   mergeMantineTheme,
   Loader,
 } from '@mantine/core';
 import {useMounted} from '@mantine/hooks';
 import {ModalsProvider} from '@mantine/modals';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import React, {useMemo, useRef} from 'react';
 import {LoaderIconError, LoaderIconIndicator, LoaderIconSuccess} from '@/common/components/LoaderIcon';
 import {PortalContext} from '@/common/contexts/PortalContext';
@@ -38,6 +40,16 @@ import kbdStyles from '@/modules/shadow_dom/styles/kbd.module.css';
 import pillStyles from '@/modules/shadow_dom/styles/pill.module.css';
 import radioStyles from '@/modules/shadow_dom/styles/radio.module.css';
 import switchStyles from '@/modules/shadow_dom/styles/switch.module.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnWindowFocus: false,
+      staleTime: 5 * 60 * 1000,
+    },
+  },
+});
 
 const mantineTheme = createTheme({
   primaryColor: DEFAULT_PRIMARY_COLOR,
@@ -170,6 +182,7 @@ const mantineTheme = createTheme({
         type: 'loaderIconIndicator',
       },
     }),
+    Tooltip: Tooltip.extend({defaultProps: {withArrow: true}}),
   },
 });
 
@@ -265,18 +278,20 @@ function ThemeProvider({children, ...props}) {
         withCssVariables={false}
         withGlobalClasses={false}
         {...props}>
-        <div ref={portalRef} id="bttv-shadow-dom-portal" />
-        {/* portalRef.current is not available during the initial render */}
-        {isMounted ? (
-          /* withinPortal:false must be the provider-level default, not just per-modal. The manager
-          renders a single persistent Modal whose per-modal props only apply while a modal is open,
-          so without this the closed Modal falls back to withinPortal:true (portaled) and the first
-          open flips it to inline — remounting the Transition already-open and skipping the enter
-          animation. Keeping it false in both states avoids that remount. */
-          <ModalsProvider modalProps={{withinPortal: false, portalProps: {target: portalRef.current}}}>
-            {children}
-          </ModalsProvider>
-        ) : null}
+        <QueryClientProvider client={queryClient}>
+          <div ref={portalRef} id="bttv-shadow-dom-portal" />
+          {/* portalRef.current is not available during the initial render */}
+          {isMounted ? (
+            /* withinPortal:false must be the provider-level default, not just per-modal. The manager
+            renders a single persistent Modal whose per-modal props only apply while a modal is open,
+            so without this the closed Modal falls back to withinPortal:true (portaled) and the first
+            open flips it to inline — remounting the Transition already-open and skipping the enter
+            animation. Keeping it false in both states avoids that remount. */
+            <ModalsProvider modalProps={{withinPortal: false, portalProps: {target: portalRef.current}}}>
+              {children}
+            </ModalsProvider>
+          ) : null}
+        </QueryClientProvider>
       </MantineProvider>
     </PortalContext>
   );

--- a/src/modules/shadow_dom/styles/button.module.css
+++ b/src/modules/shadow_dom/styles/button.module.css
@@ -12,13 +12,22 @@
     border: 1px solid var(--button-bd);
     border-bottom-width: 2px;
 
-    &:active {
+    &:active:not(:disabled, [data-disabled]) {
       border-bottom-width: 1px;
     }
 
     transition-property: background-color, border-color, border-bottom-width;
     transition-duration: 0.1s;
     transition-timing-function: ease-in-out;
+
+    /* keep the button's own colors when disabled, just muted, instead of a flat grey */
+    &:disabled:not([data-loading]),
+    &[data-disabled]:not([data-loading]) {
+      background-color: var(--button-bg);
+      color: var(--button-color);
+      border-color: var(--button-bd);
+      opacity: 0.5;
+    }
   }
 
   &[data-size='lg'] {

--- a/src/modules/shadow_dom/styles/button.module.css
+++ b/src/modules/shadow_dom/styles/button.module.css
@@ -12,7 +12,7 @@
     border: 1px solid var(--button-bd);
     border-bottom-width: 2px;
 
-    &:active {
+    &:active:not(:disabled, [data-disabled]) {
       border-bottom-width: 1px;
     }
 
@@ -27,6 +27,15 @@
     transition-property: background-color, border-color, border-bottom-width;
     transition-duration: 0.1s;
     transition-timing-function: ease-in-out;
+
+    /* keep the button's own colors when disabled, just muted, instead of a flat grey */
+    &:disabled:not([data-loading]),
+    &[data-disabled]:not([data-loading]) {
+      background-color: var(--button-bg);
+      color: var(--button-color);
+      border-color: var(--button-bd);
+      opacity: 0.5;
+    }
   }
 
   &[data-size='lg'] {

--- a/src/utils/emote.js
+++ b/src/utils/emote.js
@@ -1,3 +1,18 @@
+import {createSrc} from '@/utils/image';
+
 export function getCanonicalEmoteId(emoteId, emoteProvider) {
   return `${emoteProvider}-${emoteId}`;
+}
+
+// Returns the emote's image type label (e.g. 'PNG', 'WEBP'), preferring a provider-supplied
+// imageType and otherwise inferring it from the image URL extension.
+export function getEmoteImageType(emote) {
+  const imageType = emote.metadata?.imageType;
+  if (imageType != null) {
+    return imageType.toUpperCase();
+  }
+
+  const url = emote.images != null ? createSrc(emote.images, false) : null;
+  const match = url != null ? /\.([a-z0-9]+)(?:[?#]|$)/i.exec(url) : null;
+  return match != null ? match[1].toUpperCase() : null;
 }


### PR DESCRIPTION
## Summary

Clicking an emote in chat now opens a modal with details about it:

- The emote provider's logo (BetterTTV / FrankerFaceZ / 7TV) prefixes the emote name in the title
- A 4x preview of the emote
- **Channel** (or "Global" for global emotes), **Added On** date, **Uploaded By**, and **File Metadata** (type + dimensions)
- For BetterTTV emotes, an **Add to Channel** button to add the emote as a shared emote on your channel

Emotes that open a modal also get a clickable affordance (`cursor: pointer` + hover/active background) matching the emote menu button.

## Notes

- When adding to channel while signed out, the sign-in modal opens stacked above; cancelling or signing in reopens the emote modal (no auto-add).
- Emote details are cached in-memory, mirroring the bot-command autocomplete cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)