### PR TITLE
chore: fix safe @eslint-react warnings (React 19 idioms)

### DIFF
--- a/src/common/components/Autocomplete.jsx
+++ b/src/common/components/Autocomplete.jsx
@@ -91,7 +91,7 @@ function Autocomplete({
   getCompletionLength = null,
   onAppendSpace = null,
 }) {
-  const navigationMode = useRef(NavigationModeTypes.ARROW_KEYS);
+  const navigationModeRef = useRef(NavigationModeTypes.ARROW_KEYS);
   const [partialInput, setPartialInput] = useState('');
   const [items, setItems] = useState([]);
   const [selected, setSelected] = useState(0);
@@ -100,16 +100,16 @@ function Autocomplete({
   const [opened, {open, close}] = useDisclosure(false);
   const chatInputElement = useDomObserver(chatInputQuerySelector);
   const itemsBodyRef = useRef(null);
-  const pendingComplete = useRef(false);
+  const pendingCompleteRef = useRef(false);
   const lastValueRef = useRef(null);
   const openedRef = useRef(false);
   const updateAutocompleteSuggestionsRef = useRef(null);
-  const updateAutocompleteSuggestionsRequestId = useRef(0);
+  const updateAutocompleteSuggestionsRequestIdRef = useRef(0);
   const [pendingCompleteIndex, setPendingCompleteIndex] = useState(null);
   const [focusedWordIndex, setFocusedWordIndex] = useState(0);
 
   const handleMouseMove = useCallback(() => {
-    navigationMode.current = NavigationModeTypes.MOUSE;
+    navigationModeRef.current = NavigationModeTypes.MOUSE;
   }, []);
 
   const handleSelectedChange = useCallback((newSelected, forceScroll = false) => {
@@ -117,7 +117,7 @@ function Autocomplete({
 
     selectedRef.current = newSelected;
 
-    if (navigationMode.current === NavigationModeTypes.MOUSE && !forceScroll) {
+    if (navigationModeRef.current === NavigationModeTypes.MOUSE && !forceScroll) {
       return;
     }
 
@@ -143,7 +143,7 @@ function Autocomplete({
   const handleOpen = useCallback(() => {
     open();
     openedRef.current = true;
-    navigationMode.current = NavigationModeTypes.ARROW_KEYS;
+    navigationModeRef.current = NavigationModeTypes.ARROW_KEYS;
   }, [open]);
 
   const updateAutocompleteSuggestions = useCallback(
@@ -163,7 +163,7 @@ function Autocomplete({
 
       lastValueRef.current = value;
 
-      const requestId = ++updateAutocompleteSuggestionsRequestId.current;
+      const requestId = ++updateAutocompleteSuggestionsRequestIdRef.current;
 
       if (value == null) {
         itemsRef.current = [];
@@ -173,7 +173,7 @@ function Autocomplete({
         itemsRef.current = (await computeItems(value)).slice(0, MAX_ITEMS_SHOWN);
       }
 
-      if (requestId !== updateAutocompleteSuggestionsRequestId.current) {
+      if (requestId !== updateAutocompleteSuggestionsRequestIdRef.current) {
         return;
       }
 
@@ -238,7 +238,7 @@ function Autocomplete({
 
   const onHover = useCallback(
     (item) => {
-      if (navigationMode.current !== NavigationModeTypes.MOUSE) {
+      if (navigationModeRef.current !== NavigationModeTypes.MOUSE) {
         return;
       }
 
@@ -260,12 +260,12 @@ function Autocomplete({
     let pendingPromise = null;
 
     async function keyupCallback() {
-      if (!pendingComplete.current) {
+      if (!pendingCompleteRef.current) {
         pendingPromise = await updateAutocompleteSuggestionsRef.current();
         return;
       }
 
-      pendingComplete.current = false;
+      pendingCompleteRef.current = false;
       setPendingCompleteIndex(null);
       handleComplete(itemsRef.current[selectedRef.current]);
     }
@@ -279,7 +279,7 @@ function Autocomplete({
         return;
       }
 
-      navigationMode.current = NavigationModeTypes.ARROW_KEYS;
+      navigationModeRef.current = NavigationModeTypes.ARROW_KEYS;
 
       switch (event.key) {
         case keyCodes.Enter:
@@ -305,7 +305,7 @@ function Autocomplete({
           }
 
           stopEvent(event);
-          pendingComplete.current = true;
+          pendingCompleteRef.current = true;
           setPendingCompleteIndex(selectedRef.current);
           break;
         }

--- a/src/common/components/Scrollbar.jsx
+++ b/src/common/components/Scrollbar.jsx
@@ -1,12 +1,12 @@
 import {useMergedRef} from '@mantine/hooks';
 import classNames from 'classnames';
-import React, {forwardRef, useContext, useEffect, useRef} from 'react';
+import React, {forwardRef, use, useEffect, useRef} from 'react';
 import styles from '@/common/styles/Scrollbar.module.css';
 
 export const ScrollbarSizeTargetContext = React.createContext(null);
 
 export function useScrollbarSize(scrollRef, {mirrorPadding = false, className} = {}) {
-  const sizeTargetRef = useContext(ScrollbarSizeTargetContext);
+  const sizeTargetRef = use(ScrollbarSizeTargetContext);
 
   useEffect(() => {
     const el = scrollRef.current;

--- a/src/common/hooks/PortalRef.jsx
+++ b/src/common/hooks/PortalRef.jsx
@@ -1,8 +1,8 @@
-import {useContext, useEffect, useState} from 'react';
+import {use, useEffect, useState} from 'react';
 import {PortalContext} from '@/common/contexts/PortalContext';
 
 function usePortalRef() {
-  const portalRef = useContext(PortalContext);
+  const portalRef = use(PortalContext);
   const [ref, setRef] = useState(portalRef);
 
   useEffect(() => {

--- a/src/modules/emote_menu/components/EmoteMenu.jsx
+++ b/src/modules/emote_menu/components/EmoteMenu.jsx
@@ -45,8 +45,8 @@ function EmoteMenu({
   const handleRef = useRef(null);
   const emoteMenuContentRef = useRef(null);
   const [selected, setSelected] = useState(null);
-  const altPressed = useRef(false);
-  const shiftPressed = useRef(false);
+  const altPressedRef = useRef(false);
+  const shiftPressedRef = useRef(false);
   const [section, setSection] = useState(null);
   const [opened, {close, open}] = useDisclosure(false);
   const width = useHorizontalResize({boundingQuerySelector, handleRef, open: opened, placement});
@@ -212,7 +212,7 @@ function EmoteMenu({
   }, [handleClose]);
 
   const handleClick = useCallback((emote) => {
-    if (altPressed.current) {
+    if (altPressedRef.current) {
       emoteMenuViewStore.toggleFavorite(emote);
       markTipAsSeen(EmoteMenuTips.EMOTE_MENU_FAVORITE_EMOTE);
       return;
@@ -222,10 +222,10 @@ function EmoteMenu({
       return;
     }
 
-    appendToChat(emote, !shiftPressed.current);
+    appendToChat(emote, !shiftPressedRef.current);
     emoteMenuViewStore.trackHistory(emote);
 
-    if (shiftPressed.current) {
+    if (shiftPressedRef.current) {
       markTipAsSeen(EmoteMenuTips.EMOTE_MENU_PREVENT_CLOSE);
       return;
     }
@@ -234,8 +234,8 @@ function EmoteMenu({
   }, []);
 
   const handleKeyEvent = useCallback((event) => {
-    altPressed.current = event.altKey;
-    shiftPressed.current = event.shiftKey;
+    altPressedRef.current = event.altKey;
+    shiftPressedRef.current = event.shiftKey;
   }, []);
 
   const {onKeyDown, ...restProps} = getFloatingProps();
@@ -256,7 +256,7 @@ function EmoteMenu({
         return;
       }
 
-      keyPressCallback(event, shiftPressed.current);
+      keyPressCallback(event, shiftPressedRef.current);
     },
     [handleClick, keyPressCallback, selected]
   );
@@ -302,7 +302,7 @@ function EmoteMenu({
       onKeyDown={handleKeyDown}
       onKeyUp={handleKeyEvent}
       {...restProps}>
-      <ScrollbarSizeTargetContext.Provider value={emoteMenuContentRef}>
+      <ScrollbarSizeTargetContext value={emoteMenuContentRef}>
         <div ref={emoteMenuContentRef} className={styles.emoteMenuContent}>
           <div
             ref={handleRef}
@@ -341,7 +341,7 @@ function EmoteMenu({
             setCoords={handleCoordsChange}
           />
         </div>
-      </ScrollbarSizeTargetContext.Provider>
+      </ScrollbarSizeTargetContext>
       {opened ? <Tip className={styles.tip} onClose={handleClose} /> : null}
     </div>
   );

--- a/src/modules/emote_menu/components/Sidebar.jsx
+++ b/src/modules/emote_menu/components/Sidebar.jsx
@@ -28,7 +28,7 @@ function Sidebar({section, onClick, categories, className}) {
   const containerRef = useRef(null);
   const [hovering, setHovering] = useState(false);
   const [emojiButtonHidden, setEmojiButtonHidden] = useState(false);
-  const hoverEmojiCount = useRef(0);
+  const hoverEmojiCountRef = useRef(0);
   const middleCategories = categories.middle;
 
   const bottomDepth = useMemo(
@@ -107,9 +107,9 @@ function Sidebar({section, onClick, categories, className}) {
     let code = DEFAULT_EMOJI;
 
     if (hovering) {
-      const count = hoverEmojiCount.current;
+      const count = hoverEmojiCountRef.current;
       code = HOVER_EMOJI[count % HOVER_EMOJI.length];
-      hoverEmojiCount.current = count + 1;
+      hoverEmojiCountRef.current = count + 1;
     }
 
     return emojis.getEligibleEmote(code);

--- a/src/modules/emote_menu/components/VirtualizedList.jsx
+++ b/src/modules/emote_menu/components/VirtualizedList.jsx
@@ -23,7 +23,7 @@ function VirtualizedList(
   const wrapperRef = useRef(null);
   const {ref: sizeRef, height: windowHeight} = useElementSize(null);
   const mergedRef = useMergedRef(forwardedRef, sizeRef, wrapperRef);
-  const headerIndex = useRef(null);
+  const headerIndexRef = useRef(null);
   useScrollbarSize(wrapperRef);
 
   const listHeight = useMemo(
@@ -76,7 +76,7 @@ function VirtualizedList(
         top = (startIndex - 1) * rowHeight;
       }
 
-      return {rows: rowsVisible, top, headerIndex: stickyRowIndex};
+      return {rows: rowsVisible, top, headerIndexRef: stickyRowIndex};
     },
     [totalRows, rowHeight, windowHeight, stickyRows, overscanCount, onHeaderChange]
   );
@@ -87,14 +87,14 @@ function VirtualizedList(
     const currentWrapperRef = wrapperRef.current;
     const scrollTop = currentWrapperRef?.scrollTop ?? 0;
 
-    const {rows, top, headerIndex: newHeaderIndex} = handleViewportUpdate(scrollTop);
+    const {rows, top, headerIndexRef: newHeaderIndex} = handleViewportUpdate(scrollTop);
 
-    if (headerIndex.current != null && headerIndex.current !== newHeaderIndex) {
+    if (headerIndexRef.current != null && headerIndexRef.current !== newHeaderIndex) {
       onHeaderChange(newHeaderIndex);
     }
 
-    headerIndex.current = newHeaderIndex;
-    setData({rows, top, headerIndex: newHeaderIndex});
+    headerIndexRef.current = newHeaderIndex;
+    setData({rows, top, headerIndexRef: newHeaderIndex});
   }, [handleViewportUpdate, onHeaderChange]);
 
   useEffect(() => {

--- a/src/modules/settings/components/PageHeader.jsx
+++ b/src/modules/settings/components/PageHeader.jsx
@@ -1,7 +1,7 @@
 import {faBars} from '@fortawesome/free-solid-svg-icons';
 import {ActionIcon, Avatar, CloseButton, Title} from '@mantine/core';
 import classNames from 'classnames';
-import React, {useContext} from 'react';
+import React, {use} from 'react';
 import {useShallow} from 'zustand/react/shallow';
 import Icon from '@/common/components/Icon';
 import {PageContext} from '@/modules/settings/contexts/PageContext';
@@ -9,7 +9,7 @@ import useAuthStore from '@/stores/auth';
 import styles from './PageHeader.module.css';
 
 const PageHeader = React.forwardRef(({className, leftContent, onClose}, ref) => {
-  const {setSidenavOpen} = useContext(PageContext);
+  const {setSidenavOpen} = use(PageContext);
   const currentUser = useAuthStore(useShallow((state) => state.user));
   return (
     <div ref={ref} className={classNames(styles.header, className)}>

--- a/src/modules/settings/components/PageScrollBody.jsx
+++ b/src/modules/settings/components/PageScrollBody.jsx
@@ -1,12 +1,12 @@
 import classNames from 'classnames';
-import React, {useContext} from 'react';
+import React, {use} from 'react';
 import Scrollbar from '@/common/components/Scrollbar';
 import styles from './SettingsModal.module.css';
 
 export const PageScrollContext = React.createContext(null);
 
 export function PageScrollBody({children, className, ...props}) {
-  const ref = useContext(PageScrollContext);
+  const ref = use(PageScrollContext);
   return (
     <Scrollbar ref={ref} mirrorPadding className={classNames(styles.pageScrollBody, className)} {...props}>
       {children}

--- a/src/modules/settings/components/Promotion.jsx
+++ b/src/modules/settings/components/Promotion.jsx
@@ -1,7 +1,7 @@
 import {faClose, faPaintBrush, faRobot} from '@fortawesome/free-solid-svg-icons';
 import {ActionIcon, Button, Image, Title} from '@mantine/core';
 import classNames from 'classnames';
-import React, {useContext, useState} from 'react';
+import React, {use, useState} from 'react';
 import AnimatedCanvas from '@/common/components/AnimatedCanvas';
 import Icon from '@/common/components/Icon';
 import NightbotLogoIcon from '@/common/components/NightbotLogoIcon';
@@ -54,7 +54,7 @@ function getPromotionToDisplay() {
 }
 
 function Promotion() {
-  const {handleGotoSettingPanel} = useContext(PageContext);
+  const {handleGotoSettingPanel} = use(PageContext);
   const [activePromotion, setActivePromotion] = useState(getPromotionToDisplay);
 
   if (activePromotion == null) {

--- a/src/modules/settings/components/SettingsModal.jsx
+++ b/src/modules/settings/components/SettingsModal.jsx
@@ -97,7 +97,7 @@ const pageMotionVariants = {
   },
 };
 
-function PageTransition({children, className, computeDefaultScrollTop, scrollRef, pendingScrollToSettingPanelId}) {
+function PageTransition({children, className, computeDefaultScrollTop, scrollRef, pendingScrollToSettingPanelIdRef}) {
   const direction = usePresenceData();
   const {initial, exit} = pageMotionVariants[direction];
 
@@ -107,11 +107,11 @@ function PageTransition({children, className, computeDefaultScrollTop, scrollRef
     }
 
     scrollRef.current.scrollTop = computeDefaultScrollTop();
-    pendingScrollToSettingPanelId.current = null;
+    pendingScrollToSettingPanelIdRef.current = null;
   }, []);
 
   return (
-    <PageScrollContext.Provider value={scrollRef}>
+    <PageScrollContext value={scrollRef}>
       <motion.div
         variants={pageMotionVariants}
         initial={initial}
@@ -120,7 +120,7 @@ function PageTransition({children, className, computeDefaultScrollTop, scrollRef
         className={className}>
         {children}
       </motion.div>
-    </PageScrollContext.Provider>
+    </PageScrollContext>
   );
 }
 
@@ -149,18 +149,18 @@ function SettingsModal({setHandleOpen}) {
   const [open, modalHandlers] = useDisclosure(false);
   const [sidenavOpen, setSidenavOpen] = useState(false);
   const [search, setSearch] = useState('');
-  const settingRefs = useRef({});
-  const pendingScrollToSettingPanelId = useRef(null);
+  const settingRefsRef = useRef({});
+  const pendingScrollToSettingPanelIdRef = useRef(null);
   const [pageTransitionDirection, setPageTransitionDirection] = useState(PageTransitionDirection.RIGHT);
   const pageContentRef = useRef(null);
   const pageColumnRef = useRef(null);
-  const lastParentData = useRef({scrollTop: 0, page: null});
+  const lastParentDataRef = useRef({scrollTop: 0, page: null});
   const inputRef = useFocusTrap(isInteractive && page === PageTypes.SETTINGS);
 
   function handlePageChange(newPage) {
-    if (lastParentData.current.page !== newPage) {
-      lastParentData.current.scrollTop = 0;
-      lastParentData.current.page = null;
+    if (lastParentDataRef.current.page !== newPage) {
+      lastParentDataRef.current.scrollTop = 0;
+      lastParentDataRef.current.page = null;
     }
 
     let newDirection = PageTransitionDirection.UP;
@@ -175,8 +175,8 @@ function SettingsModal({setHandleOpen}) {
     if (currentPageDecendants != null && currentPageDecendants.includes(newPage)) {
       newDirection = PageTransitionDirection.LEFT;
 
-      lastParentData.current.page = page;
-      lastParentData.current.scrollTop = pageContentRef.current.scrollTop;
+      lastParentDataRef.current.page = page;
+      lastParentDataRef.current.scrollTop = pageContentRef.current.scrollTop;
     }
 
     if (newPageDecendants != null && newPageDecendants.includes(page)) {
@@ -188,7 +188,7 @@ function SettingsModal({setHandleOpen}) {
   }
 
   function handleSettingRefCallback(settingPanelId, ref) {
-    settingRefs.current[settingPanelId] = ref;
+    settingRefsRef.current[settingPanelId] = ref;
   }
 
   function handleGotoSettingPanel(settingPanelId) {
@@ -196,14 +196,14 @@ function SettingsModal({setHandleOpen}) {
       return;
     }
 
-    if (settingPanelId != null && settingRefs.current[settingPanelId] != null) {
-      const setting = settingRefs.current[settingPanelId];
+    if (settingPanelId != null && settingRefsRef.current[settingPanelId] != null) {
+      const setting = settingRefsRef.current[settingPanelId];
       setting.scrollIntoView();
       return;
     }
 
     handlePageChange(PageTypes.SETTINGS);
-    pendingScrollToSettingPanelId.current = settingPanelId;
+    pendingScrollToSettingPanelIdRef.current = settingPanelId;
   }
 
   useEffect(() => {
@@ -285,18 +285,18 @@ function SettingsModal({setHandleOpen}) {
   const computeDefaultScrollTop = useCallback(() => {
     if (
       page === PageTypes.SETTINGS &&
-      pendingScrollToSettingPanelId.current != null &&
-      settingRefs.current[pendingScrollToSettingPanelId.current] != null
+      pendingScrollToSettingPanelIdRef.current != null &&
+      settingRefsRef.current[pendingScrollToSettingPanelIdRef.current] != null
     ) {
-      const setting = settingRefs.current[pendingScrollToSettingPanelId.current];
+      const setting = settingRefsRef.current[pendingScrollToSettingPanelIdRef.current];
       return setting.offsetTop;
     }
 
-    if (lastParentData.current.page !== page) {
+    if (lastParentDataRef.current.page !== page) {
       return 0;
     }
 
-    return lastParentData.current.scrollTop;
+    return lastParentDataRef.current.scrollTop;
   }, [page]);
 
   return (
@@ -321,10 +321,9 @@ function SettingsModal({setHandleOpen}) {
       classNames={{content: styles.modal, body: styles.modalBody}}
       transitionProps={{transition: 'pop', duration: 100}}
       onClose={modalHandlers.close}>
-      <PageContext.Provider
-        value={{page, setPage: handlePageChange, sidenavOpen, setSidenavOpen, handleGotoSettingPanel}}>
+      <PageContext value={{page, setPage: handlePageChange, sidenavOpen, setSidenavOpen, handleGotoSettingPanel}}>
         <SideNavigation open={sidenavOpen} setOpen={setSidenavOpen} />
-        <ScrollbarSizeTargetContext.Provider value={pageColumnRef}>
+        <ScrollbarSizeTargetContext value={pageColumnRef}>
           <div className={styles.pageColumn} ref={pageColumnRef}>
             <PageHeader
               leftContent={
@@ -340,15 +339,15 @@ function SettingsModal({setHandleOpen}) {
               <PageTransition
                 scrollRef={pageContentRef}
                 key={page}
-                pendingScrollToSettingPanelId={pendingScrollToSettingPanelId}
+                pendingScrollToSettingPanelIdRef={pendingScrollToSettingPanelIdRef}
                 className={styles.pageContent}
                 computeDefaultScrollTop={computeDefaultScrollTop}>
                 <Page page={page} search={search} handleSettingRefCallback={handleSettingRefCallback} />
               </PageTransition>
             </AnimatePresence>
           </div>
-        </ScrollbarSizeTargetContext.Provider>
-      </PageContext.Provider>
+        </ScrollbarSizeTargetContext>
+      </PageContext>
     </Modal>
   );
 }

--- a/src/modules/settings/components/SideNavigation.jsx
+++ b/src/modules/settings/components/SideNavigation.jsx
@@ -1,7 +1,7 @@
 import {faArrowLeft, faCog, faScroll, faUser, faUserGear} from '@fortawesome/free-solid-svg-icons';
 import {ActionIcon, Avatar, Button, Overlay, Tooltip, useMantineTheme} from '@mantine/core';
 import classNames from 'classnames';
-import React, {useCallback, useContext} from 'react';
+import React, {useCallback, use} from 'react';
 import {useShallow} from 'zustand/react/shallow';
 import Icon from '@/common/components/Icon';
 import usePortalRef from '@/common/hooks/PortalRef';
@@ -99,7 +99,7 @@ function UserSettingsNavigationButton({active, ...props}) {
 }
 
 function SideNavigation({open, setOpen}) {
-  const {page, setPage} = useContext(PageContext);
+  const {page, setPage} = use(PageContext);
   const close = useCallback(() => setOpen(false), [setOpen]);
 
   return (

--- a/src/modules/settings/settings/twitch/BlacklistKeywords.jsx
+++ b/src/modules/settings/settings/twitch/BlacklistKeywords.jsx
@@ -1,5 +1,5 @@
 import {Button} from '@mantine/core';
-import React, {useContext} from 'react';
+import React, {use} from 'react';
 import {PageTypes, SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
@@ -10,7 +10,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 const SETTING_NAME = formatMessage({defaultMessage: 'Blacklist Keywords'});
 
 function BlacklistKeywords(props, ref) {
-  const {setPage} = useContext(PageContext);
+  const {setPage} = use(PageContext);
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>

--- a/src/modules/settings/settings/twitch/Highlights.jsx
+++ b/src/modules/settings/settings/twitch/Highlights.jsx
@@ -1,5 +1,5 @@
 import {Button} from '@mantine/core';
-import React, {useContext} from 'react';
+import React, {use} from 'react';
 import useStorageState from '@/common/hooks/StorageState';
 import {DeletedMessageTypes, PageTypes, SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
@@ -13,7 +13,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 const SETTING_NAME = formatMessage({defaultMessage: 'Highlights'});
 
 function Highlights(props, ref) {
-  const {setPage} = useContext(PageContext);
+  const {setPage} = use(PageContext);
   const [value, setValue] = useStorageState(SettingIds.PINNED_HIGHLIGHTS);
   const [deletedMessages, setDeletedMessages] = useStorageState(SettingIds.DELETED_MESSAGES);
   const [maxPinnedHighlights, setMaxPinnedHighlights] = useStorageState(SettingIds.MAX_PINNED_HIGHLIGHTS);

--- a/src/modules/settings/settings/twitch/SelfBot.jsx
+++ b/src/modules/settings/settings/twitch/SelfBot.jsx
@@ -1,5 +1,5 @@
 import {Button} from '@mantine/core';
-import React, {useCallback, useContext} from 'react';
+import React, {useCallback, use} from 'react';
 import {useShallow} from 'zustand/react/shallow';
 import useIsOnOwnChannel from '@/common/hooks/IsOnOwnChannel';
 import useStorageState from '@/common/hooks/StorageState';
@@ -31,7 +31,7 @@ function openEnableSelfBotModal(setEnabled) {
 }
 
 function SelfBot(props, ref) {
-  const {setPage} = useContext(PageContext);
+  const {setPage} = use(PageContext);
   const isOnOwnChannel = useIsOnOwnChannel();
   const [enabled, setEnabled] = useStorageState(SettingIds.SELF_BOT);
   const bttvUser = useAuthStore(useShallow((state) => state.user));

--- a/src/modules/shadow_dom/ThemeProvider.jsx
+++ b/src/modules/shadow_dom/ThemeProvider.jsx
@@ -212,7 +212,7 @@ function ThemeProvider({children, ...props}) {
   }, [normalizedPrimaryColor]);
 
   return (
-    <PortalContext.Provider value={portalRef}>
+    <PortalContext value={portalRef}>
       <MantineProvider
         forceColorScheme={dark ? 'dark' : 'light'}
         classNamesPrefix="bttv-mantine-"
@@ -233,7 +233,7 @@ function ThemeProvider({children, ...props}) {
           </ModalsProvider>
         ) : null}
       </MantineProvider>
-    </PortalContext.Provider>
+    </PortalContext>
   );
 }
 


### PR DESCRIPTION
Follow-up to #8104, which enabled `.jsx` linting and surfaced 134 `@eslint-react` warnings. This PR clears the **safe, behavior-preserving** subset (24 warnings, 134 → 110):

| Rule | Count | Change |
|------|-------|--------|
| `no-use-context` | 9 | `useContext(X)` → `use(X)` |
| `no-context-provider` | 5 | `<Context.Provider>` → `<Context>` |
| `naming-convention-ref-name` | 10 | ref variables renamed to end in `Ref` |

All three are mechanical React 19 idiom updates / renames with no runtime behavior change. Verified: `eslint .` 0 errors, `prettier --check` clean, production build succeeds.

### Deliberately left as follow-ups
These need per-case review and carry real risk, so they're out of scope here:
- `no-forward-ref` (70) — React 19 `forwardRef` → ref-as-prop migration; rewrites component signatures.
- `exhaustive-deps` (24) — adding effect deps can introduce re-render loops / change timing.
- `set-state-in-effect` (7), `use-state` (4), `purity` (2), `no-array-index-key` (2), `web-api-no-leaked-timeout` (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)