### PR TITLE
fix: stop self-bot command table showing a stray inner border

### DIFF
--- a/src/common/styles/SettingEntryTable.module.css
+++ b/src/common/styles/SettingEntryTable.module.css
@@ -1,5 +1,8 @@
 .settingGroupContent {
-  padding: 0;
+  /* Override Panel's default 20px padding regardless of stylesheet order so the
+     table sits flush to the card's rounded border (otherwise the inset table
+     borders show as a stray inner border). */
+  padding: 0 !important;
   overflow: hidden;
 }
 


### PR DESCRIPTION
### Problem
The Self Bot Commands settings table renders with a stray inner border — the table sits inset inside its rounded card instead of flush, so the grid's edges read as a second, weird border.

### Root cause
It's a CSS source-order issue, not a self-bot-specific bug. The table panel applies two equal-specificity classes:
- `Panel`'s `.panel` → `padding: 20px`
- `SettingEntryTable.module.css`'s `.settingGroupContent` → `padding: 0`

With equal specificity the winner is decided by stylesheet emit order. `SettingEntryTable`'s `.settingGroupContent` is emitted **before** `.panel`, so `.panel`'s `padding: 20px` wins and the table is inset by 20px — its borders then show as a stray inner frame. (The highlight-keywords table looks correct only because its *separate, identical* `.settingGroupContent` copy happens to be emitted **after** `.panel`.)

### Fix
Make the override order-independent with `!important`, matching the idiom already used in this file (e.g. `padding: 0 !important` on `channelsDataCell`). The table now sits flush to the card's rounded border.

CSS-only, one line. Verified in the built CSS bundle; Prettier passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)