### PR TITLE
feat: self-botting (june update)

### DIFF
--- a/src/common/hooks/CurrentUser.jsx
+++ b/src/common/hooks/CurrentUser.jsx
@@ -1,0 +1,20 @@
+import {useEffect, useState} from 'react';
+import watcher from '@/watcher';
+import {getCurrentUser} from '@/utils/user';
+
+function useCurrentUser() {
+  const [user, setUser] = useState(() => getCurrentUser());
+
+  useEffect(() => {
+    function updateUser() {
+      setUser(getCurrentUser());
+    }
+
+    const cleanups = [watcher.on('channel.updated', updateUser), watcher.on('user.updated', updateUser)];
+    return () => cleanups.forEach((cleanup) => cleanup());
+  }, []);
+
+  return user;
+}
+
+export default useCurrentUser;

--- a/src/common/hooks/IsOnOwnChannel.jsx
+++ b/src/common/hooks/IsOnOwnChannel.jsx
@@ -1,0 +1,10 @@
+import useCurrentChannel from './CurrentChannel';
+import useCurrentUser from './CurrentUser';
+
+function useIsOnOwnChannel() {
+  const user = useCurrentUser();
+  const channel = useCurrentChannel();
+  return user != null && channel != null && user.id === channel.id;
+}
+
+export default useIsOnOwnChannel;

