### PR TITLE
qol: show free command limit on self bot commands page

### DIFF
--- a/src/modules/settings/components/SettingSelfBotCommands.jsx
+++ b/src/modules/settings/components/SettingSelfBotCommands.jsx
@@ -3,6 +3,7 @@ import {
   ActionIcon,
   Button,
   NativeSelect,
+  Pill,
   Table,
   TableTbody,
   TableTd,
@@ -131,6 +132,9 @@ function SettingSelfBotCommands({value, setValue}) {
   const pendingCommandFocusRef = useRef(null);
   const bttvUser = useAuthStore(useShallow((state) => state.user));
 
+  const commandCount = entryList.length;
+  const isPro = isUserPro(bttvUser);
+
   const filteredEntryList = useMemo(() => {
     const query = search.trim().toLowerCase();
     if (query.length === 0) {
@@ -221,9 +225,19 @@ function SettingSelfBotCommands({value, setValue}) {
         />
       }
       rightContent={
-        <Button size="lg" className={tableStyles.newEntryButton} onClick={newEntryHandler}>
-          {formatMessage({defaultMessage: 'New Entry'})}
-        </Button>
+        <div className={styles.headerActions}>
+          {!isPro ? (
+            <Pill size="lg" className={styles.limitPill}>
+              {formatMessage(
+                {defaultMessage: 'Entry {count} / {limit}'},
+                {count: commandCount, limit: FREE_COMMAND_LIMIT}
+              )}
+            </Pill>
+          ) : null}
+          <Button size="lg" className={tableStyles.newEntryButton} onClick={newEntryHandler}>
+            {formatMessage({defaultMessage: 'New Entry'})}
+          </Button>
+        </div>
       }
       className={tableStyles.settingGroupContent}>
       {filteredEntryList.length > 0 ? (

--- a/src/modules/settings/components/SettingSelfBotCommands.module.css
+++ b/src/modules/settings/components/SettingSelfBotCommands.module.css
@@ -1,3 +1,14 @@
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.limitPill {
+  box-shadow: var(--mantine-shadow-xs);
+  font-weight: 500;
+}
+
 .searchInputRoot {
   width: 100%;
   max-width: 240px;


### PR DESCRIPTION
Adds a pill next to the **New Entry** button on the Self Bot → Commands page that shows non-pro users their free command usage (e.g. `Entry 0 / 5`), so the free-tier limit is visible before they hit it and get the upgrade prompt.

- Only renders for non-pro users (`!isUserPro`), so Pro users are unaffected.
- Reuses the existing `FREE_COMMAND_LIMIT` already enforced in `newEntryHandler`.
- Styling lives in the component's CSS module (`.headerActions`, `.limitPill`) with an `xs` box-shadow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)