### PR TITLE
fix: keep keyword highlight color cells square

### DIFF
--- a/src/common/styles/SettingEntryTable.module.css
+++ b/src/common/styles/SettingEntryTable.module.css
@@ -36,6 +36,11 @@
       width: 0;
       padding: 0;
     }
+
+    &.colorColumn {
+      width: 0;
+      padding: 0;
+    }
   }
 
   --table-border-color: var(--mantine-color-default-border);
@@ -86,7 +91,8 @@
   text-align: center;
 }
 
-td.actionsColumn {
+td.actionsColumn,
+td.colorColumn {
   width: 36px;
   min-width: 36px;
   max-width: 36px;

--- a/src/modules/settings/components/SettingKeywords.jsx
+++ b/src/modules/settings/components/SettingKeywords.jsx
@@ -111,7 +111,7 @@ function KeywordRow({
   return (
     <TableTr {...props}>
       {colorColumn != null ? (
-        <TableTd className={tableStyles.dataCell}>
+        <TableTd className={classNames(tableStyles.dataCell, tableStyles.colorColumn)}>
           <ColorPicker
             size="sm"
             variant="transparent"
@@ -221,7 +221,7 @@ function KeywordsTable({
     <Table withColumnBorders className={tableStyles.table} onPaste={onPaste}>
       <TableThead>
         <TableTr>
-          {showColorColumn ? <TableTh className={styles.colorColumn} /> : null}
+          {showColorColumn ? <TableTh className={tableStyles.colorColumn} /> : null}
           <TableTh className={styles.targetColumn}>{formatMessage({defaultMessage: 'Target'})}</TableTh>
           <TableTh className={styles.keywordColumn}>
             <div className={styles.keywordHeader}>

--- a/src/modules/settings/components/SettingKeywords.module.css
+++ b/src/modules/settings/components/SettingKeywords.module.css
@@ -36,11 +36,6 @@
   }
 }
 
-.colorColumn,
-.actionsColumn {
-  width: 0;
-}
-
 .targetDataCell,
 .keywordDataCell,
 .colorDataCell,


### PR DESCRIPTION
### Problem
In the highlight-keyword settings table, the color-swatch column used the shared `dataCell` style (`padding: 0 12px`) wrapped around a 36px swatch button, so each color cell rendered **60×36** — a wide rectangle. The adjacent trash-icon column was already a clean 36×36 square (it gets the `actionsColumn` treatment), so the color cells looked off by comparison.

### Fix
Give the color column the same square treatment as the actions column — a zero-padding, fixed 36px cell:
- Added a `colorColumn` class to `SettingEntryTable.module.css`, right next to `actionsColumn`, so specificity and source order stay correct relative to `dataCell`.
- Applied `tableStyles.colorColumn` to the header cell and the swatch data cell in `SettingKeywords.jsx`.
- Removed the now-dead local `.colorColumn, .actionsColumn { width: 0 }` rule from `SettingKeywords.module.css` (both classes were unused after the migration).

Color swatch cells are now exactly **36×36**, matching the trash-icon cells. CSS-only change; Prettier passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)