--- a/src/common/styles/SettingEntryTable.module.css
+++ b/src/common/styles/SettingEntryTable.module.css
@@ -1,0 +1,90 @@
+.settingGroupContent {
+  padding: 0;
+  overflow: hidden;
+}
+
+.newEntryButton {
+  margin-left: auto;
+}
+
+.table {
+  font-size: var(--mantine-font-size-md);
+
+  th {
+    font-weight: 500;
+  }
+
+  th,
+  td {
+    padding: 8px 12px;
+    height: 36px;
+  }
+
+  --table-border-color: var(--mantine-color-default-border);
+
+  td:hover {
+    background-color: var(--table-hover-color);
+  }
+}
+
+.actionsColumn {
+  width: 0;
+}
+
+.dataCell {
+  padding: 0 !important;
+}
+
+.dataCellMiddle {
+  padding: 0 !important;
+  vertical-align: middle;
+}
+
+.selectInput {
+  font-size: var(--mantine-font-size-md);
+  padding-left: 12px;
+}
+
+.textInput {
+  font-size: var(--mantine-font-size-md);
+  padding-left: 12px;
+}
+
+.textInput:focus {
+  box-shadow: unset;
+}
+
+.textInputRoot,
+.textInputWrapper,
+.textInput {
+  height: 100%;
+}
+
+.actionIcon {
+  width: 36px !important;
+  height: 36px !important;
+  min-width: 36px;
+  min-height: 36px;
+  padding: 8px;
+  border-radius: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.actionIconIcon {
+  width: 12px;
+  height: 12px;
+}
+
+.emptyText {
+  padding: 20px;
+  text-align: center;
+}
+
+td.actionsColumn {
+  width: 36px;
+  min-width: 36px;
+  max-width: 36px;
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -62,6 +62,8 @@ export const SettingIds = {
   HYPE_CHAT: 'hypeChat',
   PRIMARY_COLOR: 'primaryColor',
   CHATBOT_COMMAND_AUTOCOMPLETE: 'chatbotCommandAutocomplete',
+  SELF_BOT: 'selfBot',
+  SELF_BOT_COMMANDS_LIST: 'selfBotCommandsList',
 };
 
 export const CategoryTypes = {
@@ -152,10 +154,11 @@ export const PageTypes = {
   USER_SETTINGS: 3,
   HIGHLIGHT_KEYWORDS: 4,
   BLACKLIST_KEYWORDS: 5,
+  SELF_BOT_COMMANDS: 6,
 };
 
 export const PageDecendants = {
-  [PageTypes.SETTINGS]: [PageTypes.HIGHLIGHT_KEYWORDS, PageTypes.BLACKLIST_KEYWORDS],
+  [PageTypes.SETTINGS]: [PageTypes.HIGHLIGHT_KEYWORDS, PageTypes.BLACKLIST_KEYWORDS, PageTypes.SELF_BOT_COMMANDS],
 };
 
 export const NavigationModeTypes = {
@@ -222,6 +225,7 @@ export const EmoteMenuTips = {
 export const SettingsPromotions = {
   THEME_CUSTOMIZE: 'settingsPromotionDismissedThemeCustomize',
   CHATBOT_COMMAND_AUTOCOMPLETE: 'settingsPromotionDismissedChatbotCommandAutocomplete',
+  SELF_BOT: 'settingsPromotionDismissedSelfBot',
 };
 
 export const SettingsPrompts = {
@@ -307,6 +311,8 @@ export const SettingDefaultValues = {
   [SettingIds.HYPE_CHAT]: true,
   [SettingIds.PRIMARY_COLOR]: null,
   [SettingIds.CHATBOT_COMMAND_AUTOCOMPLETE]: true,
+  [SettingIds.SELF_BOT]: false,
+  [SettingIds.SELF_BOT_COMMANDS_LIST]: {},
 };
 
 export const FlagSettings = [

--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -1,11 +1,12 @@
 import {DateTime} from 'luxon';
-import isSafeRegex from 'safe-regex2';
 import {PlatformTypes, SettingIds} from '@/constants';
 import splitChat from '@/modules/split_chat/index';
 import settings from '@/settings';
 import cdn from '@/utils/cdn';
 import {getCurrentChannel} from '@/utils/channel';
+import {messageTextFromAST} from '@/utils/chat-message-text';
 import colors from '@/utils/colors';
+import {extractRegex} from '@/utils/keyword-regex';
 import {computeKeywords, KeywordTypes} from '@/utils/keywords';
 import {loadModuleForPlatforms} from '@/utils/modules';
 import {escapeRegExp} from '@/utils/regex';
@@ -21,7 +22,6 @@ const VOD_CHAT_MESSAGE_EMOTE_SELECTOR = '.chat-line__message--emote';
 const PINNED_HIGHLIGHT_ID = 'bttv-pinned-highlight';
 const PINNED_CONTAINER_ID = 'bttv-pin-container';
 const PINNED_HIGHLIGHT_TIMEOUT = 60 * 1000;
-const REGEX_KEYWORD_REGEX = /^~\/(.*)\/([a-z]+)?$/;
 
 function createPinnedHighlight({timestamp, from, message: messageText}) {
   const container = document.createElement('div');
@@ -181,19 +181,6 @@ function exactMatch(keyword) {
   return keyword.replace(/^<(.*)>$/g, '^$1$$');
 }
 
-function extractRegex(keyword) {
-  const matches = REGEX_KEYWORD_REGEX.exec(keyword);
-  if (matches == null || !isSafeRegex(matches[1])) {
-    return null;
-  }
-
-  try {
-    return new RegExp(matches[1], matches[2]);
-  } catch (_) {}
-
-  return null;
-}
-
 function keywordRegEx(keyword) {
   return new RegExp(`(\\s|^|@)${keyword}([!.,:';?/]|\\s|$)`, 'i');
 }
@@ -244,27 +231,6 @@ function fieldContainsKeyword(keywords, from, field, onColorChange) {
 
 function isReply(message) {
   return message.closest('.chat-input-tray__open') != null;
-}
-
-function messageTextFromAST(ast) {
-  return ast
-    .map((node) => {
-      switch (node.type) {
-        case 0: // Text
-          return node.content.trim();
-        case 3: // CurrentUserHighlight
-          return `@${node.content}`;
-        case 4: // Mention
-          return `@${node.content.recipient}`;
-        case 5: // Link
-          return node.content.url;
-        case 6: // Emote
-          return node.content.alt;
-        default:
-          return '';
-      }
-    })
-    .join(' ');
 }
 
 let pinnedHighlightsContainer;

--- a/src/modules/self_bot/commands.js
+++ b/src/modules/self_bot/commands.js
@@ -1,0 +1,79 @@
+export const SelfBotUserLevels = {
+  EVERYONE: 0,
+  VIP: 1,
+  SUBSCRIBER: 2,
+  MOD: 3,
+};
+
+function normalizeUserLevel(userLevel) {
+  if (typeof userLevel === 'string' && /^\d+$/.test(userLevel.trim())) {
+    return Number.parseInt(userLevel.trim(), 10);
+  }
+
+  if (typeof userLevel === 'number' && Object.values(SelfBotUserLevels).includes(userLevel)) {
+    return userLevel;
+  }
+
+  return SelfBotUserLevels.EVERYONE;
+}
+
+export function computeSelfBotCommands(commandsMap) {
+  const computed = [];
+
+  if (commandsMap == null) {
+    return computed;
+  }
+
+  for (const {command, response, userLevel} of Object.values(commandsMap)) {
+    if (command == null || command.trim().length === 0) {
+      continue;
+    }
+
+    if (response == null || response.trim().length === 0) {
+      continue;
+    }
+
+    computed.push({
+      command: command.trim(),
+      response: response.trim(),
+      userLevel: normalizeUserLevel(userLevel),
+    });
+  }
+
+  return computed;
+}
+
+export function matchesUserLevel(userLevel, messageObj) {
+  const level = normalizeUserLevel(userLevel);
+
+  if (level === SelfBotUserLevels.EVERYONE) {
+    return true;
+  }
+
+  const isMod = messageObj?.user?.userType === 'mod';
+  const isSubscriber = messageObj?.user?.isSubscriber === true;
+  const isVip = messageObj?.isVip === true;
+
+  switch (level) {
+    case SelfBotUserLevels.MOD:
+      return isMod;
+    case SelfBotUserLevels.VIP:
+      return isVip || isMod;
+    case SelfBotUserLevels.SUBSCRIBER:
+      return isSubscriber || isVip || isMod;
+    default:
+      return true;
+  }
+}
+
+export function matchesCommand({command}, messageText) {
+  if (messageText == null) {
+    return false;
+  }
+
+  const normalizedMessage = messageText.trim();
+  const normalizedCommand = command.toLowerCase();
+  const lowerMessage = normalizedMessage.toLowerCase();
+
+  return lowerMessage === normalizedCommand || lowerMessage.startsWith(`${normalizedCommand} `);
+}

--- a/src/modules/self_bot/index.js
+++ b/src/modules/self_bot/index.js
@@ -1,0 +1,136 @@
+import {PlatformTypes, SettingIds} from '@/constants';
+import settings from '@/settings';
+import socketClient from '@/socket-client';
+import useAuthStore from '@/stores/auth';
+import {messageTextFromAST} from '@/utils/chat-message-text';
+import {loadModuleForPlatforms} from '@/utils/modules';
+import twitch from '@/utils/twitch';
+import {getCurrentUser} from '@/utils/user';
+import watcher from '@/watcher';
+import {computeSelfBotCommands, matchesCommand, matchesUserLevel} from './commands';
+
+const COMMAND_COOLDOWN_MS = 2000;
+// only one session per user may hold this lock, ensuring a single session replies
+const SELF_BOT_SESSION_LOCK = 'self_bot';
+
+let computedCommands = [];
+const commandCooldowns = new Map();
+let loadTime = Date.now();
+
+function recomputeCommands() {
+  computedCommands = computeSelfBotCommands(settings.get(SettingIds.SELF_BOT_COMMANDS_LIST));
+}
+
+function isSelfBotActive() {
+  return (
+    settings.get(SettingIds.SELF_BOT) && useAuthStore.getState().user != null && twitch.getCurrentUserIsOwner() === true
+  );
+}
+
+// claim the lock while we are actively self-botting our own channel, release it otherwise
+// so another session can take over
+function updateSessionLock() {
+  if (isSelfBotActive()) {
+    socketClient.acquireSessionLock(SELF_BOT_SESSION_LOCK);
+  } else {
+    socketClient.releaseSessionLock(SELF_BOT_SESSION_LOCK);
+  }
+}
+
+function isOnCooldown(command) {
+  const lastTriggered = commandCooldowns.get(command);
+  if (lastTriggered == null) {
+    return false;
+  }
+
+  return Date.now() - lastTriggered < COMMAND_COOLDOWN_MS;
+}
+
+function setCooldown(command) {
+  commandCooldowns.set(command, Date.now());
+}
+
+class SelfBotModule {
+  constructor() {
+    watcher.on('load.chat', () => {
+      loadTime = Date.now();
+      recomputeCommands();
+      updateSessionLock();
+    });
+    watcher.on('chat.message', (_, messageObj) => this.onMessage(messageObj));
+    settings.on(`changed.${SettingIds.SELF_BOT_COMMANDS_LIST}`, recomputeCommands);
+    settings.on(`changed.${SettingIds.SELF_BOT}`, () => {
+      recomputeCommands();
+      updateSessionLock();
+    });
+    useAuthStore.subscribe((state) => state.user, updateSessionLock);
+
+    recomputeCommands();
+    updateSessionLock();
+  }
+
+  onMessage(messageObj) {
+    if (!settings.get(SettingIds.SELF_BOT)) {
+      return;
+    }
+
+    if (useAuthStore.getState().user == null) {
+      return;
+    }
+
+    if (!twitch.getCurrentUserIsOwner()) {
+      return;
+    }
+
+    // another session holds the lock and is responsible for replying
+    if (!socketClient.hasSessionLock(SELF_BOT_SESSION_LOCK)) {
+      return;
+    }
+
+    const {user, login, messageParts, timestamp, badges} = messageObj;
+    if (timestamp == null || timestamp <= loadTime) {
+      return;
+    }
+
+    // don't reply to other chat bots (Twitch flags them with a bot badge)
+    if (badges?.['bot-badge'] != null) {
+      return;
+    }
+
+    const currentUser = getCurrentUser();
+    if (user == null && login == null) {
+      return;
+    }
+
+    const from = login ?? user.userLogin;
+    if (currentUser != null && from.toLowerCase() === currentUser.name.toLowerCase()) {
+      return;
+    }
+
+    if (messageParts == null) {
+      return;
+    }
+
+    const messageText = messageTextFromAST(messageParts);
+
+    for (const command of computedCommands) {
+      if (isOnCooldown(command.command)) {
+        continue;
+      }
+
+      if (!matchesCommand(command, messageText)) {
+        continue;
+      }
+
+      if (!matchesUserLevel(command.userLevel, messageObj)) {
+        continue;
+      }
+
+      setCooldown(command.command);
+      twitch.sendChatMessage(command.response, {replyParentMessage: messageObj});
+      return;
+    }
+  }
+}
+
+export default loadModuleForPlatforms([PlatformTypes.TWITCH, () => new SelfBotModule()]);

--- a/src/modules/settings/components/Promotion.jsx
+++ b/src/modules/settings/components/Promotion.jsx
@@ -6,7 +6,7 @@ import {ActionIcon, Button, Image, Title} from '@mantine/core';
 import {PageContext} from '@/modules/settings/contexts/PageContext';
 import {SettingPanelIds} from '@/modules/settings/stores/SettingStore';
 import Icon from '@/common/components/Icon';
-import {faClose, faPaintBrush} from '@fortawesome/free-solid-svg-icons';
+import {faClose, faPaintBrush, faRobot} from '@fortawesome/free-solid-svg-icons';
 import formatMessage from '@/i18n/index';
 import NightbotLogoIcon from '@/common/components/NightbotLogoIcon';
 import {SettingsPromotions} from '@/constants';
@@ -33,6 +33,13 @@ function getPromotionToDisplay() {
         settingPanelId: SettingPanelIds.CHATBOTS,
         title: formatMessage({defaultMessage: 'Command Autocomplete'}),
         icon: <BotProviderPromotionIcons />,
+      };
+    case SettingsPromotions.SELF_BOT:
+      return {
+        storageKey: SettingsPromotions.SELF_BOT,
+        settingPanelId: SettingPanelIds.SELF_BOT,
+        title: formatMessage({defaultMessage: 'Auto-respond to your chat messages'}),
+        icon: <Icon icon={faRobot} className={styles.logo} />,
       };
     case SettingsPromotions.THEME_CUSTOMIZE:
       return {

--- a/src/modules/settings/components/SettingKeywords.jsx
+++ b/src/modules/settings/components/SettingKeywords.jsx
@@ -17,6 +17,7 @@ import {
 } from '@mantine/core';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {faCircleInfo, faTrash} from '@fortawesome/free-solid-svg-icons';
+import tableStyles from '@/common/styles/SettingEntryTable.module.css';
 import styles from './SettingKeywords.module.css';
 import {KeywordTypes} from '@/utils/keywords';
 import formatMessage from '@/i18n/index';
@@ -110,7 +111,7 @@ function KeywordRow({
   return (
     <TableTr {...props}>
       {colorColumn != null ? (
-        <TableTd className={styles.colorDataCell}>
+        <TableTd className={tableStyles.dataCell}>
           <ColorPicker
             size="sm"
             variant="transparent"
@@ -122,10 +123,10 @@ function KeywordRow({
           />
         </TableTd>
       ) : null}
-      <TableTd className={styles.targetDataCell}>
+      <TableTd className={tableStyles.dataCell}>
         <NativeSelect
           variant="unstyled"
-          classNames={{input: styles.targetSelectInput}}
+          classNames={{input: tableStyles.selectInput}}
           value={data.type}
           data={[
             {label: formatMessage({defaultMessage: 'Message'}), value: KeywordTypes.MESSAGE},
@@ -136,13 +137,13 @@ function KeywordRow({
           onChange={({target: {value}}) => onUpdate({type: parseInt(value, 10)})}
         />
       </TableTd>
-      <TableTd className={styles.keywordDataCell}>
+      <TableTd className={tableStyles.dataCell}>
         <TextInput
           variant="unstyled"
           classNames={{
-            input: styles.keywordInput,
-            root: styles.keywordRoot,
-            wrapper: styles.keywordWrapper,
+            input: tableStyles.textInput,
+            root: classNames(tableStyles.textInputRoot, styles.keywordRoot),
+            wrapper: tableStyles.textInputWrapper,
           }}
           ref={keywordInputRef}
           defaultValue={data.keyword}
@@ -186,13 +187,13 @@ function KeywordRow({
           )}
         </button>
       </TableTd>
-      <TableTd className={styles.actionsDataCell}>
+      <TableTd className={tableStyles.dataCell}>
         <ActionIcon
           color="gray"
           variant="transparent"
-          className={styles.actionIcon}
+          className={tableStyles.actionIcon}
           size="sm"
-          classNames={{icon: styles.actionIconIcon}}
+          classNames={{icon: tableStyles.actionIconIcon}}
           onClick={onDelete}>
           <Icon icon={faTrash} />
         </ActionIcon>
@@ -217,7 +218,7 @@ function KeywordsTable({
   onPaste,
 }) {
   return (
-    <Table withColumnBorders className={styles.table} onPaste={onPaste}>
+    <Table withColumnBorders className={tableStyles.table} onPaste={onPaste}>
       <TableThead>
         <TableTr>
           {showColorColumn ? <TableTh className={styles.colorColumn} /> : null}
@@ -236,7 +237,7 @@ function KeywordsTable({
             </div>
           </TableTh>
           <TableTh className={styles.channelsColumn}>{formatMessage({defaultMessage: 'Channels'})}</TableTh>
-          <TableTh className={styles.actionsColumn} />
+          <TableTh className={tableStyles.actionsColumn} />
         </TableTr>
       </TableThead>
       <TableTbody>
@@ -369,7 +370,7 @@ function SettingKeywords({value, setValue, colorColumn = null}) {
         />
       }
       rightContent={
-        <Button size="lg" className={styles.newEntryButton} onClick={newEntryHandler}>
+        <Button size="lg" className={tableStyles.newEntryButton} onClick={newEntryHandler}>
           {formatMessage({defaultMessage: 'New Entry'})}
         </Button>
       }
@@ -390,7 +391,7 @@ function SettingKeywords({value, setValue, colorColumn = null}) {
           {formatMessage({defaultMessage: 'No keywords match your search.'})}
         </Text>
       ) : (
-        <Text className={styles.noKeywordsText} c="dimmed">
+        <Text className={tableStyles.emptyText} c="dimmed">
           {formatMessage({defaultMessage: 'No keywords found, start by adding a new entry.'})}
         </Text>
       )}

--- a/src/modules/settings/components/SettingSelfBotCommands.jsx
+++ b/src/modules/settings/components/SettingSelfBotCommands.jsx
@@ -1,0 +1,249 @@
+import {
+  ActionIcon,
+  Button,
+  NativeSelect,
+  Table,
+  TableTbody,
+  TableTd,
+  TableTh,
+  TableThead,
+  TableTr,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import React, {useCallback, useMemo, useRef, useState} from 'react';
+import classNames from 'classnames';
+import {faTrash} from '@fortawesome/free-solid-svg-icons';
+import {useShallow} from 'zustand/react/shallow';
+import tableStyles from '@/common/styles/SettingEntryTable.module.css';
+import styles from './SettingSelfBotCommands.module.css';
+import formatMessage from '@/i18n/index';
+import Panel from './Panel';
+import Icon from '@/common/components/Icon';
+import {openSignInModal, openSubscriptionUpgradeModal} from '@/common/utils/modal';
+import useAuthStore from '@/stores/auth';
+import {isUserPro} from '@/utils/pro';
+import {SelfBotUserLevels} from '@/modules/self_bot/commands';
+
+const FREE_COMMAND_LIMIT = 5;
+
+function CommandRow({id, data, updateHandler, deleteHandler, commandInputRefCallback, ...props}) {
+  const onUpdate = useCallback((newData) => updateHandler(id, newData), [updateHandler, id]);
+  const onDelete = useCallback(() => deleteHandler(id), [deleteHandler, id]);
+  const commandInputRef = useCallback((ref) => commandInputRefCallback(id, ref), [commandInputRefCallback, id]);
+
+  const userLevel = data.userLevel ?? SelfBotUserLevels.EVERYONE;
+
+  return (
+    <TableTr {...props}>
+      <TableTd className={classNames(tableStyles.dataCellMiddle, styles.commandColumn)}>
+        <TextInput
+          variant="unstyled"
+          classNames={{
+            input: tableStyles.textInput,
+            root: classNames(tableStyles.textInputRoot, styles.commandRoot),
+            wrapper: tableStyles.textInputWrapper,
+          }}
+          ref={commandInputRef}
+          defaultValue={data.command}
+          onBlur={({target: {value}}) => onUpdate({command: value})}
+          placeholder={formatMessage({defaultMessage: '!command'})}
+        />
+      </TableTd>
+      <TableTd className={tableStyles.dataCellMiddle}>
+        <TextInput
+          variant="unstyled"
+          classNames={{
+            input: tableStyles.textInput,
+            root: classNames(tableStyles.textInputRoot, styles.responseRoot),
+            wrapper: tableStyles.textInputWrapper,
+          }}
+          defaultValue={data.response}
+          onBlur={({target: {value}}) => onUpdate({response: value})}
+          placeholder={formatMessage({defaultMessage: 'Response message'})}
+        />
+      </TableTd>
+      <TableTd className={classNames(tableStyles.dataCellMiddle, styles.userLevelColumn)}>
+        <NativeSelect
+          variant="unstyled"
+          classNames={{input: tableStyles.selectInput}}
+          value={userLevel}
+          data={[
+            {label: formatMessage({defaultMessage: 'Everyone'}), value: SelfBotUserLevels.EVERYONE},
+            {label: formatMessage({defaultMessage: 'VIP'}), value: SelfBotUserLevels.VIP},
+            {label: formatMessage({defaultMessage: 'Subscriber'}), value: SelfBotUserLevels.SUBSCRIBER},
+            {label: formatMessage({defaultMessage: 'Moderator'}), value: SelfBotUserLevels.MOD},
+          ]}
+          size="lg"
+          onChange={({target: {value}}) => onUpdate({userLevel: Number.parseInt(value, 10)})}
+        />
+      </TableTd>
+      <TableTd className={classNames(tableStyles.dataCellMiddle, tableStyles.actionsColumn)}>
+        <ActionIcon
+          color="gray"
+          variant="transparent"
+          className={tableStyles.actionIcon}
+          size="sm"
+          classNames={{icon: tableStyles.actionIconIcon}}
+          onClick={onDelete}>
+          <Icon icon={faTrash} />
+        </ActionIcon>
+      </TableTd>
+    </TableTr>
+  );
+}
+
+function createNewEntry() {
+  const nextId = crypto.randomUUID();
+  return {id: nextId, command: '', response: '', userLevel: SelfBotUserLevels.EVERYONE};
+}
+
+function CommandsTable({entryList, updateHandler, deleteHandler, commandInputRefCallback}) {
+  return (
+    <Table withColumnBorders className={tableStyles.table}>
+      <TableThead>
+        <TableTr>
+          <TableTh className={styles.commandColumn}>{formatMessage({defaultMessage: 'Command'})}</TableTh>
+          <TableTh>{formatMessage({defaultMessage: 'Response'})}</TableTh>
+          <TableTh className={styles.userLevelColumn}>{formatMessage({defaultMessage: 'User Level'})}</TableTh>
+          <TableTh className={tableStyles.actionsColumn} />
+        </TableTr>
+      </TableThead>
+      <TableTbody>
+        {entryList.map(([id, row]) => (
+          <CommandRow
+            id={id}
+            key={id}
+            data={row}
+            updateHandler={updateHandler}
+            deleteHandler={deleteHandler}
+            commandInputRefCallback={commandInputRefCallback}
+          />
+        ))}
+      </TableTbody>
+    </Table>
+  );
+}
+
+function SettingSelfBotCommands({value, setValue}) {
+  const [search, setSearch] = useState('');
+  const entryList = useMemo(() => Object.entries(value ?? {}).reverse(), [value]);
+  const pendingCommandFocusRef = useRef(null);
+  const bttvUser = useAuthStore(useShallow((state) => state.user));
+
+  const filteredEntryList = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (query.length === 0) {
+      return entryList;
+    }
+    return entryList.filter(([, row]) => row.command.toLowerCase().includes(query));
+  }, [entryList, search]);
+
+  const newEntryHandler = useCallback(() => {
+    const commandCount = Object.keys(value ?? {}).length;
+
+    if (commandCount >= FREE_COMMAND_LIMIT) {
+      if (bttvUser == null) {
+        openSignInModal({}, () => newEntryHandler());
+        return;
+      }
+
+      if (!isUserPro(bttvUser)) {
+        openSubscriptionUpgradeModal({}, () => newEntryHandler());
+        return;
+      }
+    }
+
+    setSearch('');
+    const newEntry = createNewEntry();
+
+    setValue((prevCommands) => {
+      const nextCommands = {...prevCommands};
+      nextCommands[newEntry.id] = newEntry;
+      return nextCommands;
+    });
+
+    pendingCommandFocusRef.current = newEntry.id;
+  }, [setValue, value, bttvUser]);
+
+  const deleteHandler = useCallback(
+    (id) => {
+      setValue((prevCommands) => {
+        const nextCommands = {...prevCommands};
+
+        if (nextCommands[id] == null) {
+          return prevCommands;
+        }
+
+        delete nextCommands[id];
+        return nextCommands;
+      });
+    },
+    [setValue]
+  );
+
+  const updateHandler = useCallback(
+    (id, newCommandData) => {
+      setValue((prevCommands) => {
+        const nextCommands = {...prevCommands};
+        const existingCommand = nextCommands[id];
+
+        if (existingCommand == null) {
+          return prevCommands;
+        }
+
+        nextCommands[id] = {...existingCommand, ...newCommandData};
+        return nextCommands;
+      });
+    },
+    [setValue]
+  );
+
+  const commandInputRefCallback = useCallback((id, ref) => {
+    if (pendingCommandFocusRef.current !== id) {
+      return;
+    }
+
+    ref?.focus();
+    pendingCommandFocusRef.current = null;
+  }, []);
+
+  return (
+    <Panel
+      title={
+        <TextInput
+          size="lg"
+          value={search}
+          placeholder={formatMessage({defaultMessage: 'Search commands...'})}
+          onChange={({target: {value: searchValue}}) => setSearch(searchValue)}
+          classNames={{input: styles.searchInput, root: styles.searchInputRoot}}
+          radius="lg"
+        />
+      }
+      rightContent={
+        <Button size="lg" className={tableStyles.newEntryButton} onClick={newEntryHandler}>
+          {formatMessage({defaultMessage: 'New Entry'})}
+        </Button>
+      }
+      className={tableStyles.settingGroupContent}>
+      {filteredEntryList.length > 0 ? (
+        <CommandsTable
+          entryList={filteredEntryList}
+          updateHandler={updateHandler}
+          deleteHandler={deleteHandler}
+          commandInputRefCallback={commandInputRefCallback}
+        />
+      ) : entryList.length > 0 ? (
+        <Text className={tableStyles.emptyText} c="dimmed">
+          {formatMessage({defaultMessage: 'No commands match your search.'})}
+        </Text>
+      ) : (
+        <Text className={tableStyles.emptyText} c="dimmed">
+          {formatMessage({defaultMessage: 'No commands found, start by adding a new entry.'})}
+        </Text>
+      )}
+    </Panel>
+  );
+}
+
+export default SettingSelfBotCommands;

--- a/src/modules/settings/components/SettingSelfBotCommands.module.css
+++ b/src/modules/settings/components/SettingSelfBotCommands.module.css
@@ -1,0 +1,39 @@
+.searchInputRoot {
+  width: 100%;
+  max-width: 240px;
+}
+
+.searchInput {
+  height: 32px;
+}
+
+.userLevelColumn {
+  width: 128px;
+}
+
+td.userLevelColumn {
+  width: 128px;
+  min-width: 128px;
+  max-width: 128px;
+}
+
+.commandColumn {
+  width: 128px;
+}
+
+td.commandColumn {
+  width: 128px;
+  min-width: 128px;
+  max-width: 160px;
+}
+
+.commandRoot {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.responseRoot {
+  min-width: 0;
+  width: 100%;
+}

--- a/src/modules/settings/components/SettingWrapper.jsx
+++ b/src/modules/settings/components/SettingWrapper.jsx
@@ -11,6 +11,7 @@ function SettingWrapper({
   children,
   showProBadge = false,
   showBetaBadge = false,
+  showComingSoonBadge = false,
   reverse = false,
   wrap = false,
   controlClassName = '',
@@ -48,6 +49,11 @@ function SettingWrapper({
                   {formatMessage({defaultMessage: 'Beta'})}
                 </Badge>
               </Tooltip>
+            ) : null}
+            {showComingSoonBadge ? (
+              <Badge color="green" variant="elevated" size="lg">
+                {formatMessage({defaultMessage: 'Coming Soon'})}
+              </Badge>
             ) : null}
           </Title>
         ) : null}

--- a/src/modules/settings/components/SettingsModal.jsx
+++ b/src/modules/settings/components/SettingsModal.jsx
@@ -14,6 +14,7 @@ import SideNavigation from './SideNavigation';
 import PageHeader from './PageHeader';
 import {PageContext} from '@/modules/settings/contexts/PageContext';
 import BlacklistKeywords from '@/modules/settings/pages/BlacklistKeywords';
+import SelfBotCommands from '@/modules/settings/pages/SelfBotCommands';
 import {AnimatePresence, motion, usePresenceData} from 'framer-motion';
 import {faArrowLeft} from '@fortawesome/free-solid-svg-icons';
 import Icon from '@/common/components/Icon';
@@ -42,6 +43,16 @@ function maybePromptSignIn() {
   });
 }
 
+function getParentPage(page) {
+  for (const [parentPage, childPages] of Object.entries(PageDecendants)) {
+    if (childPages.includes(page)) {
+      return Number(parentPage);
+    }
+  }
+
+  return PageTypes.SETTINGS;
+}
+
 function Page({page, search, handleSettingRefCallback}) {
   switch (page) {
     case PageTypes.CHANGELOG:
@@ -50,6 +61,8 @@ function Page({page, search, handleSettingRefCallback}) {
       return <HighlightKeywords />;
     case PageTypes.BLACKLIST_KEYWORDS:
       return <BlacklistKeywords />;
+    case PageTypes.SELF_BOT_COMMANDS:
+      return <SelfBotCommands />;
     case PageTypes.SETTINGS:
       return <Settings search={search} handleSettingRefCallback={handleSettingRefCallback} />;
     case PageTypes.USER_SETTINGS:
@@ -218,9 +231,9 @@ function SettingsModal({setHandleOpen}) {
     setSearch(value);
   }, []);
 
-  const handleBackToSettings = useCallback(() => {
-    handlePageChange(PageTypes.SETTINGS);
-  }, [handlePageChange]);
+  const handleBack = useCallback(() => {
+    handlePageChange(getParentPage(page));
+  }, [handlePageChange, page]);
 
   const leftContent = useMemo(() => {
     switch (page) {
@@ -242,6 +255,7 @@ function SettingsModal({setHandleOpen}) {
         return <Title order={1}>{formatMessage({defaultMessage: 'Changelog'})}</Title>;
       case PageTypes.HIGHLIGHT_KEYWORDS:
       case PageTypes.BLACKLIST_KEYWORDS:
+      case PageTypes.SELF_BOT_COMMANDS:
         return (
           <div className={styles.backHeader}>
             <ActionIcon
@@ -250,21 +264,23 @@ function SettingsModal({setHandleOpen}) {
               variant="subtle"
               color="gray"
               className={styles.backIcon}
-              onClick={handleBackToSettings}
-              aria-label={formatMessage({defaultMessage: 'Back to Settings'})}>
+              onClick={handleBack}
+              aria-label={formatMessage({defaultMessage: 'Back'})}>
               <Icon className={styles.backButtonIcon} icon={faArrowLeft} />
             </ActionIcon>
             <Title order={1}>
               {page === PageTypes.HIGHLIGHT_KEYWORDS
                 ? formatMessage({defaultMessage: 'Highlight Keywords'})
-                : formatMessage({defaultMessage: 'Blacklist Keywords'})}
+                : page === PageTypes.BLACKLIST_KEYWORDS
+                  ? formatMessage({defaultMessage: 'Blacklist Keywords'})
+                  : formatMessage({defaultMessage: 'Self Bot Commands'})}
             </Title>
           </div>
         );
       default:
         return null;
     }
-  }, [page, search, inputRef, handleSearchChange, handleBackToSettings]);
+  }, [page, search, inputRef, handleSearchChange, handleBack]);
 
   const computeDefaultScrollTop = useCallback(() => {
     if (

--- a/src/modules/settings/components/SideNavigation.jsx
+++ b/src/modules/settings/components/SideNavigation.jsx
@@ -4,7 +4,7 @@ import styles from './SideNavigation.module.css';
 import AnimatedLogo from './AnimatedLogo';
 import {ActionIcon, Avatar, Button, Overlay, Tooltip, useMantineTheme} from '@mantine/core';
 import {faArrowLeft, faCog, faScroll, faUser, faUserGear} from '@fortawesome/free-solid-svg-icons';
-import {PageTypes} from '@/constants';
+import {PageDecendants, PageTypes} from '@/constants';
 import classNames from 'classnames';
 import formatMessage from '@/i18n/index';
 import {PageContext} from '@/modules/settings/contexts/PageContext';
@@ -111,11 +111,7 @@ function SideNavigation({open, setOpen}) {
         </div>
         <NavigationButton
           className={styles.topNavigationButton}
-          active={
-            page === PageTypes.SETTINGS ||
-            page === PageTypes.HIGHLIGHT_KEYWORDS ||
-            page === PageTypes.BLACKLIST_KEYWORDS
-          }
+          active={page === PageTypes.SETTINGS || PageDecendants[PageTypes.SETTINGS].includes(page)}
           value={PageTypes.SETTINGS}
           setPage={setPage}
           label={formatMessage({defaultMessage: 'Settings'})}>

--- a/src/modules/settings/pages/BlacklistKeywords.module.css
+++ b/src/modules/settings/pages/BlacklistKeywords.module.css
@@ -1,8 +1,0 @@
-.arrowLeftIcon {
-  width: 14px;
-  height: 14px;
-}
-
-.backButton {
-  max-height: 36px;
-}

--- a/src/modules/settings/pages/HighlightKeywords.module.css
+++ b/src/modules/settings/pages/HighlightKeywords.module.css
@@ -1,8 +1,0 @@
-.arrowLeftIcon {
-  width: 14px;
-  height: 14px;
-}
-
-.backButton {
-  max-height: 36px;
-}

--- a/src/modules/settings/pages/SelfBotCommands.jsx
+++ b/src/modules/settings/pages/SelfBotCommands.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import useStorageState from '@/common/hooks/StorageState';
+import {SettingIds} from '@/constants';
+import SettingSelfBotCommands from '@/modules/settings/components/SettingSelfBotCommands';
+import PageScrollBody from '@/modules/settings/components/PageScrollBody';
+
+function SelfBotCommands() {
+  const [value, setValue] = useStorageState(SettingIds.SELF_BOT_COMMANDS_LIST);
+
+  return (
+    <PageScrollBody>
+      <SettingSelfBotCommands value={value} setValue={setValue} />
+    </PageScrollBody>
+  );
+}
+
+export default SelfBotCommands;

--- a/src/modules/settings/settings/twitch/SelfBot.jsx
+++ b/src/modules/settings/settings/twitch/SelfBot.jsx
@@ -1,0 +1,97 @@
+import React, {useCallback, useContext} from 'react';
+import {Button} from '@mantine/core';
+import {useShallow} from 'zustand/react/shallow';
+import {PageTypes, SettingIds} from '@/constants';
+import formatMessage from '@/i18n/index';
+import useStorageState from '@/common/hooks/StorageState';
+import useIsOnOwnChannel from '@/common/hooks/IsOnOwnChannel';
+import {openSignInModal, openConfirmModal} from '@/common/utils/modal';
+import useAuthStore from '@/stores/auth';
+import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingStore';
+import {PageContext} from '@/modules/settings/contexts/PageContext';
+import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import SettingGroup from '@/modules/settings/components/SettingGroup';
+import SettingWrapper from '@/modules/settings/components/SettingWrapper';
+
+const SETTING_NAME = formatMessage({defaultMessage: 'Self Bot'});
+
+function openEnableSelfBotModal(setEnabled) {
+  openConfirmModal({
+    title: formatMessage({defaultMessage: 'Enable Self Bot'}),
+    description: formatMessage({
+      defaultMessage: 'This setting is only available on your own channel, are you sure you want to enable it?',
+    }),
+    onConfirm: () => setEnabled(true),
+    labels: {
+      confirm: formatMessage({defaultMessage: 'Enable'}),
+      cancel: formatMessage({defaultMessage: 'Cancel'}),
+    },
+    confirmProps: {color: 'red', size: 'lg', variant: 'elevated'},
+  });
+}
+
+function SelfBot(props, ref) {
+  const {setPage} = useContext(PageContext);
+  const isOnOwnChannel = useIsOnOwnChannel();
+  const [enabled, setEnabled] = useStorageState(SettingIds.SELF_BOT);
+  const bttvUser = useAuthStore(useShallow((state) => state.user));
+  const displayEnabled = bttvUser != null && enabled;
+
+  const handleEnabledChange = useCallback(
+    (newEnabled) => {
+      const {user} = useAuthStore.getState();
+
+      if (newEnabled && user == null) {
+        openSignInModal({}, () => handleEnabledChange(true));
+        return;
+      }
+
+      if (!enabled && newEnabled && !isOnOwnChannel) {
+        openEnableSelfBotModal(setEnabled);
+        return;
+      }
+
+      setEnabled(newEnabled);
+    },
+    [isOnOwnChannel, setEnabled, enabled]
+  );
+
+  return (
+    <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
+      <SettingSwitch
+        name={formatMessage({defaultMessage: 'Self Bot'})}
+        description={formatMessage({defaultMessage: 'Automatically send and reply to messages on your own channel.'})}
+        value={displayEnabled}
+        onChange={handleEnabledChange}
+      />
+      <SettingWrapper
+        name={formatMessage({defaultMessage: 'Commands'})}
+        reverse
+        showProBadge
+        description={formatMessage({defaultMessage: 'Configure command triggers and responses.'})}>
+        <Button size="lg" onClick={() => setPage(PageTypes.SELF_BOT_COMMANDS)}>
+          {formatMessage({defaultMessage: 'Edit'})}
+        </Button>
+      </SettingWrapper>
+      <SettingWrapper
+        name={formatMessage({defaultMessage: 'Timers'})}
+        reverse
+        showProBadge
+        showComingSoonBadge
+        description={formatMessage({defaultMessage: 'Automatically send messages at specific times.'})}>
+        <Button disabled size="lg">
+          {formatMessage({defaultMessage: 'Edit'})}
+        </Button>
+      </SettingWrapper>
+    </SettingGroup>
+  );
+}
+
+SettingStore.registerSetting(React.forwardRef(SelfBot), {
+  settingPanelId: SettingPanelIds.SELF_BOT,
+  name: SETTING_NAME,
+  supportsStandaloneWindow: true,
+  keywords: ['self', 'bot', 'commands', 'reply', 'automatic', 'timers'],
+});
+
+export default React.forwardRef(SelfBot);

--- a/src/modules/settings/stores/SettingStore.jsx
+++ b/src/modules/settings/stores/SettingStore.jsx
@@ -29,6 +29,7 @@ export const SettingPanelIds = {
   AUTO_PLAY: 'autoPlay',
   AUTO_CLAIM: 'autoClaim',
   CHATBOTS: 'chatbots',
+  SELF_BOT: 'selfBot',
 };
 
 class SettingStore {

--- a/src/modules/settings/stores/promotion-store.js
+++ b/src/modules/settings/stores/promotion-store.js
@@ -17,6 +17,11 @@ const PROMOTION_SLOTS = [
     isAvailable: () => !getProSettingValue(SettingIds.CHATBOT_COMMAND_AUTOCOMPLETE, false),
   },
   {
+    storageKey: SettingsPromotions.SELF_BOT,
+    settingId: SettingIds.SELF_BOT,
+    isAvailable: () => settings.get(SettingIds.SELF_BOT) !== true,
+  },
+  {
     storageKey: SettingsPromotions.THEME_CUSTOMIZE,
     settingId: SettingIds.PRIMARY_COLOR,
     isAvailable: () => getProSettingValue(SettingIds.PRIMARY_COLOR, null) == null,

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -21,6 +21,8 @@ export const EventNames = {
   SETTINGS_UPDATE: 'settings_update',
   AUTHENTICATION_UPDATE: 'authentication_update',
   USER_UPDATE: 'user_update',
+  SESSION_LOCK_UPDATE: 'session_lock_update',
+  SESSION_LOCK_RELEASED: 'session_lock_released',
 };
 
 const WEBSOCKET_ENDPOINT = SOCKET_ENDPOINT ?? 'wss://sockets.betterttv.net/ws';
@@ -32,6 +34,9 @@ let authenticated = false;
 let retryAuthenticationRequest = true;
 
 const joinedChannels = [];
+// session locks this client wants to hold, and the subset the server has granted us
+const desiredSessionLocks = new Set();
+const heldSessionLocks = new Set();
 
 function makeSocketChannel(provider, providerId) {
   return `${provider}:${providerId}`;
@@ -84,8 +89,16 @@ class SocketClient extends SafeEventEmitter {
 
     if (authenticated) {
       retryAuthenticationRequest = true;
+      // session locks live on the (possibly new) authenticated connection, so (re)claim any we want
+      heldSessionLocks.clear();
+      for (const key of desiredSessionLocks) {
+        this.send('acquire_session_lock', {key});
+      }
       return;
     }
+
+    // our locks are gone once we lose authentication
+    heldSessionLocks.clear();
 
     if (data.reason === 'invalid_token') {
       if (!retryAuthenticationRequest) {
@@ -153,13 +166,67 @@ class SocketClient extends SafeEventEmitter {
         handleUserUpdateEvent(evt.data);
       }
 
+      if (evt.name === EventNames.SESSION_LOCK_UPDATE) {
+        this.handleSessionLockUpdate(evt.data);
+      }
+
+      if (evt.name === EventNames.SESSION_LOCK_RELEASED) {
+        this.handleSessionLockReleased(evt.data);
+      }
+
       this.emit(evt.name, evt.data);
     };
+  }
+
+  // result of this session's own acquire/release request
+  handleSessionLockUpdate({key, acquired} = {}) {
+    if (key == null) {
+      return;
+    }
+
+    if (acquired) {
+      heldSessionLocks.add(key);
+    } else {
+      heldSessionLocks.delete(key);
+    }
+  }
+
+  // a holder (on any server) freed this lock; reclaim it if we want it and don't hold it
+  handleSessionLockReleased({key} = {}) {
+    if (key == null || heldSessionLocks.has(key) || !desiredSessionLocks.has(key)) {
+      return;
+    }
+
+    this.send('acquire_session_lock', {key});
+  }
+
+  acquireSessionLock(key) {
+    desiredSessionLocks.add(key);
+    this.send('acquire_session_lock', {key});
+  }
+
+  releaseSessionLock(key) {
+    // gate on desire, not held: an acquire may still be in flight (not yet granted),
+    // and releasing only on `held` would leak that lock on the server if the grant lands
+    // after we give up. the server ignores a release from a non-holder, so this is safe.
+    const wasDesired = desiredSessionLocks.delete(key);
+    heldSessionLocks.delete(key);
+
+    if (wasDesired) {
+      this.send('release_session_lock', {key});
+    }
+  }
+
+  hasSessionLock(key) {
+    return heldSessionLocks.has(key);
   }
 
   reconnect() {
     if (state === CONNECTION_STATES.CONNECTING) return;
     state = CONNECTION_STATES.DISCONNECTED;
+
+    // locks do not survive a dropped connection; we re-acquire after re-authenticating
+    heldSessionLocks.clear();
 
     if (socket) {
       try {

--- a/src/utils/chat-message-text.js
+++ b/src/utils/chat-message-text.js
@@ -1,0 +1,20 @@
+export function messageTextFromAST(ast) {
+  return ast
+    .map((node) => {
+      switch (node.type) {
+        case 0: // Text
+          return node.content.trim();
+        case 3: // CurrentUserHighlight
+          return `@${node.content}`;
+        case 4: // Mention
+          return `@${node.content.recipient}`;
+        case 5: // Link
+          return node.content.url;
+        case 6: // Emote
+          return node.content.alt;
+        default:
+          return '';
+      }
+    })
+    .join(' ');
+}

--- a/src/utils/keyword-regex.js
+++ b/src/utils/keyword-regex.js
@@ -1,0 +1,16 @@
+import isSafeRegex from 'safe-regex2';
+
+export const REGEX_KEYWORD_REGEX = /^~\/(.*)\/([a-z]+)?$/;
+
+export function extractRegex(keyword) {
+  const matches = REGEX_KEYWORD_REGEX.exec(keyword);
+  if (matches == null || !isSafeRegex(matches[1])) {
+    return null;
+  }
+
+  try {
+    return new RegExp(matches[1], matches[2]);
+  } catch (_) {}
+
+  return null;
+}

--- a/src/utils/twitch.js
+++ b/src/utils/twitch.js
@@ -494,10 +494,23 @@ export default {
     });
   },
 
-  sendChatMessage(message) {
+  sendChatMessage(message, {replyParentMessage} = {}) {
     const currentChat = this.getCurrentChat();
     if (!currentChat) return;
-    currentChat.props.onSendMessage(message);
+    if (replyParentMessage != null) {
+      currentChat.props.onSendMessage(message, {
+        reply: {
+          parentDeleted: replyParentMessage.deleted ?? false,
+          parentMsgId: replyParentMessage.id,
+          parentMessageBody: replyParentMessage.messageBody,
+          parentUid: replyParentMessage.user?.userID,
+          parentUserLogin: replyParentMessage.user?.userLogin,
+          parentDisplayName: replyParentMessage.user?.userDisplayName,
+        },
+      });
+    } else {
+      currentChat.props.onSendMessage(message);
+    }
   },
 
   getCurrentUserIsModerator() {

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -1,3 +1,5 @@
+import watcher from '@/watcher';
+
 let currentUser;
 
 export function setCurrentUser({provider, id, name, displayName, avatar}) {
@@ -8,6 +10,8 @@ export function setCurrentUser({provider, id, name, displayName, avatar}) {
     displayName,
     avatar,
   };
+
+  watcher.emit('user.updated', currentUser);
 }
 
 export function getCurrentUser() {


### PR DESCRIPTION
Adds a self-bot that automatically responds to chat messages on your own channel based on configurable commands.

## Features
- **Commands** — configurable list of triggers → responses, each with a user level (Everyone / VIP / Subscriber / Moderator)
- **Replies** — responses are sent as threaded replies to the message that triggered them
- **Single responder** — a distributed session lock ensures only one open BetterTTV session replies, avoiding duplicate responses across tabs/devices
- **Owner-only** — only runs on your own channel when enabled
- **Settings UI** — new Self Bot section under Twitch settings, plus a settings promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)