### PR TITLE
feat: show BetterTTV logo in autocomplete header

### DIFF
--- a/src/common/components/Autocomplete.jsx
+++ b/src/common/components/Autocomplete.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import useDomObserver from '@/common/hooks/DomObserver';
 import formatMessage from '@/i18n/index';
 import Icon from './Icon';
+import LogoIcon from './LogoIcon';
 import {faArrowDown, faArrowTurnDown, faArrowUp} from '@fortawesome/free-solid-svg-icons';
 import {Kbd, Text} from '@mantine/core';
 import Scrollbar from './Scrollbar';
@@ -318,6 +319,7 @@ function Autocomplete({
       onMouseMove={handleMouseMove}
       {...getFloatingProps()}>
       <div className={styles.autocompleteHeader}>
+        <LogoIcon className={styles.logoIcon} />
         <Text truncate>
           {formatMessage(
             {defaultMessage: 'Results for <bold>{query}</bold>'},

--- a/src/common/components/Autocomplete.module.css
+++ b/src/common/components/Autocomplete.module.css
@@ -39,6 +39,12 @@
   rotate: 90deg;
 }
 
+.logoIcon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+}
+
 .floatRight {
   margin-left: auto;
 }


### PR DESCRIPTION
## What

Adds the BetterTTV logo to the top-left of the shared autocomplete menu header, next to the **Results for …** label.

This component backs both the **emote** autocomplete (`@user` / `:emote`) and the **command** autocomplete, so both menus pick up the branding from a single change.

## Details

- Renders the existing `LogoIcon` as the first child of `autocompleteHeader` in the shared `Autocomplete` component.
- Adds a `.logoIcon` class (16×16, `flex-shrink: 0`) so it sits cleanly to the left of the (truncating) query text without being squished.
- The icon inherits the user's configured primary color via `LogoIcon`, consistent with the emote menu header.

## Testing

- `eslint .` passes
- `prettier --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)