### PR TITLE
chore: migrate forwardRef to ref-as-prop (React 19)

### DIFF
--- a/src/modules/emote_menu/components/Preview.jsx
+++ b/src/modules/emote_menu/components/Preview.jsx
@@ -7,7 +7,7 @@ import formatMessage from '@/i18n/index';
 import Icons from './Icons';
 import styles from './Preview.module.css';
 
-const Preview = React.forwardRef(({className, emote}, ref) => {
+const Preview = ({className, emote, ref}) => {
   if (emote == null) return null;
 
   let icon = null;
@@ -31,6 +31,6 @@ const Preview = React.forwardRef(({className, emote}, ref) => {
       <div className={styles.emoteStatusIcon}>{icon}</div>
     </div>
   );
-});
+};
 
 export default Preview;

--- a/src/modules/settings/components/PageHeader.jsx
+++ b/src/modules/settings/components/PageHeader.jsx
@@ -8,7 +8,7 @@ import {PageContext} from '@/modules/settings/contexts/PageContext';
 import useAuthStore from '@/stores/auth';
 import styles from './PageHeader.module.css';
 
-const PageHeader = React.forwardRef(({className, leftContent, onClose}, ref) => {
+const PageHeader = ({className, leftContent, onClose, ref}) => {
   const {setSidenavOpen} = use(PageContext);
   const currentUser = useAuthStore(useShallow((state) => state.user));
   return (
@@ -29,6 +29,6 @@ const PageHeader = React.forwardRef(({className, leftContent, onClose}, ref) => 
       <CloseButton className={styles.closeButton} radius="lg" variant="subtle" size="md" onClick={onClose} />
     </div>
   );
-});
+};
 
 export default PageHeader;

--- a/src/modules/settings/components/Panel.jsx
+++ b/src/modules/settings/components/Panel.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import React from 'react';
 import styles from './Panel.module.css';
 
-function Panel({title, rightContent, children, className, containerClassName, style, ...restProps}, ref) {
+function Panel({title, rightContent, children, className, containerClassName, style, ref, ...restProps}) {
   const hasHeader = title != null || rightContent != null;
 
   return (
@@ -21,4 +21,4 @@ function Panel({title, rightContent, children, className, containerClassName, st
   );
 }
 
-export default React.forwardRef(Panel);
+export default Panel;

--- a/src/modules/settings/components/SettingCheckboxGroup.jsx
+++ b/src/modules/settings/components/SettingCheckboxGroup.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {hasFlag} from '@/utils/flags';
 import SettingGroup from './SettingGroup';
 
-function SettingCheckboxGroup({name, value, onChange, flags, disabled, children}, ref) {
+function SettingCheckboxGroup({name, value, onChange, flags, disabled, children, ref}) {
   const groupValue = flags.filter((flag) => hasFlag(value, flag)).map(String);
 
   function handleChange(stringArray) {
@@ -20,4 +20,4 @@ function SettingCheckboxGroup({name, value, onChange, flags, disabled, children}
   );
 }
 
-export default React.forwardRef(SettingCheckboxGroup);
+export default SettingCheckboxGroup;

--- a/src/modules/settings/components/SettingGroup.jsx
+++ b/src/modules/settings/components/SettingGroup.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Panel from './Panel';
 import styles from './SettingGroup.module.css';
 
-function SettingGroup({children, name, rightContent, className, ...restProps}, ref) {
+function SettingGroup({children, name, rightContent, className, ref, ...restProps}) {
   return (
     <Panel
       ref={ref}
@@ -17,4 +17,4 @@ function SettingGroup({children, name, rightContent, className, ...restProps}, r
   );
 }
 
-export default React.forwardRef(SettingGroup);
+export default SettingGroup;

--- a/src/modules/settings/components/SettingRadioGroup.jsx
+++ b/src/modules/settings/components/SettingRadioGroup.jsx
@@ -2,7 +2,7 @@ import {RadioGroup} from '@mantine/core';
 import React from 'react';
 import SettingGroup from './SettingGroup';
 
-function SettingRadioGroup({name, value, onChange, disabled, children}, ref) {
+function SettingRadioGroup({name, value, onChange, disabled, children, ref}) {
   const groupValue = value != null ? String(value) : null;
 
   function handleChange(stringVal) {
@@ -19,4 +19,4 @@ function SettingRadioGroup({name, value, onChange, disabled, children}, ref) {
   );
 }
 
-export default React.forwardRef(SettingRadioGroup);
+export default SettingRadioGroup;

--- a/src/modules/settings/settings/global/ChatBots.jsx
+++ b/src/modules/settings/settings/global/ChatBots.jsx
@@ -9,7 +9,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Chat Bots'});
 
-function ChatBots(props, ref) {
+function ChatBots({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.CHATBOT_COMMAND_AUTOCOMPLETE);
   const [normalizedValue, setNormalizedValue] = useProRequiredState({
     value,
@@ -35,11 +35,11 @@ function ChatBots(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(ChatBots), {
+SettingStore.registerSetting(ChatBots, {
   settingPanelId: SettingPanelIds.CHATBOTS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['command', 'autocomplete', 'nightbot', 'fossabot', 'moobot', 'streamelements', 'commands', 'chat', 'bot'],
 });
 
-export default React.forwardRef(ChatBots);
+export default ChatBots;

--- a/src/modules/settings/settings/global/Emotes.jsx
+++ b/src/modules/settings/settings/global/Emotes.jsx
@@ -72,7 +72,7 @@ function openEmoteModifiersModal() {
   });
 }
 
-function EmotesModule(props, ref) {
+function EmotesModule({ref, ...props}) {
   const [emotes, setEmotes] = useStorageState(SettingIds.EMOTES);
 
   function handleEmoteModifiersChange(newFlags) {
@@ -166,11 +166,11 @@ function EmotesModule(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(EmotesModule), {
+SettingStore.registerSetting(EmotesModule, {
   settingPanelId: SettingPanelIds.EMOTES,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['bttv', 'ffz', '7tv', 'betterttv', 'frankerfacez', 'animated', 'gif', 'images', 'emotes'],
 });
 
-export default React.forwardRef(EmotesModule);
+export default EmotesModule;

--- a/src/modules/settings/settings/twitch/AnonChat.jsx
+++ b/src/modules/settings/settings/twitch/AnonChat.jsx
@@ -9,7 +9,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Anon Chat'});
 
-function AnonChat(props, ref) {
+function AnonChat({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.ANON_CHAT);
   const [channels, setChannels] = useStorageState(
     value ? SettingIds.ANON_CHAT_WHITELISTED_CHANNELS : SettingIds.ANON_CHAT_BLACKLISTED_CHANNELS
@@ -43,11 +43,11 @@ function AnonChat(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(AnonChat), {
+SettingStore.registerSetting(AnonChat, {
   settingPanelId: SettingPanelIds.ANON_CHAT,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['anon', 'chat'],
 });
 
-export default React.forwardRef(AnonChat);
+export default AnonChat;

--- a/src/modules/settings/settings/twitch/AutoClaim.jsx
+++ b/src/modules/settings/settings/twitch/AutoClaim.jsx
@@ -9,7 +9,7 @@ import {hasFlag, setFlag} from '@/utils/flags';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Auto Claim'});
 
-function AutoClaim(props, ref) {
+function AutoClaim({ref, ...props}) {
   const [autoClaim, setAutoClaim] = useStorageState(SettingIds.AUTO_CLAIM);
   const [channelPoints, setChannelPoints] = useStorageState(SettingIds.CHANNEL_POINTS);
 
@@ -35,11 +35,11 @@ function AutoClaim(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(AutoClaim), {
+SettingStore.registerSetting(AutoClaim, {
   settingPanelId: SettingPanelIds.AUTO_CLAIM,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['auto', 'claim', 'drops', 'moments', 'points'],
 });
 
-export default React.forwardRef(AutoClaim);
+export default AutoClaim;

--- a/src/modules/settings/settings/twitch/AutoPlay.jsx
+++ b/src/modules/settings/settings/twitch/AutoPlay.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Auto Play'});
 
-function AutoplayModule(props, ref) {
+function AutoplayModule({ref, ...props}) {
   const [autoplay, setAutoplay] = useStorageState(SettingIds.AUTO_PLAY);
 
   return (
@@ -42,10 +42,10 @@ function AutoplayModule(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(AutoplayModule), {
+SettingStore.registerSetting(AutoplayModule, {
   settingPanelId: SettingPanelIds.AUTO_PLAY,
   name: SETTING_NAME,
   keywords: ['auto', 'play'],
 });
 
-export default React.forwardRef(AutoplayModule);
+export default AutoplayModule;

--- a/src/modules/settings/settings/twitch/BlacklistKeywords.jsx
+++ b/src/modules/settings/settings/twitch/BlacklistKeywords.jsx
@@ -9,7 +9,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Blacklist Keywords'});
 
-function BlacklistKeywords(props, ref) {
+function BlacklistKeywords({ref, ...props}) {
   const {setPage} = use(PageContext);
 
   return (
@@ -26,11 +26,11 @@ function BlacklistKeywords(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(BlacklistKeywords), {
+SettingStore.registerSetting(BlacklistKeywords, {
   settingPanelId: SettingPanelIds.BLACKLIST_KEYWORDS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['black', 'list', 'keywords', 'banned', 'remove', 'hide'],
 });
 
-export default React.forwardRef(BlacklistKeywords);
+export default BlacklistKeywords;

--- a/src/modules/settings/settings/twitch/ChannelPoints.jsx
+++ b/src/modules/settings/settings/twitch/ChannelPoints.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Channel Points'});
 
-function ChannelPointsModule(props, ref) {
+function ChannelPointsModule({ref, ...props}) {
   const [channelPoints, setChannelPoints] = useStorageState(SettingIds.CHANNEL_POINTS);
 
   return (
@@ -40,11 +40,11 @@ function ChannelPointsModule(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(ChannelPointsModule), {
+SettingStore.registerSetting(ChannelPointsModule, {
   settingPanelId: SettingPanelIds.CHANNEL_POINTS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['channel', 'points', 'auto', 'claim'],
 });
 
-export default React.forwardRef(ChannelPointsModule);
+export default ChannelPointsModule;

--- a/src/modules/settings/settings/twitch/Chat.jsx
+++ b/src/modules/settings/settings/twitch/Chat.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Chat'});
 
-function ChatModule(props, ref) {
+function ChatModule({ref, ...props}) {
   const [chat, setChat] = useStorageState(SettingIds.CHAT);
 
   return (
@@ -64,11 +64,11 @@ function ChatModule(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(ChatModule), {
+SettingStore.registerSetting(ChatModule, {
   settingPanelId: SettingPanelIds.CHAT,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['bits', 'highlights', 'community', 'chat', 'replies', 'clips', 'subs', 'subscriptions'],
 });
 
-export default React.forwardRef(ChatModule);
+export default ChatModule;

--- a/src/modules/settings/settings/twitch/ChatDirection.jsx
+++ b/src/modules/settings/settings/twitch/ChatDirection.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Chat Direction'});
 
-function ChatDirection(props, ref) {
+function ChatDirection({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.REVERSE_CHAT_DIRECTION);
 
   return (
@@ -23,11 +23,11 @@ function ChatDirection(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(ChatDirection), {
+SettingStore.registerSetting(ChatDirection, {
   settingPanelId: SettingPanelIds.CHAT_DIRECTION,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['chat', 'direction', 'up', 'down', 'reverse'],
 });
 
-export default React.forwardRef(ChatDirection);
+export default ChatDirection;

--- a/src/modules/settings/settings/twitch/ChatLayout.jsx
+++ b/src/modules/settings/settings/twitch/ChatLayout.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Chat Layout'});
 
-function ChatLayout(props, ref) {
+function ChatLayout({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.CHAT_LAYOUT);
 
   return (
@@ -27,10 +27,10 @@ function ChatLayout(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(ChatLayout), {
+SettingStore.registerSetting(ChatLayout, {
   settingPanelId: SettingPanelIds.CHAT_LAYOUT,
   name: SETTING_NAME,
   keywords: ['chat', 'layout', 'position', 'placement', 'left', 'right'],
 });
 
-export default React.forwardRef(ChatLayout);
+export default ChatLayout;

--- a/src/modules/settings/settings/twitch/DeletedMessages.jsx
+++ b/src/modules/settings/settings/twitch/DeletedMessages.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Deleted Messages'});
 
-function DeletedMessagesModule(props, ref) {
+function DeletedMessagesModule({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.DELETED_MESSAGES);
 
   return (
@@ -41,11 +41,11 @@ function DeletedMessagesModule(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(DeletedMessagesModule), {
+SettingStore.registerSetting(DeletedMessagesModule, {
   settingPanelId: SettingPanelIds.DELETED_MESSAGES,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['messages', 'deleted'],
 });
 
-export default React.forwardRef(DeletedMessagesModule);
+export default DeletedMessagesModule;

--- a/src/modules/settings/settings/twitch/Directory.jsx
+++ b/src/modules/settings/settings/twitch/Directory.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Directory'});
 
-function ShowDirectoryLiveTab(props, ref) {
+function ShowDirectoryLiveTab({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.SHOW_DIRECTORY_LIVE_TAB);
 
   return (
@@ -23,10 +23,10 @@ function ShowDirectoryLiveTab(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(ShowDirectoryLiveTab), {
+SettingStore.registerSetting(ShowDirectoryLiveTab, {
   settingPanelId: SettingPanelIds.DIRECTORY,
   name: SETTING_NAME,
   keywords: ['live', 'tab'],
 });
 
-export default React.forwardRef(ShowDirectoryLiveTab);
+export default ShowDirectoryLiveTab;

--- a/src/modules/settings/settings/twitch/EmoteMenu.jsx
+++ b/src/modules/settings/settings/twitch/EmoteMenu.jsx
@@ -10,7 +10,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Emote Menu'});
 
-function EmoteMenu(props, ref) {
+function EmoteMenu({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.EMOTE_MENU);
   const [width, setWidth] = useStorageState(SettingIds.EMOTE_MENU_WIDTH);
   const toggled = value !== EmoteMenuTypes.NONE;
@@ -43,11 +43,11 @@ function EmoteMenu(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(EmoteMenu), {
+SettingStore.registerSetting(EmoteMenu, {
   settingPanelId: SettingPanelIds.EMOTE_MENU,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['emotes', 'popup'],
 });
 
-export default React.forwardRef(EmoteMenu);
+export default EmoteMenu;

--- a/src/modules/settings/settings/twitch/Highlights.jsx
+++ b/src/modules/settings/settings/twitch/Highlights.jsx
@@ -12,7 +12,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Highlights'});
 
-function Highlights(props, ref) {
+function Highlights({ref, ...props}) {
   const {setPage} = use(PageContext);
   const [value, setValue] = useStorageState(SettingIds.PINNED_HIGHLIGHTS);
   const [deletedMessages, setDeletedMessages] = useStorageState(SettingIds.DELETED_MESSAGES);
@@ -84,11 +84,11 @@ function Highlights(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(Highlights), {
+SettingStore.registerSetting(Highlights, {
   settingPanelId: SettingPanelIds.HIGHLIGHTS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['pinned', 'highlights', 'highlight', 'feedback', 'keywords', 'first', 'chatter', 'first-time'],
 });
 
-export default React.forwardRef(Highlights);
+export default Highlights;

--- a/src/modules/settings/settings/twitch/Moderation.jsx
+++ b/src/modules/settings/settings/twitch/Moderation.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Moderation'});
 
-function Moderation(props, ref) {
+function Moderation({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.AUTO_MOD_VIEW);
 
   return (
@@ -25,10 +25,10 @@ function Moderation(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(Moderation), {
+SettingStore.registerSetting(Moderation, {
   settingPanelId: SettingPanelIds.MODERATION,
   name: SETTING_NAME,
   keywords: ['auto', 'mod', 'view'],
 });
 
-export default React.forwardRef(Moderation);
+export default Moderation;

--- a/src/modules/settings/settings/twitch/Player.jsx
+++ b/src/modules/settings/settings/twitch/Player.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Player'});
 
-function Player(props, ref) {
+function Player({ref, ...props}) {
   const [clickToPlay, setClickToPlay] = useStorageState(SettingIds.CLICK_TO_PLAY);
   const [muteInvisiblePlayer, setMuteInvisiblePlayer] = useStorageState(SettingIds.MUTE_INVISIBLE_PLAYER);
   const [playerExtensions, setPlayerExtensions] = useStorageState(SettingIds.PLAYER_EXTENSIONS);
@@ -55,7 +55,7 @@ function Player(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(Player), {
+SettingStore.registerSetting(Player, {
   settingPanelId: SettingPanelIds.PLAYER,
   name: SETTING_NAME,
   keywords: [
@@ -77,4 +77,4 @@ SettingStore.registerSetting(React.forwardRef(Player), {
   ],
 });
 
-export default React.forwardRef(Player);
+export default Player;

--- a/src/modules/settings/settings/twitch/PrimeGaming.jsx
+++ b/src/modules/settings/settings/twitch/PrimeGaming.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Prime Gaming'});
 
-function PrimeGaming(props, ref) {
+function PrimeGaming({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.PRIME_PROMOTIONS);
 
   return (
@@ -23,10 +23,10 @@ function PrimeGaming(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(PrimeGaming), {
+SettingStore.registerSetting(PrimeGaming, {
   settingPanelId: SettingPanelIds.PRIME_GAMING,
   name: SETTING_NAME,
   keywords: ['ad', 'prime', 'promotions', 'block', 'gaming'],
 });
 
-export default React.forwardRef(PrimeGaming);
+export default PrimeGaming;

--- a/src/modules/settings/settings/twitch/Raids.jsx
+++ b/src/modules/settings/settings/twitch/Raids.jsx
@@ -9,7 +9,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Raids'});
 
-function AutoJoinRaids(props, ref) {
+function AutoJoinRaids({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.AUTO_JOIN_RAIDS);
   const [channels, setChannels] = useStorageState(
     value ? SettingIds.AUTO_JOIN_RAIDS_WHITELISTED_CHANNELS : SettingIds.AUTO_JOIN_RAIDS_BLACKLISTED_CHANNELS
@@ -43,11 +43,11 @@ function AutoJoinRaids(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(AutoJoinRaids), {
+SettingStore.registerSetting(AutoJoinRaids, {
   settingPanelId: SettingPanelIds.RAIDS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['auto', 'join', 'raids'],
 });
 
-export default React.forwardRef(AutoJoinRaids);
+export default AutoJoinRaids;

--- a/src/modules/settings/settings/twitch/SelfBot.jsx
+++ b/src/modules/settings/settings/twitch/SelfBot.jsx
@@ -30,7 +30,7 @@ function openEnableSelfBotModal(setEnabled) {
   });
 }
 
-function SelfBot(props, ref) {
+function SelfBot({ref, ...props}) {
   const {setPage} = use(PageContext);
   const isOnOwnChannel = useIsOnOwnChannel();
   const [enabled, setEnabled] = useStorageState(SettingIds.SELF_BOT);
@@ -86,11 +86,11 @@ function SelfBot(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(SelfBot), {
+SettingStore.registerSetting(SelfBot, {
   settingPanelId: SettingPanelIds.SELF_BOT,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['self', 'bot', 'commands', 'reply', 'automatic', 'timers'],
 });
 
-export default React.forwardRef(SelfBot);
+export default SelfBot;

--- a/src/modules/settings/settings/twitch/Sidebar.jsx
+++ b/src/modules/settings/settings/twitch/Sidebar.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Sidebar'});
 
-function SidebarComponent(props, ref) {
+function SidebarComponent({ref, ...props}) {
   const [sidebar, setSidebar] = useStorageState(SettingIds.SIDEBAR);
 
   return (
@@ -60,7 +60,7 @@ function SidebarComponent(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(SidebarComponent), {
+SettingStore.registerSetting(SidebarComponent, {
   settingPanelId: SettingPanelIds.SIDEBAR,
   name: SETTING_NAME,
   keywords: [
@@ -77,4 +77,4 @@ SettingStore.registerSetting(React.forwardRef(SidebarComponent), {
   ],
 });
 
-export default React.forwardRef(SidebarComponent);
+export default SidebarComponent;

--- a/src/modules/settings/settings/twitch/SplitChat.jsx
+++ b/src/modules/settings/settings/twitch/SplitChat.jsx
@@ -10,7 +10,7 @@ import SplitChatModule from '@/modules/split_chat/index';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Split Chat'});
 
-function SplitChat(props, ref) {
+function SplitChat({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.SPLIT_CHAT);
   const [colorValue, setColorValue] = useStorageState(SettingIds.SPLIT_CHAT_COLOR);
   const defaultColor = SplitChatModule.getDefaultColor();
@@ -48,11 +48,11 @@ function SplitChat(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(SplitChat), {
+SettingStore.registerSetting(SplitChat, {
   settingPanelId: SettingPanelIds.SPLIT_CHAT,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['split', 'chat'],
 });
 
-export default React.forwardRef(SplitChat);
+export default SplitChat;

--- a/src/modules/settings/settings/twitch/TabCompletion.jsx
+++ b/src/modules/settings/settings/twitch/TabCompletion.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Tab Completion'});
 
-function TabCompletion(props, ref) {
+function TabCompletion({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.TAB_COMPLETION_EMOTE_PRIORITY);
 
   return (
@@ -23,11 +23,11 @@ function TabCompletion(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(TabCompletion), {
+SettingStore.registerSetting(TabCompletion, {
   settingPanelId: SettingPanelIds.TAB_COMPLETION,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['tab', 'completion', 'emote', 'priority'],
 });
 
-export default React.forwardRef(TabCompletion);
+export default TabCompletion;

--- a/src/modules/settings/settings/twitch/Theme.jsx
+++ b/src/modules/settings/settings/twitch/Theme.jsx
@@ -10,7 +10,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Theme'});
 
-function Theme(props, ref) {
+function Theme({ref, ...props}) {
   const [darkThemeValue, setDarkThemeValue] = useStorageState(SettingIds.DARKENED_MODE);
   const [autoThemeValue, setAutoThemeValue] = useStorageState(SettingIds.AUTO_THEME_MODE);
   const [themeColorValue, setThemeColorValue] = useStorageState(SettingIds.PRIMARY_COLOR);
@@ -49,11 +49,11 @@ function Theme(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(Theme), {
+SettingStore.registerSetting(Theme, {
   settingPanelId: SettingPanelIds.THEME,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['dark', 'mode', 'light', 'theme', 'white', 'black'],
 });
 
-export default React.forwardRef(Theme);
+export default Theme;

--- a/src/modules/settings/settings/twitch/Usernames.jsx
+++ b/src/modules/settings/settings/twitch/Usernames.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Usernames'});
 
-function UsernamesModule(props, ref) {
+function UsernamesModule({ref, ...props}) {
   const [usernames, setUsernames] = useStorageState(SettingIds.USERNAMES);
 
   return (
@@ -47,11 +47,11 @@ function UsernamesModule(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(UsernamesModule), {
+SettingStore.registerSetting(UsernamesModule, {
   settingPanelId: SettingPanelIds.USERNAMES,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['color', 'username', 'accessibility', 'readability'],
 });
 
-export default React.forwardRef(UsernamesModule);
+export default UsernamesModule;

--- a/src/modules/settings/settings/twitch/Whispers.jsx
+++ b/src/modules/settings/settings/twitch/Whispers.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Whispers'});
 
-function DisableWhispers(props, ref) {
+function DisableWhispers({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.WHISPERS);
 
   return (
@@ -23,10 +23,10 @@ function DisableWhispers(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(DisableWhispers), {
+SettingStore.registerSetting(DisableWhispers, {
   settingPanelId: SettingPanelIds.WHISPERS,
   name: SETTING_NAME,
   keywords: ['whispers', 'direct', 'messages'],
 });
 
-export default React.forwardRef(DisableWhispers);
+export default DisableWhispers;

--- a/src/modules/settings/settings/twitch/YouTube.jsx
+++ b/src/modules/settings/settings/twitch/YouTube.jsx
@@ -59,7 +59,7 @@ function requestYouTubePermission() {
   sendExtensionCommand({type: 'REQUEST_YOUTUBE_PERMISSION'});
 }
 
-function YouTube(props, ref) {
+function YouTube({ref, ...props}) {
   const [loading, setLoading] = React.useState(true);
   const [value, setValue] = React.useState(false);
 
@@ -111,16 +111,14 @@ function maybeRegisterComponent() {
     return null;
   }
 
-  const YouTubeForwardRef = React.forwardRef(YouTube);
-
-  SettingStore.registerSetting(YouTubeForwardRef, {
+  SettingStore.registerSetting(YouTube, {
     settingPanelId: SettingPanelIds.YOUTUBE,
     name: SETTING_NAME,
     supportsStandaloneWindow: true,
     keywords: ['youtube'],
   });
 
-  return YouTubeForwardRef;
+  return YouTube;
 }
 
 export default maybeRegisterComponent();

--- a/src/modules/settings/settings/youtube/AutoLiveChatView.jsx
+++ b/src/modules/settings/settings/youtube/AutoLiveChatView.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Auto Live Chat View'});
 
-function EmoteAutoLiveChatView(props, ref) {
+function EmoteAutoLiveChatView({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.AUTO_LIVE_CHAT_VIEW);
 
   return (
@@ -25,11 +25,11 @@ function EmoteAutoLiveChatView(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(EmoteAutoLiveChatView), {
+SettingStore.registerSetting(EmoteAutoLiveChatView, {
   settingPanelId: SettingPanelIds.AUTO_LIVE_CHAT_VIEW,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['auto', 'live', 'chat', 'view'],
 });
 
-export default React.forwardRef(EmoteAutoLiveChatView);
+export default EmoteAutoLiveChatView;

--- a/src/modules/settings/settings/youtube/EmoteAutocomplete.jsx
+++ b/src/modules/settings/settings/youtube/EmoteAutocomplete.jsx
@@ -8,7 +8,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Emote Autocomplete'});
 
-function EmoteAutocomplete(props, ref) {
+function EmoteAutocomplete({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.EMOTE_AUTOCOMPLETE);
 
   return (
@@ -25,11 +25,11 @@ function EmoteAutocomplete(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(EmoteAutocomplete), {
+SettingStore.registerSetting(EmoteAutocomplete, {
   settingPanelId: SettingPanelIds.EMOTE_AUTOCOMPLETE,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['auto', 'autocomplete', 'emote', ':'],
 });
 
-export default React.forwardRef(EmoteAutocomplete);
+export default EmoteAutocomplete;

--- a/src/modules/settings/settings/youtube/EmoteMenu.jsx
+++ b/src/modules/settings/settings/youtube/EmoteMenu.jsx
@@ -10,7 +10,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Emote Menu'});
 
-function EmoteMenu(props, ref) {
+function EmoteMenu({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.EMOTE_MENU);
   const [width, setWidth] = useStorageState(SettingIds.EMOTE_MENU_WIDTH);
   const isEnabled = value !== EmoteMenuTypes.NONE;
@@ -36,11 +36,11 @@ function EmoteMenu(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(EmoteMenu), {
+SettingStore.registerSetting(EmoteMenu, {
   settingPanelId: SettingPanelIds.EMOTE_MENU,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['emotes', 'popup'],
 });
 
-export default React.forwardRef(EmoteMenu);
+export default EmoteMenu;

--- a/src/modules/settings/settings/youtube/Theme.jsx
+++ b/src/modules/settings/settings/youtube/Theme.jsx
@@ -9,7 +9,7 @@ import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/SettingSt
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Theme'});
 
-function Theme(props, ref) {
+function Theme({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.PRIMARY_COLOR);
 
   const [normalizedValue, setNormalizedValue] = useProRequiredState({
@@ -31,11 +31,11 @@ function Theme(props, ref) {
   );
 }
 
-SettingStore.registerSetting(React.forwardRef(Theme), {
+SettingStore.registerSetting(Theme, {
   settingPanelId: SettingPanelIds.THEME,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
   keywords: ['primary', 'color', 'theme', 'accent'],
 });
 
-export default React.forwardRef(Theme);
+export default Theme;


### PR DESCRIPTION
Follow-up to #8104. Migrates `React.forwardRef` to React 19's ref-as-prop for the **65 of 70** `no-forward-ref` warnings that are mechanical.

### Fixed
- **34 settings panels / group components** — `function X(props, ref)` + `React.forwardRef(X)` → `function X({ref, ...props})` + `X` (drops the wrapper at both the `registerSetting` and `export default` sites).
- **PageHeader, Preview** — inline `forwardRef` arrows → `ref` in the props destructure.

Verified: `eslint .` 0 errors, `prettier --check` clean, production build succeeds.

### Left for a follow-up decision (5 warnings, 3 files)
These merge the forwarded ref with internal refs via `useMergedRef` (and `EmoteList` is `memo`-wrapped with 3 components), so they're called out separately rather than converted blindly:
- `src/common/components/Scrollbar.jsx`
- `src/modules/emote_menu/components/VirtualizedList.jsx`
- `src/modules/emote_menu/components/EmoteList.jsx`

> Note: overlaps a few files with #8106 / #8107; whichever merges first, the others may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)