### PR TITLE
fix: dedupe session-lock acquires so a held lock isn't dropped

### DIFF
--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -37,6 +37,13 @@ const joinedChannels = [];
 // session locks this client wants to hold, and the subset the server has granted us
 const desiredSessionLocks = new Set();
 const heldSessionLocks = new Set();
+const pendingSessionLockAcquires = new Set();
+
+// desired intent survives a reconnect; what we hold and what we're mid-acquire does not
+function resetSessionLockConnectionState() {
+  heldSessionLocks.clear();
+  pendingSessionLockAcquires.clear();
+}
 
 function makeSocketChannel(provider, providerId) {
   return `${provider}:${providerId}`;
@@ -90,15 +97,15 @@ class SocketClient extends SafeEventEmitter {
     if (authenticated) {
       retryAuthenticationRequest = true;
       // session locks live on the (possibly new) authenticated connection, so (re)claim any we want
-      heldSessionLocks.clear();
+      resetSessionLockConnectionState();
       for (const key of desiredSessionLocks) {
-        this.send('acquire_session_lock', {key});
+        this.sendAcquireSessionLock(key);
       }
       return;
     }
 
     // our locks are gone once we lose authentication
-    heldSessionLocks.clear();
+    resetSessionLockConnectionState();
 
     if (data.reason === 'invalid_token') {
       if (!retryAuthenticationRequest) {
@@ -184,6 +191,8 @@ class SocketClient extends SafeEventEmitter {
       return;
     }
 
+    pendingSessionLockAcquires.delete(key);
+
     if (acquired) {
       heldSessionLocks.add(key);
     } else {
@@ -193,16 +202,26 @@ class SocketClient extends SafeEventEmitter {
 
   // a holder (on any server) freed this lock; reclaim it if we want it and don't hold it
   handleSessionLockReleased({key} = {}) {
-    if (key == null || heldSessionLocks.has(key) || !desiredSessionLocks.has(key)) {
+    if (key == null || !desiredSessionLocks.has(key)) {
       return;
     }
 
+    this.sendAcquireSessionLock(key);
+  }
+
+  // single gate for actually sending an acquire: skip if we already hold it or one is in flight
+  sendAcquireSessionLock(key) {
+    if (heldSessionLocks.has(key) || pendingSessionLockAcquires.has(key)) {
+      return;
+    }
+
+    pendingSessionLockAcquires.add(key);
     this.send('acquire_session_lock', {key});
   }
 
   acquireSessionLock(key) {
     desiredSessionLocks.add(key);
-    this.send('acquire_session_lock', {key});
+    this.sendAcquireSessionLock(key);
   }
 
   releaseSessionLock(key) {
@@ -211,6 +230,7 @@ class SocketClient extends SafeEventEmitter {
     // after we give up. the server ignores a release from a non-holder, so this is safe.
     const wasDesired = desiredSessionLocks.delete(key);
     heldSessionLocks.delete(key);
+    pendingSessionLockAcquires.delete(key);
 
     if (wasDesired) {
       this.send('release_session_lock', {key});
@@ -226,7 +246,7 @@ class SocketClient extends SafeEventEmitter {
     state = CONNECTION_STATES.DISCONNECTED;
 
     // locks do not survive a dropped connection; we re-acquire after re-authenticating
-    heldSessionLocks.clear();
+    resetSessionLockConnectionState();
 
     if (socket) {
       try {


### PR DESCRIPTION
## Problem

`acquireSessionLock` sends an `acquire_session_lock` frame on **every** call, but the same lock gets nudged repeatedly — `self_bot`'s `updateSessionLock` fires from several triggers (the `SELF_BOT` setting change, the auth-user subscription, and `load.chat`), so one socket can emit two acquires for the same key in quick succession.

When two acquires race, the responses can come back as a contradictory `acquired: true` followed by `acquired: false`. `handleSessionLockUpdate` applies whichever arrives last, so the `false` clears a lock the session actually holds. After that, `hasSessionLock('self_bot')` is `false` and the bot silently stops responding even though it owns the lock, until the page reloads.

## Fix

Track **in-flight** acquires and skip a duplicate while one is already pending, rather than firing an acquire on every call. All three acquire paths (`acquireSessionLock`, the reconnect re-claim in `handleAuthenticationUpdate`, and the retry in `handleSessionLockReleased`) go through one `sendAcquireSessionLock` helper; `pendingSessionLockAcquires` is cleared on every `session_lock_update` response and on reconnect/logout.

Gating on *pending* rather than *desired* matters: a failed or expired grant leaves the key desired but not held, and the server's heartbeat-expiry sends `acquired: false` with **no** `session_lock_released` — so recovery has to come from a fresh acquire. A `desired`-based guard would suppress that and leave the bot stuck; the `pending`-based guard allows it while still collapsing the duplicate burst.

## Validation

Local socket harness against the real lock protocol:
- duplicate acquires no longer desync — the bot keeps the lock and replies
- after a server-injected heartbeat `expired`, the next `updateSessionLock` re-acquires and the bot recovers (a `desired`-based guard fails this; the `pending`-based guard passes)
- reconnect re-acquire and release-retry still work

Prettier passes; the eslint config references a plugin that isn't installed locally, so that's left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)