### PR TITLE
feat: add setting to hide Twitch watch streaks

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -120,6 +120,7 @@ export const ChatFlags = {
   SUB_NOTICE: 1 << 4,
   COMMUNITY_HIGHLIGHTS: 1 << 5,
   CHAT_MESSAGE_HISTORY: 1 << 6,
+  WATCH_STREAKS: 1 << 7,
 };
 
 export const ChannelPointsFlags = {
@@ -293,7 +294,8 @@ export const SettingDefaultValues = {
       ChatFlags.COMMUNITY_HIGHLIGHTS |
       ChatFlags.SUB_NOTICE |
       ChatFlags.VIEWER_GREETING |
-      ChatFlags.CHAT_MESSAGE_HISTORY,
+      ChatFlags.CHAT_MESSAGE_HISTORY |
+      ChatFlags.WATCH_STREAKS,
     0,
   ],
   [SettingIds.AUTO_PLAY]: [

--- a/src/constants.js
+++ b/src/constants.js
@@ -122,6 +122,7 @@ export const ChatFlags = {
   COMMUNITY_HIGHLIGHTS: 1 << 5,
   CHAT_MESSAGE_HISTORY: 1 << 6,
   AI_STREAM_SUMMARY: 1 << 7,
+  WATCH_STREAKS: 1 << 8,
 };
 
 export const ChannelPointsFlags = {
@@ -297,7 +298,8 @@ export const SettingDefaultValues = {
       ChatFlags.SUB_NOTICE |
       ChatFlags.VIEWER_GREETING |
       ChatFlags.CHAT_MESSAGE_HISTORY |
-      ChatFlags.AI_STREAM_SUMMARY,
+      ChatFlags.AI_STREAM_SUMMARY |
+      ChatFlags.WATCH_STREAKS,
     0,
   ],
   [SettingIds.AUTO_PLAY]: [

--- a/src/modules/hide_watch_streaks/index.js
+++ b/src/modules/hide_watch_streaks/index.js
@@ -1,0 +1,33 @@
+import {ChatFlags, PlatformTypes, SettingIds} from '@/constants';
+import settings from '@/settings';
+import {hasFlag} from '@/utils/flags';
+import {loadModuleForPlatforms} from '@/utils/modules';
+import twitch from '@/utils/twitch';
+import watcher from '@/watcher';
+
+const HIDE_WATCH_STREAKS_CLASS = 'bttv-hide-watch-streaks';
+
+function watchStreaksHidden() {
+  return !hasFlag(settings.get(SettingIds.CHAT), ChatFlags.WATCH_STREAKS);
+}
+
+class HideWatchStreaksModule {
+  constructor() {
+    watcher.on('chat.message.handler', (message) => this.handleMessage(message));
+    watcher.on('load', () => this.toggleWatchStreaks());
+    settings.on(`changed.${SettingIds.CHAT}`, () => this.toggleWatchStreaks());
+  }
+
+  handleMessage({message, preventDefault}) {
+    // Watch streaks are delivered to chat as "viewer milestone" messages.
+    if (watchStreaksHidden() && message.type === twitch.getTMIActionTypes()?.VIEWER_MILESTONE) {
+      preventDefault();
+    }
+  }
+
+  toggleWatchStreaks() {
+    document.body.classList.toggle(HIDE_WATCH_STREAKS_CLASS, watchStreaksHidden());
+  }
+}
+
+export default loadModuleForPlatforms([PlatformTypes.TWITCH, () => new HideWatchStreaksModule()]);

--- a/src/modules/hide_watch_streaks/style.css
+++ b/src/modules/hide_watch_streaks/style.css
@@ -1,0 +1,7 @@
+/* The sidebar watch streak badge has no class of its own. Target it downward from the
+   flame icon (`:has(> div > svg path…)` matches the element whose direct child wraps the
+   svg, i.e. the badge), so only the badge collapses. Matching downward means the rule can
+   never climb to the channel card, even on cards that have no .side-nav-card__title. */
+.bttv-hide-watch-streaks .side-nav-card :has(> div > svg path[d^='M11 4.5L9 2L4.80069 6.89']) {
+  display: none !important;
+}

--- a/src/modules/settings/settings/twitch/Chat.jsx
+++ b/src/modules/settings/settings/twitch/Chat.jsx
@@ -54,6 +54,13 @@ function ChatModule(props, ref) {
         })}
       />
       <SettingCheckbox
+        value={ChatFlags.WATCH_STREAKS}
+        name={formatMessage({defaultMessage: 'Watch Streaks'})}
+        description={formatMessage({
+          defaultMessage: 'Show watch streaks in chat and on followed channels in the sidebar.',
+        })}
+      />
+      <SettingCheckbox
         value={ChatFlags.CHAT_MESSAGE_HISTORY}
         name={formatMessage({defaultMessage: 'Message History'})}
         description={formatMessage({
@@ -68,7 +75,18 @@ SettingStore.registerSetting(React.forwardRef(ChatModule), {
   settingPanelId: SettingPanelIds.CHAT,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['bits', 'highlights', 'community', 'chat', 'replies', 'clips', 'subs', 'subscriptions'],
+  keywords: [
+    'bits',
+    'highlights',
+    'community',
+    'chat',
+    'replies',
+    'clips',
+    'subs',
+    'subscriptions',
+    'watch',
+    'streaks',
+  ],
 });
 
 export default React.forwardRef(ChatModule);

--- a/src/modules/settings/settings/twitch/ChatFeatures.jsx
+++ b/src/modules/settings/settings/twitch/ChatFeatures.jsx
@@ -54,6 +54,13 @@ function ChatFeatures({ref, ...props}) {
         })}
       />
       <SettingCheckbox
+        value={ChatFlags.WATCH_STREAKS}
+        name={formatMessage({defaultMessage: 'Watch Streaks'})}
+        description={formatMessage({
+          defaultMessage: 'Show watch streaks in chat and on followed channels in the sidebar.',
+        })}
+      />
+      <SettingCheckbox
         value={ChatFlags.CHAT_MESSAGE_HISTORY}
         name={formatMessage({defaultMessage: 'Message History'})}
         description={formatMessage({

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -253,6 +253,7 @@ export default {
       SUBSCRIPTION: twitchTMIActionTypes.Subscription,
       RESUBSCRIPTION: twitchTMIActionTypes.Resubscription,
       SUBGIFT: twitchTMIActionTypes.SubGift,
+      VIEWER_MILESTONE: twitchTMIActionTypes.ViewerMilestone,
     };
 
     return TMIActionTypes;

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -284,6 +284,7 @@ export default {
       SUBSCRIPTION: twitchTMIActionTypes.Subscription,
       RESUBSCRIPTION: twitchTMIActionTypes.Resubscription,
       SUBGIFT: twitchTMIActionTypes.SubGift,
+      VIEWER_MILESTONE: twitchTMIActionTypes.ViewerMilestone,
     };
 
     return TMIActionTypes;


### PR DESCRIPTION
## Description

Adds a **Watch Streaks** chat flag (enabled by default, in the Chat settings group) that hides Twitch's watch streaks:

- **Chat** — watch streaks arrive as `ViewerMilestone` chat messages; these are dropped through the existing `chat.message.handler` (`preventDefault`), the same mechanism `hide_chat_events` uses — robust and locale-independent. (This also covers the "share your watch streak" prompt above the chat input, which is delivered through the same message path.)
- **Sidebar** — each followed-channel card can show a "Watch Streak N" badge. Twitch renders it with only hashed styled-component classes (no `data-test-selector`/`aria-label`), so it's hidden with a `bttv-hide-watch-streaks` body-class CSS rule that matches the flame icon's path **downward** (`:has(> div > svg path[d^=…])`), isolating just the badge — the rule can never climb up and collapse the whole channel card, even on cards with no `.side-nav-card__title`.

`twitch.getTMIActionTypes()` now also exposes `VIEWER_MILESTONE`.

## Testing

- Verified on live Twitch: `ViewerMilestone` (type 51) messages are dropped by the patched chat handler when the flag is off; toggling the flag drives the body class; the upgrade enables the new flag for existing users.
- Confirmed the sidebar `:has()` rule hides only the badge (channel title, avatar, live status, and card all stay).
- `eslint`, `prettier`, and `vite build` pass; rebased on latest `master`.