### PR TITLE
fix: stale autocomplete hover index when results re-filter

### DIFF
--- a/src/common/components/Autocomplete.jsx
+++ b/src/common/components/Autocomplete.jsx
@@ -60,13 +60,12 @@ function stopEvent(event) {
 
 const AutocompleteListRow = React.memo(function AutocompleteListRow({
   item,
-  index,
   renderRow,
   isSelected,
   isActive,
   focusedWordIndex,
   handleCompleteResultItem,
-  onHoverIndex,
+  onHover,
 }) {
   return renderRow({
     item,
@@ -74,7 +73,7 @@ const AutocompleteListRow = React.memo(function AutocompleteListRow({
     selected: isSelected,
     active: isActive,
     focusedWordIndex,
-    onMouseOver: () => onHoverIndex(index),
+    onMouseOver: () => onHover(item),
   });
 });
 
@@ -238,9 +237,14 @@ function Autocomplete({
     [handleCompleteResult, onComplete, handleClose]
   );
 
-  const onHoverIndex = useCallback(
-    (index) => {
+  const onHover = useCallback(
+    (item) => {
       if (navigationMode.current !== NavigationModeTypes.MOUSE) {
+        return;
+      }
+
+      const index = itemsRef.current.indexOf(item);
+      if (index === -1) {
         return;
       }
 
@@ -359,13 +363,12 @@ function Autocomplete({
           <AutocompleteListRow
             key={getItemKey(item)}
             item={item}
-            index={index}
             renderRow={renderRow}
             isSelected={selected === index}
             isActive={pendingCompleteIndex === index}
             focusedWordIndex={focusedWordIndex}
             handleCompleteResultItem={handleComplete}
-            onHoverIndex={onHoverIndex}
+            onHover={onHover}
           />
         ))}
       </Scrollbar>


### PR DESCRIPTION
## Problem

Hovering certain rows in the autocomplete menu doesn't highlight the row under the cursor — the highlight jumps to a different (wrong) row, or appears not to respond. It's intermittent and tied to typing.

## Root cause

The hover handler in `Autocomplete.jsx` captured the row **index**:

```js
onMouseOver: () => onHoverIndex(index)
```

But the row memo comparators (`EmoteRow`, `CommandRow`, `AutocompleteRow`) intentionally exclude `onMouseOver` from comparison. When typing re-filters the list, an item keeps its `key` but shifts position. The row's other compared props (item / selected / active) are unchanged, so it skips re-render — and the `<button>` keeps a **stale `onMouseOver` closure pointing at the old index**. Hovering then selects whatever row now sits at that old index.

`onClick` never had this bug because it already keys off the `item` object (`() => handleCompleteResultItem(item)`), which is stable across re-filters.

## Fix

Key hover off the `item` like `onClick` does, and resolve the live index at hover time via `itemsRef.current.indexOf(item)`. Item identity is stable, so the handler stays correct across re-filters without weakening the existing row memoization (no need to add `onMouseOver` to the comparators).

Single change in the shared `Autocomplete.jsx`, so it covers all consumers (Twitch + YouTube emote autocomplete, Twitch + YouTube command autocomplete).

## Testing

Built locally and verified hover highlights the correct row while the result list re-filters during typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)