### PR TITLE
fix: close emote menu when replacing the default emote picker button

### DIFF
--- a/src/modules/emote_menu/components/Tip.jsx
+++ b/src/modules/emote_menu/components/Tip.jsx
@@ -23,6 +23,7 @@ function getTipToDisplay(onClose) {
   const replaceDefaultEmoteMenu = () => {
     markTipAsSeen(EmoteMenuTips.EMOTE_MENU_REPLACE_DEFAULT);
     setEmoteMenuValue(EmoteMenuTypes.ENABLED);
+    onClose();
   };
 
   const customizeAccentColor = () => {


### PR DESCRIPTION
## Description

Clicking the **"Replace the default emote picker button"** tip in the emote menu enabled the setting (`EMOTE_MENU` → `ENABLED`) but left the emote menu open. Every other actionable tip closes the menu after being clicked — for example, the "Customize the accent color" tip calls `onClose()`.

This adds the missing `onClose()` call to `replaceDefaultEmoteMenu` so the menu closes after the tip is clicked, matching the existing behavior of the accent color tip.

## Changes

- `src/modules/emote_menu/components/Tip.jsx`: call `onClose()` in `replaceDefaultEmoteMenu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)