### PR TITLE
feat: settings search

### DIFF
--- a/src/modules/settings/components/SettingsModal.jsx
+++ b/src/modules/settings/components/SettingsModal.jsx
@@ -72,16 +72,18 @@ function PageContainer({children, className, scrollRef, onMount}) {
 
 function SettingsModal({setHandleOpen}) {
   const {width} = useViewportSize();
-  const [page, setPage] = useState(PageTypes.SETTINGS);
   const [open, modalHandlers] = useDisclosure(false);
   const [sidenavOpen, setSidenavOpen] = useState(false);
+  // True once the open animation finishes, so auto-focus doesn't fight the transition.
+  const [isInteractive, setIsInteractive] = useState(false);
   const settingRefsRef = useRef({});
-  const pendingScrollToSettingPanelIdRef = useRef(null);
   const pageContentRef = useRef(null);
   const pageColumnRef = useRef(null);
   const lastParentDataRef = useRef({scrollTop: 0, page: null});
 
+  const page = useSettingsNavigationStore((state) => state.page);
   const setActivePanelId = useSettingsNavigationStore((state) => state.setActivePanelId);
+  const pendingSettingPanelId = useSettingsNavigationStore((state) => state.pendingSettingPanelId);
 
   // Panel scroll targets use scroll-margin on the panels; scrolling is just scrollIntoView.
   const scrollToPanel = useCallback(
@@ -107,7 +109,7 @@ function SettingsModal({setHandleOpen}) {
       lastParentDataRef.current.scrollTop = pageContentRef.current.scrollTop;
     }
 
-    setPage(newPage);
+    useSettingsNavigationStore.getState().setPage(newPage);
   }
 
   function handleSettingRefCallback(settingPanelId, ref) {
@@ -125,8 +127,19 @@ function SettingsModal({setHandleOpen}) {
     }
 
     handlePageChange(PageTypes.SETTINGS);
-    pendingScrollToSettingPanelIdRef.current = settingPanelId;
+    useSettingsNavigationStore.getState().gotoSettingPanel(settingPanelId);
   }
+
+  // Consume a pending panel navigation when the target is already rendered (e.g. navigating from
+  // search while on the settings page). Page changes are consumed by handlePageMount instead.
+  useEffect(() => {
+    if (pendingSettingPanelId == null || settingRefsRef.current[pendingSettingPanelId] == null) {
+      return;
+    }
+
+    scrollToPanel(pendingSettingPanelId);
+    useSettingsNavigationStore.getState().clearPendingSettingPanel();
+  }, [pendingSettingPanelId, scrollToPanel]);
 
   useEffect(() => {
     setHandleOpen((isOpen, {scrollToSettingPanelId} = {scrollToSettingPanelId: null}) => {
@@ -146,6 +159,9 @@ function SettingsModal({setHandleOpen}) {
     event.stopPropagation();
   }, []);
 
+  const handleEnterTransitionEnd = useCallback(() => setIsInteractive(true), []);
+  const handleExitTransitionEnd = useCallback(() => setIsInteractive(false), []);
+
   // Runs when a page mounts: scroll to a pending setting panel, otherwise restore the
   // parent page's scroll position (or start at the top).
   const handlePageMount = useCallback(() => {
@@ -154,11 +170,11 @@ function SettingsModal({setHandleOpen}) {
       return;
     }
 
-    const pendingPanelId = pendingScrollToSettingPanelIdRef.current;
-    pendingScrollToSettingPanelIdRef.current = null;
+    const {pendingSettingPanelId: pendingPanelId, clearPendingSettingPanel} = useSettingsNavigationStore.getState();
 
     if (page === PageTypes.SETTINGS && pendingPanelId != null && settingRefsRef.current[pendingPanelId] != null) {
       scrollToPanel(pendingPanelId);
+      clearPendingSettingPanel();
       return;
     }
 
@@ -184,6 +200,8 @@ function SettingsModal({setHandleOpen}) {
       withCloseButton={false}
       classNames={{content: styles.modal, body: styles.modalBody}}
       transitionProps={{transition: 'pop', duration: 100}}
+      onEnterTransitionEnd={handleEnterTransitionEnd}
+      onExitTransitionEnd={handleExitTransitionEnd}
       onClose={modalHandlers.close}>
       <PageContext
         value={{
@@ -193,6 +211,7 @@ function SettingsModal({setHandleOpen}) {
           setSidenavOpen,
           handleGotoSettingPanel,
           closeModal: modalHandlers.close,
+          isInteractive,
         }}>
         <SideNavigation open={sidenavOpen} setOpen={setSidenavOpen} />
         <ScrollbarSizeTargetContext value={pageColumnRef}>

--- a/src/modules/settings/components/SettingsSearch.jsx
+++ b/src/modules/settings/components/SettingsSearch.jsx
@@ -1,0 +1,178 @@
+import {faMagnifyingGlass} from '@fortawesome/free-solid-svg-icons';
+import {Combobox, Text, TextInput, useCombobox} from '@mantine/core';
+import {useFocusTrap} from '@mantine/hooks';
+import React, {use, useCallback, useEffect, useMemo, useState} from 'react';
+import Icon from '@/common/components/Icon';
+import usePortalRef from '@/common/hooks/PortalRef';
+import formatMessage from '@/i18n/index';
+import {PageContext} from '@/modules/settings/contexts/PageContext';
+import searchStore from '@/modules/settings/stores/search-store';
+import keyCodes from '@/utils/keycodes';
+import styles from './SettingsSearch.module.css';
+
+const MAX_RESULTS = 4;
+
+function SettingsSearch({onNavigate}) {
+  const {isInteractive} = use(PageContext);
+  const focusRef = useFocusTrap(isInteractive);
+  const portalRef = usePortalRef();
+  const combobox = useCombobox();
+  const [search, setSearch] = useState('');
+  // True while Enter/Tab is held; the selected option darkens and submits on release,
+  // matching the autocomplete's pending-complete behavior.
+  const [pendingComplete, setPendingComplete] = useState(false);
+
+  const query = search.trim();
+  const results = useMemo(() => (query.length > 0 ? searchStore.search(query).slice(0, MAX_RESULTS) : []), [query]);
+
+  // Keep the best match selected as the user types, so Enter/Tab picks it immediately.
+  useEffect(() => {
+    combobox.selectFirstOption();
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- combobox store is stable
+  }, [search]);
+
+  const handleOptionSubmit = useCallback(
+    (value) => {
+      const entry = results[Number(value)];
+      if (entry == null) {
+        return;
+      }
+
+      entry.goto();
+      combobox.closeDropdown();
+      setSearch('');
+      onNavigate?.();
+    },
+    [results, combobox, onNavigate]
+  );
+
+  const handleChange = useCallback(
+    (event) => {
+      const {value} = event.currentTarget;
+      setSearch(value);
+      // Only show the dropdown once there's a query to match against.
+      if (value.trim().length > 0) {
+        combobox.openDropdown();
+      } else {
+        combobox.closeDropdown();
+      }
+    },
+    [combobox]
+  );
+
+  const handleFocus = useCallback(() => {
+    if (query.length > 0) {
+      combobox.openDropdown();
+    }
+  }, [combobox, query]);
+
+  const handleBlur = useCallback(() => {
+    setPendingComplete(false);
+    combobox.closeDropdown();
+  }, [combobox]);
+
+  // Keyboard navigation is handled here (withKeyboardNavigation is off) so Enter/Tab can mark the
+  // selected option as pending on keydown and only submit on keyup, like the autocomplete.
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (!combobox.dropdownOpened || results.length === 0) {
+        return;
+      }
+
+      switch (event.key) {
+        case keyCodes.ArrowDown:
+          event.preventDefault();
+          combobox.selectNextOption();
+          break;
+        case keyCodes.ArrowUp:
+          event.preventDefault();
+          combobox.selectPreviousOption();
+          break;
+        case keyCodes.Escape:
+          combobox.closeDropdown();
+          break;
+        case keyCodes.Enter:
+        case keyCodes.Tab:
+          event.preventDefault();
+          setPendingComplete(true);
+          break;
+        default:
+          break;
+      }
+    },
+    [combobox, results.length]
+  );
+
+  const handleKeyUp = useCallback(
+    (event) => {
+      if ((event.key !== keyCodes.Enter && event.key !== keyCodes.Tab) || !pendingComplete) {
+        return;
+      }
+
+      setPendingComplete(false);
+      combobox.clickSelectedOption();
+    },
+    [combobox, pendingComplete]
+  );
+
+  // Selection follows the mouse, like the autocomplete's hover behavior.
+  const handleOptionMouseOver = useCallback(
+    (event) => {
+      combobox.selectOption(Number(event.currentTarget.dataset.index));
+    },
+    [combobox]
+  );
+
+  return (
+    <Combobox
+      store={combobox}
+      withinPortal
+      portalProps={{target: portalRef.current}}
+      position="bottom-start"
+      offset={4}
+      width={400}
+      radius="lg"
+      shadow="md"
+      onOptionSubmit={handleOptionSubmit}>
+      <Combobox.Target withKeyboardNavigation={false}>
+        <TextInput
+          ref={focusRef}
+          size="lg"
+          radius="lg"
+          value={search}
+          placeholder={formatMessage({defaultMessage: 'Search'})}
+          leftSection={<Icon icon={faMagnifyingGlass} className={styles.searchIcon} />}
+          className={styles.searchInputRoot}
+          onChange={handleChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          onKeyUp={handleKeyUp}
+        />
+      </Combobox.Target>
+      <Combobox.Dropdown hidden={results.length === 0} className={styles.dropdown}>
+        <Combobox.Options data-pending-complete={pendingComplete || undefined}>
+          {results.map((entry, index) => (
+            <Combobox.Option
+              value={String(index)}
+              key={`${entry.name}-${entry.description}`}
+              className={styles.option}
+              data-index={index}
+              onMouseOver={handleOptionMouseOver}>
+              <Text size="md" className={styles.optionName}>
+                {entry.name}
+              </Text>
+              {entry.description != null ? (
+                <Text size="md" c="dimmed" truncate className={styles.optionDescription}>
+                  {entry.description}
+                </Text>
+              ) : null}
+            </Combobox.Option>
+          ))}
+        </Combobox.Options>
+      </Combobox.Dropdown>
+    </Combobox>
+  );
+}
+
+export default SettingsSearch;

--- a/src/modules/settings/components/SettingsSearch.module.css
+++ b/src/modules/settings/components/SettingsSearch.module.css
@@ -1,0 +1,47 @@
+.searchInputRoot {
+  --input-height: 40px;
+  margin: 8px;
+}
+
+.searchIcon {
+  width: 14px;
+  height: 14px;
+}
+
+/* results are capped (MAX_RESULTS) instead of scrolled, so the dropdown never shows a scrollbar */
+.dropdown {
+  padding: 6px;
+}
+
+.option {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px;
+  border-radius: var(--mantine-radius-md);
+}
+
+/* mirror the autocomplete row states (see AutocompleteRow.module.css): the selection (which
+   follows both the keyboard and the mouse) gets the light-hover surface with primary text,
+   pressing darkens to light-active */
+.option[data-combobox-selected] {
+  color: var(--mantine-primary-color-filled);
+  background-color: var(--mantine-primary-color-light-hover);
+}
+
+.option[data-combobox-selected] .optionDescription {
+  color: var(--mantine-primary-color-text-dimmed) !important;
+}
+
+/* pressed: mouse-down on an option, or the selected option while Enter/Tab is held */
+.option:active,
+[data-pending-complete] .option[data-combobox-selected] {
+  background-color: var(--mantine-primary-color-light-active);
+  transition-property: background-color, color;
+  transition-duration: 0.1s;
+  transition-timing-function: ease-in-out;
+}
+
+.optionName {
+  font-weight: 500;
+}

--- a/src/modules/settings/components/SideNavigation.jsx
+++ b/src/modules/settings/components/SideNavigation.jsx
@@ -14,6 +14,7 @@ import useSettingsNavigationStore from '@/modules/settings/stores/settings-navig
 import useAuthStore from '@/stores/auth';
 import {isUserPro} from '@/utils/pro';
 import AnimatedLogo from './AnimatedLogo';
+import SettingsSearch from './SettingsSearch';
 import styles from './SideNavigation.module.css';
 
 // The category collapse animation scales linearly with the number of items, so every category
@@ -170,6 +171,7 @@ function SideNavigation({open, setOpen}) {
           <CloseMenuButton onClick={close} className={styles.closeButton} />
         </div>
         <div className={styles.settingsScrollArea} ref={containerRef}>
+          <SettingsSearch onNavigate={close} />
           {categorizedGroups.map((group) => {
             const isCollapsed = openCategory !== group.id;
             const hasActiveChild =

--- a/src/modules/settings/settings/global/ChatBots.jsx
+++ b/src/modules/settings/settings/global/ChatBots.jsx
@@ -5,9 +5,16 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Chat Bots'});
+
+const COMMAND_AUTOCOMPLETE_NAME = formatMessage({defaultMessage: 'Command Autocomplete'});
+const COMMAND_AUTOCOMPLETE_DESCRIPTION = formatMessage({
+  defaultMessage: 'Enable command autocomplete for supported chatbot commands.',
+});
 
 function ChatBots({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.CHATBOT_COMMAND_AUTOCOMPLETE);
@@ -24,12 +31,10 @@ function ChatBots({ref, ...props}) {
         {...props}
         showProBadge
         showBetaBadge
-        name={formatMessage({defaultMessage: 'Command Autocomplete'})}
+        name={COMMAND_AUTOCOMPLETE_NAME}
         value={normalizedValue}
         onChange={setNormalizedValue}
-        description={formatMessage({
-          defaultMessage: 'Enable command autocomplete for supported chatbot commands.',
-        })}
+        description={COMMAND_AUTOCOMPLETE_DESCRIPTION}
       />
     </SettingGroup>
   );
@@ -39,7 +44,12 @@ SettingStore.registerSetting(ChatBots, {
   settingPanelId: SettingPanelIds.CHATBOTS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['command', 'autocomplete', 'nightbot', 'fossabot', 'moobot', 'streamelements', 'commands', 'chat', 'bot'],
+});
+
+searchStore.registerSearchEntry({
+  name: COMMAND_AUTOCOMPLETE_NAME,
+  description: COMMAND_AUTOCOMPLETE_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.CHATBOTS),
 });
 
 export default ChatBots;

--- a/src/modules/settings/settings/global/Emotes.jsx
+++ b/src/modules/settings/settings/global/Emotes.jsx
@@ -7,11 +7,40 @@ import formatMessage from '@/i18n/index';
 import globalEmotes from '@/modules/emotes/global-emotes';
 import SettingCheckbox from '@/modules/settings/components/SettingCheckbox';
 import SettingCheckboxGroup from '@/modules/settings/components/SettingCheckboxGroup';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 import {hasFlag} from '@/utils/flags';
 import styles from './Emotes.module.css';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Emotes'});
+
+const ANIMATED_EMOTES_NAME = formatMessage({defaultMessage: 'Animated Emotes'});
+const ANIMATED_EMOTES_DESCRIPTION = formatMessage({
+  defaultMessage: 'Autoplays animated emotes, otherwise only when hovered.',
+});
+const ANIMATED_PERSONAL_EMOTES_NAME = formatMessage({defaultMessage: 'Animated Personal Emotes'});
+const ANIMATED_PERSONAL_EMOTES_DESCRIPTION = formatMessage({
+  defaultMessage: 'Autoplays animated personal emotes, otherwise only when hovered.',
+});
+const EMOTE_MODIFIERS_NAME = formatMessage({defaultMessage: 'Emote Modifiers'});
+const EMOTE_MODIFIERS_PLAIN_DESCRIPTION = formatMessage({
+  defaultMessage: 'Emote modifiers allow you to transform emotes in realtime.',
+});
+const BTTV_EMOTES_NAME = formatMessage({defaultMessage: 'BetterTTV Emotes'});
+const BTTV_EMOTES_DESCRIPTION = formatMessage({defaultMessage: 'Adds extra cool emotes for you to use.'});
+const FFZ_EMOTES_NAME = formatMessage({defaultMessage: 'FrankerFaceZ Emotes'});
+const FFZ_EMOTES_DESCRIPTION = formatMessage({
+  defaultMessage: 'Enables emotes from the third party FrankerFaceZ extension.',
+});
+const SEVENTV_EMOTES_NAME = formatMessage({defaultMessage: '7TV Emotes'});
+const SEVENTV_EMOTES_DESCRIPTION = formatMessage({
+  defaultMessage: 'Enables emotes from the third party 7TV extension.',
+});
+const SEVENTV_UNLISTED_EMOTES_NAME = formatMessage({defaultMessage: 'Unlisted 7TV Emotes'});
+const SEVENTV_UNLISTED_EMOTES_DESCRIPTION = formatMessage({
+  defaultMessage: 'Enables unlisted emotes from the third party 7TV extension.',
+});
 
 const EMOTE_MODIFIERS_DESCRIPTION = {
   'w!': formatMessage({defaultMessage: 'Will display the emote in a wide format'}),
@@ -110,21 +139,17 @@ function EmotesModule({ref, ...props}) {
       flags={Object.values(EmoteTypeFlags)}>
       <SettingCheckbox
         value={EmoteTypeFlags.ANIMATED_EMOTES}
-        name={formatMessage({defaultMessage: 'Animated Emotes'})}
-        description={formatMessage({
-          defaultMessage: 'Autoplays animated emotes, otherwise only when hovered.',
-        })}
+        name={ANIMATED_EMOTES_NAME}
+        description={ANIMATED_EMOTES_DESCRIPTION}
       />
       <SettingCheckbox
         value={EmoteTypeFlags.ANIMATED_PERSONAL_EMOTES}
-        name={formatMessage({defaultMessage: 'Animated Personal Emotes'})}
-        description={formatMessage({
-          defaultMessage: 'Autoplays animated personal emotes, otherwise only when hovered.',
-        })}
+        name={ANIMATED_PERSONAL_EMOTES_NAME}
+        description={ANIMATED_PERSONAL_EMOTES_DESCRIPTION}
       />
       <SettingCheckbox
         value={EmoteTypeFlags.EMOTE_MODIFIERS}
-        name={formatMessage({defaultMessage: 'Emote Modifiers'})}
+        name={EMOTE_MODIFIERS_NAME}
         description={formatMessage(
           {defaultMessage: '<link>Emote modifiers</link> allow you to transform emotes in realtime.'},
           {
@@ -138,29 +163,19 @@ function EmotesModule({ref, ...props}) {
       />
       <SettingCheckbox
         value={EmoteTypeFlags.BTTV_EMOTES}
-        name={formatMessage({defaultMessage: 'BetterTTV Emotes'})}
-        description={formatMessage({defaultMessage: 'Adds extra cool emotes for you to use.'})}
+        name={BTTV_EMOTES_NAME}
+        description={BTTV_EMOTES_DESCRIPTION}
       />
-      <SettingCheckbox
-        value={EmoteTypeFlags.FFZ_EMOTES}
-        name={formatMessage({defaultMessage: 'FrankerFaceZ Emotes'})}
-        description={formatMessage({
-          defaultMessage: 'Enables emotes from the third party FrankerFaceZ extension.',
-        })}
-      />
+      <SettingCheckbox value={EmoteTypeFlags.FFZ_EMOTES} name={FFZ_EMOTES_NAME} description={FFZ_EMOTES_DESCRIPTION} />
       <SettingCheckbox
         value={EmoteTypeFlags.SEVENTV_EMOTES}
-        name={formatMessage({defaultMessage: '7TV Emotes'})}
-        description={formatMessage({
-          defaultMessage: 'Enables emotes from the third party 7TV extension.',
-        })}
+        name={SEVENTV_EMOTES_NAME}
+        description={SEVENTV_EMOTES_DESCRIPTION}
       />
       <SettingCheckbox
         value={EmoteTypeFlags.SEVENTV_UNLISTED_EMOTES}
-        name={formatMessage({defaultMessage: 'Unlisted 7TV Emotes'})}
-        description={formatMessage({
-          defaultMessage: 'Enables unlisted emotes from the third party 7TV extension.',
-        })}
+        name={SEVENTV_UNLISTED_EMOTES_NAME}
+        description={SEVENTV_UNLISTED_EMOTES_DESCRIPTION}
       />
     </SettingCheckboxGroup>
   );
@@ -170,7 +185,18 @@ SettingStore.registerSetting(EmotesModule, {
   settingPanelId: SettingPanelIds.EMOTES,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['bttv', 'ffz', '7tv', 'betterttv', 'frankerfacez', 'animated', 'gif', 'images', 'emotes'],
 });
+
+for (const entry of [
+  {name: ANIMATED_EMOTES_NAME, description: ANIMATED_EMOTES_DESCRIPTION},
+  {name: ANIMATED_PERSONAL_EMOTES_NAME, description: ANIMATED_PERSONAL_EMOTES_DESCRIPTION},
+  {name: EMOTE_MODIFIERS_NAME, description: EMOTE_MODIFIERS_PLAIN_DESCRIPTION},
+  {name: BTTV_EMOTES_NAME, description: BTTV_EMOTES_DESCRIPTION},
+  {name: FFZ_EMOTES_NAME, description: FFZ_EMOTES_DESCRIPTION},
+  {name: SEVENTV_EMOTES_NAME, description: SEVENTV_EMOTES_DESCRIPTION},
+  {name: SEVENTV_UNLISTED_EMOTES_NAME, description: SEVENTV_UNLISTED_EMOTES_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.EMOTES)});
+}
 
 export default EmotesModule;

--- a/src/modules/settings/settings/twitch/AnonChat.jsx
+++ b/src/modules/settings/settings/twitch/AnonChat.jsx
@@ -5,9 +5,19 @@ import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
 import SettingTagInput from '@/modules/settings/components/SettingTagInput';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Anon Chat'});
+const SETTING_DESCRIPTION = formatMessage({
+  defaultMessage: 'Anonymously read chat without appearing in the user list.',
+});
+
+const WHITELIST_CHANNELS_NAME = formatMessage({defaultMessage: 'Whitelist Channels'});
+const WHITELIST_CHANNELS_DESCRIPTION = formatMessage({defaultMessage: 'List of channels that disable Anon Chat.'});
+const BLACKLIST_CHANNELS_NAME = formatMessage({defaultMessage: 'Blacklist Channels'});
+const BLACKLIST_CHANNELS_DESCRIPTION = formatMessage({defaultMessage: 'List of channels that enable Anon Chat.'});
 
 function AnonChat({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.ANON_CHAT);
@@ -17,23 +27,10 @@ function AnonChat({ref, ...props}) {
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
-      <SettingSwitch
-        name={SETTING_NAME}
-        description={formatMessage({defaultMessage: 'Anonymously read chat without appearing in the user list.'})}
-        value={value}
-        onChange={setValue}
-      />
+      <SettingSwitch name={SETTING_NAME} description={SETTING_DESCRIPTION} value={value} onChange={setValue} />
       <SettingTagInput
-        name={
-          value
-            ? formatMessage({defaultMessage: 'Whitelist Channels'})
-            : formatMessage({defaultMessage: 'Blacklist Channels'})
-        }
-        description={
-          value
-            ? formatMessage({defaultMessage: 'List of channels that disable Anon Chat.'})
-            : formatMessage({defaultMessage: 'List of channels that enable Anon Chat.'})
-        }
+        name={value ? WHITELIST_CHANNELS_NAME : BLACKLIST_CHANNELS_NAME}
+        description={value ? WHITELIST_CHANNELS_DESCRIPTION : BLACKLIST_CHANNELS_DESCRIPTION}
         value={channels}
         onChange={setChannels}
         withCurrentChannel
@@ -47,7 +44,12 @@ SettingStore.registerSetting(AnonChat, {
   settingPanelId: SettingPanelIds.ANON_CHAT,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['anon', 'chat'],
+});
+
+searchStore.registerSearchEntry({
+  name: SETTING_NAME,
+  description: SETTING_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.ANON_CHAT),
 });
 
 export default AnonChat;

--- a/src/modules/settings/settings/twitch/AutoClaim.jsx
+++ b/src/modules/settings/settings/twitch/AutoClaim.jsx
@@ -4,10 +4,17 @@ import {SettingIds, AutoClaimFlags, ChannelPointsFlags} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingCheckbox from '@/modules/settings/components/SettingCheckbox';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 import {hasFlag, setFlag} from '@/utils/flags';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Auto Claim'});
+
+const BONUS_CHANNEL_POINTS_NAME = formatMessage({defaultMessage: 'Bonus Channel Points'});
+const BONUS_CHANNEL_POINTS_DESCRIPTION = formatMessage({defaultMessage: 'Claim bonus channel points when available.'});
+const DROPS_NAME = formatMessage({defaultMessage: 'Drops'});
+const DROPS_DESCRIPTION = formatMessage({defaultMessage: 'Claim all drops once you earn them.'});
 
 function AutoClaim({ref, ...props}) {
   const [autoClaim, setAutoClaim] = useStorageState(SettingIds.AUTO_CLAIM);
@@ -16,18 +23,14 @@ function AutoClaim({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingCheckbox
-        name={formatMessage({defaultMessage: 'Bonus Channel Points'})}
-        description={formatMessage({
-          defaultMessage: 'Claim bonus channel points when available.',
-        })}
+        name={BONUS_CHANNEL_POINTS_NAME}
+        description={BONUS_CHANNEL_POINTS_DESCRIPTION}
         checked={hasFlag(channelPoints, ChannelPointsFlags.AUTO_CLAIM)}
         onChange={(checked) => setChannelPoints(setFlag(channelPoints, ChannelPointsFlags.AUTO_CLAIM, checked))}
       />
       <SettingCheckbox
-        name={formatMessage({defaultMessage: 'Drops'})}
-        description={formatMessage({
-          defaultMessage: 'Claim all drops once you earn them.',
-        })}
+        name={DROPS_NAME}
+        description={DROPS_DESCRIPTION}
         checked={hasFlag(autoClaim, AutoClaimFlags.DROPS)}
         onChange={(checked) => setAutoClaim(setFlag(autoClaim, AutoClaimFlags.DROPS, checked))}
       />
@@ -39,7 +42,13 @@ SettingStore.registerSetting(AutoClaim, {
   settingPanelId: SettingPanelIds.AUTO_CLAIM,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['auto', 'claim', 'drops', 'moments', 'points'],
 });
+
+for (const entry of [
+  {name: BONUS_CHANNEL_POINTS_NAME, description: BONUS_CHANNEL_POINTS_DESCRIPTION},
+  {name: DROPS_NAME, description: DROPS_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.AUTO_CLAIM)});
+}
 
 export default AutoClaim;

--- a/src/modules/settings/settings/twitch/AutoPlay.jsx
+++ b/src/modules/settings/settings/twitch/AutoPlay.jsx
@@ -4,9 +4,23 @@ import {SettingIds, AutoPlayFlags} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingCheckbox from '@/modules/settings/components/SettingCheckbox';
 import SettingCheckboxGroup from '@/modules/settings/components/SettingCheckboxGroup';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
+import {isStandaloneWindow} from '@/utils/window';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Auto Play'});
+
+const FP_VIDEO_NAME = formatMessage({defaultMessage: 'Front Page Player'});
+const FP_VIDEO_DESCRIPTION = formatMessage({defaultMessage: 'Automatically play videos on the front page.'});
+const OFFLINE_CHANNEL_VIDEO_NAME = formatMessage({defaultMessage: 'Offline Channel Player'});
+const OFFLINE_CHANNEL_VIDEO_DESCRIPTION = formatMessage({
+  defaultMessage: 'Automatically play the welcome video or last stream on offline channels.',
+});
+const VOD_RECOMMENDATION_NAME = formatMessage({defaultMessage: 'VOD Player'});
+const VOD_RECOMMENDATION_DESCRIPTION = formatMessage({
+  defaultMessage: 'Automatically play recommended videos on VoDs.',
+});
 
 function AutoplayModule({ref, ...props}) {
   const [autoplay, setAutoplay] = useStorageState(SettingIds.AUTO_PLAY);
@@ -19,24 +33,16 @@ function AutoplayModule({ref, ...props}) {
       value={autoplay}
       onChange={setAutoplay}
       flags={Object.values(AutoPlayFlags)}>
-      <SettingCheckbox
-        value={AutoPlayFlags.FP_VIDEO}
-        name={formatMessage({defaultMessage: 'Front Page Player'})}
-        description={formatMessage({defaultMessage: 'Automatically play videos on the front page.'})}
-      />
+      <SettingCheckbox value={AutoPlayFlags.FP_VIDEO} name={FP_VIDEO_NAME} description={FP_VIDEO_DESCRIPTION} />
       <SettingCheckbox
         value={AutoPlayFlags.OFFLINE_CHANNEL_VIDEO}
-        name={formatMessage({defaultMessage: 'Offline Channel Player'})}
-        description={formatMessage({
-          defaultMessage: 'Automatically play the welcome video or last stream on offline channels.',
-        })}
+        name={OFFLINE_CHANNEL_VIDEO_NAME}
+        description={OFFLINE_CHANNEL_VIDEO_DESCRIPTION}
       />
       <SettingCheckbox
         value={AutoPlayFlags.VOD_RECOMMENDATION_AUTOPLAY}
-        name={formatMessage({defaultMessage: 'VOD Player'})}
-        description={formatMessage({
-          defaultMessage: 'Automatically play recommended videos on VoDs.',
-        })}
+        name={VOD_RECOMMENDATION_NAME}
+        description={VOD_RECOMMENDATION_DESCRIPTION}
       />
     </SettingCheckboxGroup>
   );
@@ -45,7 +51,18 @@ function AutoplayModule({ref, ...props}) {
 SettingStore.registerSetting(AutoplayModule, {
   settingPanelId: SettingPanelIds.AUTO_PLAY,
   name: SETTING_NAME,
-  keywords: ['auto', 'play'],
 });
+
+for (const entry of [
+  {name: FP_VIDEO_NAME, description: FP_VIDEO_DESCRIPTION},
+  {name: OFFLINE_CHANNEL_VIDEO_NAME, description: OFFLINE_CHANNEL_VIDEO_DESCRIPTION},
+  {name: VOD_RECOMMENDATION_NAME, description: VOD_RECOMMENDATION_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({
+    ...entry,
+    goto: () => gotoSettingPanel(SettingPanelIds.AUTO_PLAY),
+    predicate: () => !isStandaloneWindow(),
+  });
+}
 
 export default AutoplayModule;

--- a/src/modules/settings/settings/twitch/BlacklistKeywords.jsx
+++ b/src/modules/settings/settings/twitch/BlacklistKeywords.jsx
@@ -5,19 +5,19 @@ import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingWrapper from '@/modules/settings/components/SettingWrapper';
 import {PageContext} from '@/modules/settings/contexts/PageContext';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Blacklist Keywords'});
+const SETTING_DESCRIPTION = formatMessage({defaultMessage: 'Remove certain words, phrases or users from your chat.'});
 
 function BlacklistKeywords({ref, ...props}) {
   const {setPage} = use(PageContext);
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
-      <SettingWrapper
-        name={formatMessage({defaultMessage: 'Blacklist Keywords'})}
-        reverse
-        description={formatMessage({defaultMessage: 'Remove certain words, phrases or users from your chat.'})}>
+      <SettingWrapper name={SETTING_NAME} reverse description={SETTING_DESCRIPTION}>
         <Button size="lg" onClick={() => setPage(PageTypes.BLACKLIST_KEYWORDS)}>
           {formatMessage({defaultMessage: 'Edit'})}
         </Button>
@@ -30,7 +30,12 @@ SettingStore.registerSetting(BlacklistKeywords, {
   settingPanelId: SettingPanelIds.BLACKLIST_KEYWORDS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['black', 'list', 'keywords', 'banned', 'remove', 'hide'],
+});
+
+searchStore.registerSearchEntry({
+  name: SETTING_NAME,
+  description: SETTING_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.BLACKLIST_KEYWORDS),
 });
 
 export default BlacklistKeywords;

--- a/src/modules/settings/settings/twitch/ChannelPoints.jsx
+++ b/src/modules/settings/settings/twitch/ChannelPoints.jsx
@@ -4,9 +4,19 @@ import {SettingIds, ChannelPointsFlags} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingCheckbox from '@/modules/settings/components/SettingCheckbox';
 import SettingCheckboxGroup from '@/modules/settings/components/SettingCheckboxGroup';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Channel Points'});
+const SETTING_DESCRIPTION = formatMessage({defaultMessage: 'Show channel points in the chat window.'});
+
+const AUTO_CLAIM_NAME = formatMessage({defaultMessage: 'Auto Claim'});
+const AUTO_CLAIM_DESCRIPTION = formatMessage({defaultMessage: 'Claim bonus channel points when available.'});
+const MESSAGE_HIGHLIGHTS_NAME = formatMessage({defaultMessage: 'Message Highlight Rewards'});
+const MESSAGE_HIGHLIGHTS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Show channel point highlighted messages in the chat window.',
+});
 
 function ChannelPointsModule({ref, ...props}) {
   const [channelPoints, setChannelPoints] = useStorageState(SettingIds.CHANNEL_POINTS);
@@ -21,20 +31,18 @@ function ChannelPointsModule({ref, ...props}) {
       flags={Object.values(ChannelPointsFlags)}>
       <SettingCheckbox
         value={ChannelPointsFlags.CHANNEL_POINTS}
-        name={formatMessage({defaultMessage: 'Channel Points'})}
-        description={formatMessage({defaultMessage: 'Show channel points in the chat window.'})}
+        name={SETTING_NAME}
+        description={SETTING_DESCRIPTION}
       />
       <SettingCheckbox
         value={ChannelPointsFlags.AUTO_CLAIM}
-        name={formatMessage({defaultMessage: 'Auto Claim'})}
-        description={formatMessage({defaultMessage: 'Claim bonus channel points when available.'})}
+        name={AUTO_CLAIM_NAME}
+        description={AUTO_CLAIM_DESCRIPTION}
       />
       <SettingCheckbox
         value={ChannelPointsFlags.MESSAGE_HIGHLIGHTS}
-        name={formatMessage({defaultMessage: 'Message Highlight Rewards'})}
-        description={formatMessage({
-          defaultMessage: 'Show channel point highlighted messages in the chat window.',
-        })}
+        name={MESSAGE_HIGHLIGHTS_NAME}
+        description={MESSAGE_HIGHLIGHTS_DESCRIPTION}
       />
     </SettingCheckboxGroup>
   );
@@ -44,7 +52,14 @@ SettingStore.registerSetting(ChannelPointsModule, {
   settingPanelId: SettingPanelIds.CHANNEL_POINTS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['channel', 'points', 'auto', 'claim'],
 });
+
+for (const entry of [
+  {name: SETTING_NAME, description: SETTING_DESCRIPTION},
+  {name: AUTO_CLAIM_NAME, description: AUTO_CLAIM_DESCRIPTION},
+  {name: MESSAGE_HIGHLIGHTS_NAME, description: MESSAGE_HIGHLIGHTS_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.CHANNEL_POINTS)});
+}
 
 export default ChannelPointsModule;

--- a/src/modules/settings/settings/twitch/Chat.jsx
+++ b/src/modules/settings/settings/twitch/Chat.jsx
@@ -4,9 +4,32 @@ import {SettingIds, ChatFlags} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingCheckbox from '@/modules/settings/components/SettingCheckbox';
 import SettingCheckboxGroup from '@/modules/settings/components/SettingCheckboxGroup';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Chat'});
+
+const CHAT_REPLIES_NAME = formatMessage({defaultMessage: 'Chat Replies'});
+const CHAT_REPLIES_DESCRIPTION = formatMessage({defaultMessage: 'Show the reply button in chat.'});
+const BITS_NAME = formatMessage({defaultMessage: 'Bits'});
+const BITS_DESCRIPTION = formatMessage({defaultMessage: 'Show bits in the chat window.'});
+const VIEWER_GREETING_NAME = formatMessage({defaultMessage: 'Viewer Greetings'});
+const VIEWER_GREETING_DESCRIPTION = formatMessage({defaultMessage: 'Show new viewer greetings in the chat window.'});
+const SUB_NOTICE_NAME = formatMessage({defaultMessage: 'Subscription Notices'});
+const SUB_NOTICE_DESCRIPTION = formatMessage({
+  defaultMessage: 'Show subs, re-subs, and gift subs notices in the chat window.',
+});
+const CHAT_CLIPS_NAME = formatMessage({defaultMessage: 'Clip Embeds'});
+const CHAT_CLIPS_DESCRIPTION = formatMessage({defaultMessage: 'Show clip previews in the chat window.'});
+const COMMUNITY_HIGHLIGHTS_NAME = formatMessage({defaultMessage: 'Community Highlights'});
+const COMMUNITY_HIGHLIGHTS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Show alerts above chat window for hype trains, drops, pinned messages, etc.',
+});
+const CHAT_MESSAGE_HISTORY_NAME = formatMessage({defaultMessage: 'Message History'});
+const CHAT_MESSAGE_HISTORY_DESCRIPTION = formatMessage({
+  defaultMessage: 'Restore what you previously typed by pressing up/down arrow in chat.',
+});
 
 function ChatModule({ref, ...props}) {
   const [chat, setChat] = useStorageState(SettingIds.CHAT);
@@ -19,46 +42,24 @@ function ChatModule({ref, ...props}) {
       value={chat}
       onChange={setChat}
       flags={Object.values(ChatFlags)}>
-      <SettingCheckbox
-        value={ChatFlags.CHAT_REPLIES}
-        name={formatMessage({defaultMessage: 'Chat Replies'})}
-        description={formatMessage({defaultMessage: 'Show the reply button in chat.'})}
-      />
-      <SettingCheckbox
-        value={ChatFlags.BITS}
-        name={formatMessage({defaultMessage: 'Bits'})}
-        description={formatMessage({defaultMessage: 'Show bits in the chat window.'})}
-      />
+      <SettingCheckbox value={ChatFlags.CHAT_REPLIES} name={CHAT_REPLIES_NAME} description={CHAT_REPLIES_DESCRIPTION} />
+      <SettingCheckbox value={ChatFlags.BITS} name={BITS_NAME} description={BITS_DESCRIPTION} />
       <SettingCheckbox
         value={ChatFlags.VIEWER_GREETING}
-        name={formatMessage({defaultMessage: 'Viewer Greetings'})}
-        description={formatMessage({defaultMessage: 'Show new viewer greetings in the chat window.'})}
+        name={VIEWER_GREETING_NAME}
+        description={VIEWER_GREETING_DESCRIPTION}
       />
-      <SettingCheckbox
-        value={ChatFlags.SUB_NOTICE}
-        name={formatMessage({defaultMessage: 'Subscription Notices'})}
-        description={formatMessage({
-          defaultMessage: 'Show subs, re-subs, and gift subs notices in the chat window.',
-        })}
-      />
-      <SettingCheckbox
-        value={ChatFlags.CHAT_CLIPS}
-        name={formatMessage({defaultMessage: 'Clip Embeds'})}
-        description={formatMessage({defaultMessage: 'Show clip previews in the chat window.'})}
-      />
+      <SettingCheckbox value={ChatFlags.SUB_NOTICE} name={SUB_NOTICE_NAME} description={SUB_NOTICE_DESCRIPTION} />
+      <SettingCheckbox value={ChatFlags.CHAT_CLIPS} name={CHAT_CLIPS_NAME} description={CHAT_CLIPS_DESCRIPTION} />
       <SettingCheckbox
         value={ChatFlags.COMMUNITY_HIGHLIGHTS}
-        name={formatMessage({defaultMessage: 'Community Highlights'})}
-        description={formatMessage({
-          defaultMessage: 'Show alerts above chat window for hype trains, drops, pinned messages, etc.',
-        })}
+        name={COMMUNITY_HIGHLIGHTS_NAME}
+        description={COMMUNITY_HIGHLIGHTS_DESCRIPTION}
       />
       <SettingCheckbox
         value={ChatFlags.CHAT_MESSAGE_HISTORY}
-        name={formatMessage({defaultMessage: 'Message History'})}
-        description={formatMessage({
-          defaultMessage: 'Restore what you previously typed by pressing up/down arrow in chat.',
-        })}
+        name={CHAT_MESSAGE_HISTORY_NAME}
+        description={CHAT_MESSAGE_HISTORY_DESCRIPTION}
       />
     </SettingCheckboxGroup>
   );
@@ -68,7 +69,18 @@ SettingStore.registerSetting(ChatModule, {
   settingPanelId: SettingPanelIds.CHAT,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['bits', 'highlights', 'community', 'chat', 'replies', 'clips', 'subs', 'subscriptions'],
 });
+
+for (const entry of [
+  {name: CHAT_REPLIES_NAME, description: CHAT_REPLIES_DESCRIPTION},
+  {name: BITS_NAME, description: BITS_DESCRIPTION},
+  {name: VIEWER_GREETING_NAME, description: VIEWER_GREETING_DESCRIPTION},
+  {name: SUB_NOTICE_NAME, description: SUB_NOTICE_DESCRIPTION},
+  {name: CHAT_CLIPS_NAME, description: CHAT_CLIPS_DESCRIPTION},
+  {name: COMMUNITY_HIGHLIGHTS_NAME, description: COMMUNITY_HIGHLIGHTS_DESCRIPTION},
+  {name: CHAT_MESSAGE_HISTORY_NAME, description: CHAT_MESSAGE_HISTORY_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.CHAT)});
+}
 
 export default ChatModule;

--- a/src/modules/settings/settings/twitch/ChatDirection.jsx
+++ b/src/modules/settings/settings/twitch/ChatDirection.jsx
@@ -4,9 +4,16 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Chat Direction'});
+
+const REVERSE_CHAT_DIRECTION_NAME = formatMessage({defaultMessage: 'Reverse Chat Direction'});
+const REVERSE_CHAT_DIRECTION_DESCRIPTION = formatMessage({
+  defaultMessage: 'Move new chat messages from top to bottom of chat.',
+});
 
 function ChatDirection({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.REVERSE_CHAT_DIRECTION);
@@ -14,8 +21,8 @@ function ChatDirection({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Reverse Chat Direction'})}
-        description={formatMessage({defaultMessage: 'Move new chat messages from top to bottom of chat.'})}
+        name={REVERSE_CHAT_DIRECTION_NAME}
+        description={REVERSE_CHAT_DIRECTION_DESCRIPTION}
         value={value}
         onChange={setValue}
       />
@@ -27,7 +34,12 @@ SettingStore.registerSetting(ChatDirection, {
   settingPanelId: SettingPanelIds.CHAT_DIRECTION,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['chat', 'direction', 'up', 'down', 'reverse'],
+});
+
+searchStore.registerSearchEntry({
+  name: REVERSE_CHAT_DIRECTION_NAME,
+  description: REVERSE_CHAT_DIRECTION_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.CHAT_DIRECTION),
 });
 
 export default ChatDirection;

--- a/src/modules/settings/settings/twitch/ChatLayout.jsx
+++ b/src/modules/settings/settings/twitch/ChatLayout.jsx
@@ -4,25 +4,25 @@ import {SettingIds, ChatLayoutTypes} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingRadio from '@/modules/settings/components/SettingRadio';
 import SettingRadioGroup from '@/modules/settings/components/SettingRadioGroup';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
+import {isStandaloneWindow} from '@/utils/window';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Chat Layout'});
+
+const RIGHT_NAME = formatMessage({defaultMessage: 'Right'});
+const RIGHT_DESCRIPTION = formatMessage({defaultMessage: 'Moves the chat to the right of the player.'});
+const LEFT_NAME = formatMessage({defaultMessage: 'Left'});
+const LEFT_DESCRIPTION = formatMessage({defaultMessage: 'Moves the chat to the left of the player.'});
 
 function ChatLayout({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.CHAT_LAYOUT);
 
   return (
     <SettingRadioGroup ref={ref} {...props} name={SETTING_NAME} value={value} onChange={setValue}>
-      <SettingRadio
-        optionValue={ChatLayoutTypes.RIGHT}
-        name={formatMessage({defaultMessage: 'Right'})}
-        description={formatMessage({defaultMessage: 'Moves the chat to the right of the player.'})}
-      />
-      <SettingRadio
-        optionValue={ChatLayoutTypes.LEFT}
-        name={formatMessage({defaultMessage: 'Left'})}
-        description={formatMessage({defaultMessage: 'Moves the chat to the left of the player.'})}
-      />
+      <SettingRadio optionValue={ChatLayoutTypes.RIGHT} name={RIGHT_NAME} description={RIGHT_DESCRIPTION} />
+      <SettingRadio optionValue={ChatLayoutTypes.LEFT} name={LEFT_NAME} description={LEFT_DESCRIPTION} />
     </SettingRadioGroup>
   );
 }
@@ -30,7 +30,17 @@ function ChatLayout({ref, ...props}) {
 SettingStore.registerSetting(ChatLayout, {
   settingPanelId: SettingPanelIds.CHAT_LAYOUT,
   name: SETTING_NAME,
-  keywords: ['chat', 'layout', 'position', 'placement', 'left', 'right'],
 });
+
+for (const entry of [
+  {name: RIGHT_NAME, description: RIGHT_DESCRIPTION},
+  {name: LEFT_NAME, description: LEFT_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({
+    ...entry,
+    goto: () => gotoSettingPanel(SettingPanelIds.CHAT_LAYOUT),
+    predicate: () => !isStandaloneWindow(),
+  });
+}
 
 export default ChatLayout;

--- a/src/modules/settings/settings/twitch/DeletedMessages.jsx
+++ b/src/modules/settings/settings/twitch/DeletedMessages.jsx
@@ -4,38 +4,37 @@ import {SettingIds, DeletedMessageTypes} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingRadio from '@/modules/settings/components/SettingRadio';
 import SettingRadioGroup from '@/modules/settings/components/SettingRadioGroup';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Deleted Messages'});
+
+const DEFAULT_NAME = formatMessage({defaultMessage: 'Default'});
+const DEFAULT_DESCRIPTION = formatMessage({defaultMessage: 'Do what Twitch normally does.'});
+const HIDE_NAME = formatMessage({defaultMessage: 'Hide Deleted Messages'});
+const HIDE_DESCRIPTION = formatMessage({defaultMessage: 'Remove timed out messages from view.'});
+const SHOW_NAME = formatMessage({defaultMessage: 'Restore Deleted Messages'});
+const SHOW_DESCRIPTION = formatMessage({
+  defaultMessage: "Changes '<'message deleted'>' back to users' original messages.",
+});
+const HIGHLIGHT_NAME = formatMessage({defaultMessage: 'Restore and Highlight Deleted Messages'});
+const HIGHLIGHT_DESCRIPTION = formatMessage({
+  defaultMessage: "Changes '<'message deleted'>' back to users' original messages and highlights them.",
+});
 
 function DeletedMessagesModule({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.DELETED_MESSAGES);
 
   return (
     <SettingRadioGroup ref={ref} {...props} name={SETTING_NAME} value={value} onChange={setValue}>
-      <SettingRadio
-        optionValue={DeletedMessageTypes.DEFAULT}
-        name={formatMessage({defaultMessage: 'Default'})}
-        description={formatMessage({defaultMessage: 'Do what Twitch normally does.'})}
-      />
-      <SettingRadio
-        optionValue={DeletedMessageTypes.HIDE}
-        name={formatMessage({defaultMessage: 'Hide Deleted Messages'})}
-        description={formatMessage({defaultMessage: 'Remove timed out messages from view.'})}
-      />
-      <SettingRadio
-        optionValue={DeletedMessageTypes.SHOW}
-        name={formatMessage({defaultMessage: 'Restore Deleted Messages'})}
-        description={formatMessage({
-          defaultMessage: "Changes '<'message deleted'>' back to users' original messages.",
-        })}
-      />
+      <SettingRadio optionValue={DeletedMessageTypes.DEFAULT} name={DEFAULT_NAME} description={DEFAULT_DESCRIPTION} />
+      <SettingRadio optionValue={DeletedMessageTypes.HIDE} name={HIDE_NAME} description={HIDE_DESCRIPTION} />
+      <SettingRadio optionValue={DeletedMessageTypes.SHOW} name={SHOW_NAME} description={SHOW_DESCRIPTION} />
       <SettingRadio
         optionValue={DeletedMessageTypes.HIGHLIGHT}
-        name={formatMessage({defaultMessage: 'Restore and Highlight Deleted Messages'})}
-        description={formatMessage({
-          defaultMessage: "Changes '<'message deleted'>' back to users' original messages and highlights them.",
-        })}
+        name={HIGHLIGHT_NAME}
+        description={HIGHLIGHT_DESCRIPTION}
       />
     </SettingRadioGroup>
   );
@@ -45,7 +44,14 @@ SettingStore.registerSetting(DeletedMessagesModule, {
   settingPanelId: SettingPanelIds.DELETED_MESSAGES,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['messages', 'deleted'],
 });
+
+for (const entry of [
+  {name: HIDE_NAME, description: HIDE_DESCRIPTION},
+  {name: SHOW_NAME, description: SHOW_DESCRIPTION},
+  {name: HIGHLIGHT_NAME, description: HIGHLIGHT_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.DELETED_MESSAGES)});
+}
 
 export default DeletedMessagesModule;

--- a/src/modules/settings/settings/twitch/Directory.jsx
+++ b/src/modules/settings/settings/twitch/Directory.jsx
@@ -4,21 +4,22 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
+import {isStandaloneWindow} from '@/utils/window';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Directory'});
+
+const LIVE_TAB_NAME = formatMessage({defaultMessage: 'Default to Live Tab'});
+const LIVE_TAB_DESCRIPTION = formatMessage({defaultMessage: 'Default to live tab on the following page.'});
 
 function ShowDirectoryLiveTab({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.SHOW_DIRECTORY_LIVE_TAB);
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
-      <SettingSwitch
-        name={formatMessage({defaultMessage: 'Default to Live Tab'})}
-        description={formatMessage({defaultMessage: 'Default to live tab on the following page.'})}
-        value={value}
-        onChange={setValue}
-      />
+      <SettingSwitch name={LIVE_TAB_NAME} description={LIVE_TAB_DESCRIPTION} value={value} onChange={setValue} />
     </SettingGroup>
   );
 }
@@ -26,7 +27,13 @@ function ShowDirectoryLiveTab({ref, ...props}) {
 SettingStore.registerSetting(ShowDirectoryLiveTab, {
   settingPanelId: SettingPanelIds.DIRECTORY,
   name: SETTING_NAME,
-  keywords: ['live', 'tab'],
+});
+
+searchStore.registerSearchEntry({
+  name: LIVE_TAB_NAME,
+  description: LIVE_TAB_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.DIRECTORY),
+  predicate: () => !isStandaloneWindow(),
 });
 
 export default ShowDirectoryLiveTab;

--- a/src/modules/settings/settings/twitch/EmoteMenu.jsx
+++ b/src/modules/settings/settings/twitch/EmoteMenu.jsx
@@ -6,9 +6,19 @@ import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingNumberInput from '@/modules/settings/components/SettingNumberInput';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Emote Menu'});
+const SETTING_DESCRIPTION = formatMessage({defaultMessage: 'Enables a more advanced emote menu for chat.'});
+
+const REPLACE_NATIVE_NAME = formatMessage({defaultMessage: 'Replace Native'});
+const REPLACE_NATIVE_DESCRIPTION = formatMessage({defaultMessage: "Replace Twitch's native emote menu."});
+const MAX_WIDTH_NAME = formatMessage({defaultMessage: 'Max Width'});
+const MAX_WIDTH_DESCRIPTION = formatMessage({
+  defaultMessage: 'Maximum width of the emote menu, measured in pixels.',
+});
 
 function EmoteMenu({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.EMOTE_MENU);
@@ -18,22 +28,22 @@ function EmoteMenu({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Emote Menu'})}
-        description={formatMessage({defaultMessage: 'Enables a more advanced emote menu for chat.'})}
+        name={SETTING_NAME}
+        description={SETTING_DESCRIPTION}
         value={toggled}
         onChange={(state) => setValue(state ? EmoteMenuTypes.ENABLED : EmoteMenuTypes.NONE)}
       />
       <SettingSwitch
         disabled={!toggled}
-        name={formatMessage({defaultMessage: 'Replace Native'})}
-        description={formatMessage({defaultMessage: "Replace Twitch's native emote menu."})}
+        name={REPLACE_NATIVE_NAME}
+        description={REPLACE_NATIVE_DESCRIPTION}
         value={value === EmoteMenuTypes.ENABLED}
         onChange={(state) => setValue(state ? EmoteMenuTypes.ENABLED : EmoteMenuTypes.LEGACY_ENABLED)}
       />
       <SettingNumberInput
         disabled={!toggled}
-        name={formatMessage({defaultMessage: 'Max Width'})}
-        description={formatMessage({defaultMessage: 'Maximum width of the emote menu, measured in pixels.'})}
+        name={MAX_WIDTH_NAME}
+        description={MAX_WIDTH_DESCRIPTION}
         value={width}
         onChange={setWidth}
         placeholder={SettingDefaultValues[SettingIds.EMOTE_MENU_WIDTH]}
@@ -47,7 +57,14 @@ SettingStore.registerSetting(EmoteMenu, {
   settingPanelId: SettingPanelIds.EMOTE_MENU,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['emotes', 'popup'],
 });
+
+for (const entry of [
+  {name: SETTING_NAME, description: SETTING_DESCRIPTION},
+  {name: REPLACE_NATIVE_NAME, description: REPLACE_NATIVE_DESCRIPTION},
+  {name: MAX_WIDTH_NAME, description: MAX_WIDTH_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.EMOTE_MENU)});
+}
 
 export default EmoteMenu;

--- a/src/modules/settings/settings/twitch/Highlights.jsx
+++ b/src/modules/settings/settings/twitch/Highlights.jsx
@@ -8,9 +8,34 @@ import SettingNumberInput from '@/modules/settings/components/SettingNumberInput
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
 import SettingWrapper from '@/modules/settings/components/SettingWrapper';
 import {PageContext} from '@/modules/settings/contexts/PageContext';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Highlights'});
+
+const HIGHLIGHT_KEYWORDS_NAME = formatMessage({defaultMessage: 'Highlight Keywords'});
+const HIGHLIGHT_KEYWORDS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Highlight certain words, phrases or users in your chat.',
+});
+const PINNED_HIGHLIGHTS_NAME = formatMessage({defaultMessage: 'Pinned Highlights'});
+const PINNED_HIGHLIGHTS_DESCRIPTION = formatMessage({defaultMessage: 'Pin your highlighted messages above chat.'});
+const EXPIRE_PINNED_HIGHLIGHTS_NAME = formatMessage({defaultMessage: 'Expire Pinned Highlights'});
+const EXPIRE_PINNED_HIGHLIGHTS_DESCRIPTION = formatMessage({defaultMessage: 'Hide pinned highlights after 1 minute.'});
+const MAX_PINNED_HIGHLIGHTS_NAME = formatMessage({defaultMessage: 'Maximum Pinned highlights'});
+const MAX_PINNED_HIGHLIGHTS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Number of pinned highlights that can be displayed.',
+});
+const HIGHLIGHT_FEEDBACK_NAME = formatMessage({defaultMessage: 'Play A Sound'});
+const HIGHLIGHT_FEEDBACK_DESCRIPTION = formatMessage({defaultMessage: 'Play a sound for messages directed at you.'});
+const FIRST_TIME_CHATTERS_NAME = formatMessage({defaultMessage: 'Highlight First-Time Chatters'});
+const FIRST_TIME_CHATTERS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Highlight messages from viewers chatting in the channel for the first time.',
+});
+const HIGHLIGHT_DELETED_MESSAGES_NAME = formatMessage({defaultMessage: 'Highlight Deleted Messages'});
+const HIGHLIGHT_DELETED_MESSAGES_DESCRIPTION = formatMessage({
+  defaultMessage: 'Highlight and prevent deletion of messages.',
+});
 
 function Highlights({ref, ...props}) {
   const {setPage} = use(PageContext);
@@ -25,32 +50,29 @@ function Highlights({ref, ...props}) {
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
-      <SettingWrapper
-        name={formatMessage({defaultMessage: 'Highlight Keywords'})}
-        reverse
-        description={formatMessage({defaultMessage: 'Highlight certain words, phrases or users in your chat.'})}>
+      <SettingWrapper name={HIGHLIGHT_KEYWORDS_NAME} reverse description={HIGHLIGHT_KEYWORDS_DESCRIPTION}>
         <Button size="lg" onClick={() => setPage(PageTypes.HIGHLIGHT_KEYWORDS)}>
           {formatMessage({defaultMessage: 'Edit'})}
         </Button>
       </SettingWrapper>
       <SettingSwitch
         reverse
-        name={formatMessage({defaultMessage: 'Pinned Highlights'})}
-        description={formatMessage({defaultMessage: 'Pin your highlighted messages above chat.'})}
+        name={PINNED_HIGHLIGHTS_NAME}
+        description={PINNED_HIGHLIGHTS_DESCRIPTION}
         value={value}
         onChange={setValue}
       />
       <SettingSwitch
         reverse
-        name={formatMessage({defaultMessage: 'Expire Pinned Highlights'})}
-        description={formatMessage({defaultMessage: 'Hide pinned highlights after 1 minute.'})}
+        name={EXPIRE_PINNED_HIGHLIGHTS_NAME}
+        description={EXPIRE_PINNED_HIGHLIGHTS_DESCRIPTION}
         value={timeoutHighlightsValue}
         onChange={setTimeoutHighlightsValue}
         disabled={!value}
       />
       <SettingNumberInput
-        name={formatMessage({defaultMessage: 'Maximum Pinned highlights'})}
-        description={formatMessage({defaultMessage: 'Number of pinned highlights that can be displayed.'})}
+        name={MAX_PINNED_HIGHLIGHTS_NAME}
+        description={MAX_PINNED_HIGHLIGHTS_DESCRIPTION}
         value={maxPinnedHighlights}
         onChange={setMaxPinnedHighlights}
         min={1}
@@ -59,24 +81,22 @@ function Highlights({ref, ...props}) {
       />
       <SettingSwitch
         reverse
-        name={formatMessage({defaultMessage: 'Play A Sound'})}
-        description={formatMessage({defaultMessage: 'Play a sound for messages directed at you.'})}
+        name={HIGHLIGHT_FEEDBACK_NAME}
+        description={HIGHLIGHT_FEEDBACK_DESCRIPTION}
         value={highlightFeedback}
         onChange={setHighlightFeedback}
       />
       <SettingSwitch
         reverse
-        name={formatMessage({defaultMessage: 'Highlight First-Time Chatters'})}
-        description={formatMessage({
-          defaultMessage: 'Highlight messages from viewers chatting in the channel for the first time.',
-        })}
+        name={FIRST_TIME_CHATTERS_NAME}
+        description={FIRST_TIME_CHATTERS_DESCRIPTION}
         value={highlightFirstTimeChatters}
         onChange={setHighlightFirstTimeChatters}
       />
       <SettingSwitch
         reverse
-        name={formatMessage({defaultMessage: 'Highlight Deleted Messages'})}
-        description={formatMessage({defaultMessage: 'Highlight and prevent deletion of messages.'})}
+        name={HIGHLIGHT_DELETED_MESSAGES_NAME}
+        description={HIGHLIGHT_DELETED_MESSAGES_DESCRIPTION}
         value={deletedMessages === DeletedMessageTypes.HIGHLIGHT}
         onChange={(value) => setDeletedMessages(value ? DeletedMessageTypes.HIGHLIGHT : DeletedMessageTypes.DEFAULT)}
       />
@@ -88,7 +108,18 @@ SettingStore.registerSetting(Highlights, {
   settingPanelId: SettingPanelIds.HIGHLIGHTS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['pinned', 'highlights', 'highlight', 'feedback', 'keywords', 'first', 'chatter', 'first-time'],
 });
+
+for (const entry of [
+  {name: HIGHLIGHT_KEYWORDS_NAME, description: HIGHLIGHT_KEYWORDS_DESCRIPTION},
+  {name: PINNED_HIGHLIGHTS_NAME, description: PINNED_HIGHLIGHTS_DESCRIPTION},
+  {name: EXPIRE_PINNED_HIGHLIGHTS_NAME, description: EXPIRE_PINNED_HIGHLIGHTS_DESCRIPTION},
+  {name: MAX_PINNED_HIGHLIGHTS_NAME, description: MAX_PINNED_HIGHLIGHTS_DESCRIPTION},
+  {name: HIGHLIGHT_FEEDBACK_NAME, description: HIGHLIGHT_FEEDBACK_DESCRIPTION},
+  {name: FIRST_TIME_CHATTERS_NAME, description: FIRST_TIME_CHATTERS_DESCRIPTION},
+  {name: HIGHLIGHT_DELETED_MESSAGES_NAME, description: HIGHLIGHT_DELETED_MESSAGES_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.HIGHLIGHTS)});
+}
 
 export default Highlights;

--- a/src/modules/settings/settings/twitch/Moderation.jsx
+++ b/src/modules/settings/settings/twitch/Moderation.jsx
@@ -4,9 +4,15 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
+import {isStandaloneWindow} from '@/utils/window';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Moderation'});
+
+const AUTO_MOD_VIEW_NAME = formatMessage({defaultMessage: 'Auto Mod View'});
+const AUTO_MOD_VIEW_DESCRIPTION = formatMessage({defaultMessage: 'Enter moderation view when possible.'});
 
 function Moderation({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.AUTO_MOD_VIEW);
@@ -14,10 +20,8 @@ function Moderation({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Auto Mod View'})}
-        description={formatMessage({
-          defaultMessage: 'Enter moderation view when possible.',
-        })}
+        name={AUTO_MOD_VIEW_NAME}
+        description={AUTO_MOD_VIEW_DESCRIPTION}
         value={value}
         onChange={setValue}
       />
@@ -28,7 +32,13 @@ function Moderation({ref, ...props}) {
 SettingStore.registerSetting(Moderation, {
   settingPanelId: SettingPanelIds.MODERATION,
   name: SETTING_NAME,
-  keywords: ['auto', 'mod', 'view'],
+});
+
+searchStore.registerSearchEntry({
+  name: AUTO_MOD_VIEW_NAME,
+  description: AUTO_MOD_VIEW_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.MODERATION),
+  predicate: () => !isStandaloneWindow(),
 });
 
 export default Moderation;

--- a/src/modules/settings/settings/twitch/Player.jsx
+++ b/src/modules/settings/settings/twitch/Player.jsx
@@ -4,9 +4,29 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
+import {isStandaloneWindow} from '@/utils/window';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Player'});
+
+const CLICK_TO_PLAY_NAME = formatMessage({defaultMessage: 'Click to Play'});
+const CLICK_TO_PLAY_DESCRIPTION = formatMessage({defaultMessage: 'Clicking the player will pause/resume playback.'});
+const MUTE_INVISIBLE_PLAYER_NAME = formatMessage({defaultMessage: 'Mute Invisible Player'});
+const MUTE_INVISIBLE_PLAYER_DESCRIPTION = formatMessage({
+  defaultMessage: 'Toggle sound when you change browser tab or window.',
+});
+const PLAYER_EXTENSIONS_NAME = formatMessage({defaultMessage: 'Player Extensions'});
+const PLAYER_EXTENSIONS_DESCRIPTION = formatMessage({
+  defaultMessage: "Show the interactive overlays on top of Twitch's video player.",
+});
+const SCROLL_PLAYER_CONTROLS_NAME = formatMessage({defaultMessage: 'Scroll Player Controls'});
+const SCROLL_PLAYER_CONTROLS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Enable scrolling to change the player volume. Hold ALT when scrolling to seek.',
+});
+const AUTO_THEATRE_MODE_NAME = formatMessage({defaultMessage: 'Auto Theatre Mode'});
+const AUTO_THEATRE_MODE_DESCRIPTION = formatMessage({defaultMessage: 'Enable theatre mode when possible.'});
 
 function Player({ref, ...props}) {
   const [clickToPlay, setClickToPlay] = useStorageState(SettingIds.CLICK_TO_PLAY);
@@ -18,36 +38,32 @@ function Player({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Click to Play'})}
-        description={formatMessage({defaultMessage: 'Clicking the player will pause/resume playback.'})}
+        name={CLICK_TO_PLAY_NAME}
+        description={CLICK_TO_PLAY_DESCRIPTION}
         value={clickToPlay}
         onChange={setClickToPlay}
       />
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Mute Invisible Player'})}
-        description={formatMessage({
-          defaultMessage: 'Toggle sound when you change browser tab or window.',
-        })}
+        name={MUTE_INVISIBLE_PLAYER_NAME}
+        description={MUTE_INVISIBLE_PLAYER_DESCRIPTION}
         value={muteInvisiblePlayer}
         onChange={setMuteInvisiblePlayer}
       />
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Player Extensions'})}
-        description={formatMessage({defaultMessage: "Show the interactive overlays on top of Twitch's video player."})}
+        name={PLAYER_EXTENSIONS_NAME}
+        description={PLAYER_EXTENSIONS_DESCRIPTION}
         value={playerExtensions}
         onChange={setPlayerExtensions}
       />
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Scroll Player Controls'})}
-        description={formatMessage({
-          defaultMessage: 'Enable scrolling to change the player volume. Hold ALT when scrolling to seek.',
-        })}
+        name={SCROLL_PLAYER_CONTROLS_NAME}
+        description={SCROLL_PLAYER_CONTROLS_DESCRIPTION}
         value={scrollPlayerControls}
         onChange={setScrollPlayerControls}
       />
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Auto Theatre Mode'})}
-        description={formatMessage({defaultMessage: 'Enable theatre mode when possible.'})}
+        name={AUTO_THEATRE_MODE_NAME}
+        description={AUTO_THEATRE_MODE_DESCRIPTION}
         value={autoTheatreMode}
         onChange={setAutoTheatreMode}
       />
@@ -58,23 +74,20 @@ function Player({ref, ...props}) {
 SettingStore.registerSetting(Player, {
   settingPanelId: SettingPanelIds.PLAYER,
   name: SETTING_NAME,
-  keywords: [
-    'click',
-    'play',
-    'mute',
-    'invisible',
-    'player',
-    'video',
-    'extensions',
-    'addons',
-    'volume',
-    'seek',
-    'control',
-    'scroll',
-    'auto',
-    'theatre',
-    'mode',
-  ],
 });
+
+for (const entry of [
+  {name: CLICK_TO_PLAY_NAME, description: CLICK_TO_PLAY_DESCRIPTION},
+  {name: MUTE_INVISIBLE_PLAYER_NAME, description: MUTE_INVISIBLE_PLAYER_DESCRIPTION},
+  {name: PLAYER_EXTENSIONS_NAME, description: PLAYER_EXTENSIONS_DESCRIPTION},
+  {name: SCROLL_PLAYER_CONTROLS_NAME, description: SCROLL_PLAYER_CONTROLS_DESCRIPTION},
+  {name: AUTO_THEATRE_MODE_NAME, description: AUTO_THEATRE_MODE_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({
+    ...entry,
+    goto: () => gotoSettingPanel(SettingPanelIds.PLAYER),
+    predicate: () => !isStandaloneWindow(),
+  });
+}
 
 export default Player;

--- a/src/modules/settings/settings/twitch/PrimeGaming.jsx
+++ b/src/modules/settings/settings/twitch/PrimeGaming.jsx
@@ -4,9 +4,17 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
+import {isStandaloneWindow} from '@/utils/window';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Prime Gaming'});
+
+const PRIME_PROMOTIONS_NAME = formatMessage({defaultMessage: 'Prime Promotions'});
+const PRIME_PROMOTIONS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Show Prime Gaming loot notices, like the ones in the sidebar.',
+});
 
 function PrimeGaming({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.PRIME_PROMOTIONS);
@@ -14,8 +22,8 @@ function PrimeGaming({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Prime Promotions'})}
-        description={formatMessage({defaultMessage: 'Show Prime Gaming loot notices, like the ones in the sidebar.'})}
+        name={PRIME_PROMOTIONS_NAME}
+        description={PRIME_PROMOTIONS_DESCRIPTION}
         value={value}
         onChange={setValue}
       />
@@ -26,7 +34,13 @@ function PrimeGaming({ref, ...props}) {
 SettingStore.registerSetting(PrimeGaming, {
   settingPanelId: SettingPanelIds.PRIME_GAMING,
   name: SETTING_NAME,
-  keywords: ['ad', 'prime', 'promotions', 'block', 'gaming'],
+});
+
+searchStore.registerSearchEntry({
+  name: PRIME_PROMOTIONS_NAME,
+  description: PRIME_PROMOTIONS_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.PRIME_GAMING),
+  predicate: () => !isStandaloneWindow(),
 });
 
 export default PrimeGaming;

--- a/src/modules/settings/settings/twitch/Raids.jsx
+++ b/src/modules/settings/settings/twitch/Raids.jsx
@@ -5,9 +5,23 @@ import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
 import SettingTagInput from '@/modules/settings/components/SettingTagInput';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Raids'});
+
+const AUTO_JOIN_NAME = formatMessage({defaultMessage: 'Auto Join'});
+const AUTO_JOIN_DESCRIPTION = formatMessage({defaultMessage: 'Join raids when possible.'});
+
+const WHITELIST_CHANNELS_NAME = formatMessage({defaultMessage: 'Whitelist Channels'});
+const WHITELIST_CHANNELS_DESCRIPTION = formatMessage({
+  defaultMessage: 'List of channels that disable auto joining raids.',
+});
+const BLACKLIST_CHANNELS_NAME = formatMessage({defaultMessage: 'Blacklist Channels'});
+const BLACKLIST_CHANNELS_DESCRIPTION = formatMessage({
+  defaultMessage: 'List of channels that enable auto joining raids.',
+});
 
 function AutoJoinRaids({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.AUTO_JOIN_RAIDS);
@@ -17,23 +31,10 @@ function AutoJoinRaids({ref, ...props}) {
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
-      <SettingSwitch
-        name={formatMessage({defaultMessage: 'Auto Join'})}
-        description={formatMessage({defaultMessage: 'Join raids when possible.'})}
-        value={value}
-        onChange={setValue}
-      />
+      <SettingSwitch name={AUTO_JOIN_NAME} description={AUTO_JOIN_DESCRIPTION} value={value} onChange={setValue} />
       <SettingTagInput
-        name={
-          value
-            ? formatMessage({defaultMessage: 'Whitelist Channels'})
-            : formatMessage({defaultMessage: 'Blacklist Channels'})
-        }
-        description={
-          value
-            ? formatMessage({defaultMessage: 'List of channels that disable auto joining raids.'})
-            : formatMessage({defaultMessage: 'List of channels that enable auto joining raids.'})
-        }
+        name={value ? WHITELIST_CHANNELS_NAME : BLACKLIST_CHANNELS_NAME}
+        description={value ? WHITELIST_CHANNELS_DESCRIPTION : BLACKLIST_CHANNELS_DESCRIPTION}
         value={channels}
         onChange={setChannels}
         withCurrentChannel
@@ -47,7 +48,12 @@ SettingStore.registerSetting(AutoJoinRaids, {
   settingPanelId: SettingPanelIds.RAIDS,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['auto', 'join', 'raids'],
+});
+
+searchStore.registerSearchEntry({
+  name: AUTO_JOIN_NAME,
+  description: AUTO_JOIN_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.RAIDS),
 });
 
 export default AutoJoinRaids;

--- a/src/modules/settings/settings/twitch/SelfBot.jsx
+++ b/src/modules/settings/settings/twitch/SelfBot.jsx
@@ -10,10 +10,20 @@ import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
 import SettingWrapper from '@/modules/settings/components/SettingWrapper';
 import {PageContext} from '@/modules/settings/contexts/PageContext';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 import useAuthStore from '@/stores/auth';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Self Bot'});
+const SETTING_DESCRIPTION = formatMessage({
+  defaultMessage: 'Automatically send and reply to messages on your own channel.',
+});
+
+const COMMANDS_NAME = formatMessage({defaultMessage: 'Commands'});
+const COMMANDS_DESCRIPTION = formatMessage({defaultMessage: 'Configure command triggers and responses.'});
+const TIMERS_NAME = formatMessage({defaultMessage: 'Timers'});
+const TIMERS_DESCRIPTION = formatMessage({defaultMessage: 'Automatically send messages at specific times.'});
 
 function openEnableSelfBotModal(setEnabled) {
   openConfirmModal({
@@ -59,25 +69,18 @@ function SelfBot({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Self Bot'})}
-        description={formatMessage({defaultMessage: 'Automatically send and reply to messages on your own channel.'})}
+        name={SETTING_NAME}
+        description={SETTING_DESCRIPTION}
         showBetaBadge
         value={displayEnabled}
         onChange={handleEnabledChange}
       />
-      <SettingWrapper
-        name={formatMessage({defaultMessage: 'Commands'})}
-        reverse
-        description={formatMessage({defaultMessage: 'Configure command triggers and responses.'})}>
+      <SettingWrapper name={COMMANDS_NAME} reverse description={COMMANDS_DESCRIPTION}>
         <Button size="lg" onClick={() => setPage(PageTypes.SELF_BOT_COMMANDS)}>
           {formatMessage({defaultMessage: 'Edit'})}
         </Button>
       </SettingWrapper>
-      <SettingWrapper
-        name={formatMessage({defaultMessage: 'Timers'})}
-        reverse
-        showComingSoonBadge
-        description={formatMessage({defaultMessage: 'Automatically send messages at specific times.'})}>
+      <SettingWrapper name={TIMERS_NAME} reverse showComingSoonBadge description={TIMERS_DESCRIPTION}>
         <Button disabled size="lg">
           {formatMessage({defaultMessage: 'Edit'})}
         </Button>
@@ -90,7 +93,14 @@ SettingStore.registerSetting(SelfBot, {
   settingPanelId: SettingPanelIds.SELF_BOT,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['self', 'bot', 'commands', 'reply', 'automatic', 'timers'],
 });
+
+for (const entry of [
+  {name: SETTING_NAME, description: SETTING_DESCRIPTION},
+  {name: COMMANDS_NAME, description: COMMANDS_DESCRIPTION},
+  {name: TIMERS_NAME, description: TIMERS_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.SELF_BOT)});
+}
 
 export default SelfBot;

--- a/src/modules/settings/settings/twitch/Sidebar.jsx
+++ b/src/modules/settings/settings/twitch/Sidebar.jsx
@@ -4,9 +4,35 @@ import {SettingIds, SidebarFlags} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingCheckbox from '@/modules/settings/components/SettingCheckbox';
 import SettingCheckboxGroup from '@/modules/settings/components/SettingCheckboxGroup';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
+import {isStandaloneWindow} from '@/utils/window';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Sidebar'});
+
+const RECENTLY_WATCHED_CHANNELS_NAME = formatMessage({defaultMessage: 'Recently Watched Channels'});
+const RECENTLY_WATCHED_CHANNELS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Show recently watched channels in the sidebar.',
+});
+const RECOMMENDED_CHANNELS_NAME = formatMessage({defaultMessage: 'Recommended Channels'});
+const RECOMMENDED_CHANNELS_DESCRIPTION = formatMessage({defaultMessage: 'Show recommended channels in the sidebar.'});
+const RECOMMENDED_CATEGORIES_NAME = formatMessage({defaultMessage: 'Recommended Categories'});
+const RECOMMENDED_CATEGORIES_DESCRIPTION = formatMessage({
+  defaultMessage: 'Show recommended categories in the sidebar.',
+});
+const SIMILAR_CHANNELS_NAME = formatMessage({defaultMessage: 'Similar Channels'});
+const SIMILAR_CHANNELS_DESCRIPTION = formatMessage({defaultMessage: 'Show similar channels in the sidebar.'});
+const OFFLINE_FOLLOWED_CHANNELS_NAME = formatMessage({defaultMessage: 'Offline Followed Channels'});
+const OFFLINE_FOLLOWED_CHANNELS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Show offline followed channels in the sidebar.',
+});
+const AUTO_EXPAND_CHANNELS_NAME = formatMessage({defaultMessage: 'Auto-Expand Channels'});
+const AUTO_EXPAND_CHANNELS_DESCRIPTION = formatMessage({
+  defaultMessage: 'Clicks the Load More followed channels button in the sidebar for you.',
+});
+const STORIES_NAME = formatMessage({defaultMessage: 'Stories'});
+const STORIES_DESCRIPTION = formatMessage({defaultMessage: 'Show stories in the sidebar.'});
 
 function SidebarComponent({ref, ...props}) {
   const [sidebar, setSidebar] = useStorageState(SettingIds.SIDEBAR);
@@ -21,41 +47,35 @@ function SidebarComponent({ref, ...props}) {
       flags={Object.values(SidebarFlags)}>
       <SettingCheckbox
         value={SidebarFlags.RECENTLY_WATCHED_CHANNELS}
-        name={formatMessage({defaultMessage: 'Recently Watched Channels'})}
-        description={formatMessage({defaultMessage: 'Show recently watched channels in the sidebar.'})}
+        name={RECENTLY_WATCHED_CHANNELS_NAME}
+        description={RECENTLY_WATCHED_CHANNELS_DESCRIPTION}
       />
       <SettingCheckbox
         value={SidebarFlags.RECOMMENDED_CHANNELS}
-        name={formatMessage({defaultMessage: 'Recommended Channels'})}
-        description={formatMessage({defaultMessage: 'Show recommended channels in the sidebar.'})}
+        name={RECOMMENDED_CHANNELS_NAME}
+        description={RECOMMENDED_CHANNELS_DESCRIPTION}
       />
       <SettingCheckbox
         value={SidebarFlags.RECOMMENDED_CATEGORIES}
-        name={formatMessage({defaultMessage: 'Recommended Categories'})}
-        description={formatMessage({defaultMessage: 'Show recommended categories in the sidebar.'})}
+        name={RECOMMENDED_CATEGORIES_NAME}
+        description={RECOMMENDED_CATEGORIES_DESCRIPTION}
       />
       <SettingCheckbox
         value={SidebarFlags.SIMILAR_CHANNELS}
-        name={formatMessage({defaultMessage: 'Similar Channels'})}
-        description={formatMessage({defaultMessage: 'Show similar channels in the sidebar.'})}
+        name={SIMILAR_CHANNELS_NAME}
+        description={SIMILAR_CHANNELS_DESCRIPTION}
       />
       <SettingCheckbox
         value={SidebarFlags.OFFLINE_FOLLOWED_CHANNELS}
-        name={formatMessage({defaultMessage: 'Offline Followed Channels'})}
-        description={formatMessage({defaultMessage: 'Show offline followed channels in the sidebar.'})}
+        name={OFFLINE_FOLLOWED_CHANNELS_NAME}
+        description={OFFLINE_FOLLOWED_CHANNELS_DESCRIPTION}
       />
       <SettingCheckbox
         value={SidebarFlags.AUTO_EXPAND_CHANNELS}
-        name={formatMessage({defaultMessage: 'Auto-Expand Channels'})}
-        description={formatMessage({
-          defaultMessage: 'Clicks the Load More followed channels button in the sidebar for you.',
-        })}
+        name={AUTO_EXPAND_CHANNELS_NAME}
+        description={AUTO_EXPAND_CHANNELS_DESCRIPTION}
       />
-      <SettingCheckbox
-        value={SidebarFlags.STORIES}
-        name={formatMessage({defaultMessage: 'Stories'})}
-        description={formatMessage({defaultMessage: 'Show stories in the sidebar.'})}
-      />
+      <SettingCheckbox value={SidebarFlags.STORIES} name={STORIES_NAME} description={STORIES_DESCRIPTION} />
     </SettingCheckboxGroup>
   );
 }
@@ -63,18 +83,22 @@ function SidebarComponent({ref, ...props}) {
 SettingStore.registerSetting(SidebarComponent, {
   settingPanelId: SettingPanelIds.SIDEBAR,
   name: SETTING_NAME,
-  keywords: [
-    'sidebar',
-    'recently',
-    'watched',
-    'recommended',
-    'similar',
-    'offline',
-    'categories',
-    'channels',
-    'expand',
-    'stories',
-  ],
 });
+
+for (const entry of [
+  {name: RECENTLY_WATCHED_CHANNELS_NAME, description: RECENTLY_WATCHED_CHANNELS_DESCRIPTION},
+  {name: RECOMMENDED_CHANNELS_NAME, description: RECOMMENDED_CHANNELS_DESCRIPTION},
+  {name: RECOMMENDED_CATEGORIES_NAME, description: RECOMMENDED_CATEGORIES_DESCRIPTION},
+  {name: SIMILAR_CHANNELS_NAME, description: SIMILAR_CHANNELS_DESCRIPTION},
+  {name: OFFLINE_FOLLOWED_CHANNELS_NAME, description: OFFLINE_FOLLOWED_CHANNELS_DESCRIPTION},
+  {name: AUTO_EXPAND_CHANNELS_NAME, description: AUTO_EXPAND_CHANNELS_DESCRIPTION},
+  {name: STORIES_NAME, description: STORIES_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({
+    ...entry,
+    goto: () => gotoSettingPanel(SettingPanelIds.SIDEBAR),
+    predicate: () => !isStandaloneWindow(),
+  });
+}
 
 export default SidebarComponent;

--- a/src/modules/settings/settings/twitch/SplitChat.jsx
+++ b/src/modules/settings/settings/twitch/SplitChat.jsx
@@ -5,10 +5,20 @@ import formatMessage from '@/i18n/index';
 import SettingColorPicker from '@/modules/settings/components/SettingColorPicker';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 import SplitChatModule from '@/modules/split_chat/index';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Split Chat'});
+const SETTING_DESCRIPTION = formatMessage({
+  defaultMessage: 'Alternate backgrounds between messages in chat to improve readability.',
+});
+
+const ALTERNATE_BACKGROUND_COLOR_NAME = formatMessage({defaultMessage: 'Alternate Background Color'});
+const ALTERNATE_BACKGROUND_COLOR_DESCRIPTION = formatMessage({
+  defaultMessage: 'The color of the alternate background.',
+});
 
 function SplitChat({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.SPLIT_CHAT);
@@ -25,21 +35,11 @@ function SplitChat({ref, ...props}) {
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
-      <SettingSwitch
-        name={SETTING_NAME}
-        reverse
-        description={formatMessage({
-          defaultMessage: 'Alternate backgrounds between messages in chat to improve readability.',
-        })}
-        value={value}
-        onChange={setValue}
-      />
+      <SettingSwitch name={SETTING_NAME} reverse description={SETTING_DESCRIPTION} value={value} onChange={setValue} />
       <SettingColorPicker
         reverse
-        name={formatMessage({defaultMessage: 'Alternate Background Color'})}
-        description={formatMessage({
-          defaultMessage: 'The color of the alternate background.',
-        })}
+        name={ALTERNATE_BACKGROUND_COLOR_NAME}
+        description={ALTERNATE_BACKGROUND_COLOR_DESCRIPTION}
         value={colorValue}
         defaultValue={defaultColor}
         onChange={handleColorChange}
@@ -52,7 +52,13 @@ SettingStore.registerSetting(SplitChat, {
   settingPanelId: SettingPanelIds.SPLIT_CHAT,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['split', 'chat'],
 });
+
+for (const entry of [
+  {name: SETTING_NAME, description: SETTING_DESCRIPTION},
+  {name: ALTERNATE_BACKGROUND_COLOR_NAME, description: ALTERNATE_BACKGROUND_COLOR_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.SPLIT_CHAT)});
+}
 
 export default SplitChat;

--- a/src/modules/settings/settings/twitch/TabCompletion.jsx
+++ b/src/modules/settings/settings/twitch/TabCompletion.jsx
@@ -4,9 +4,16 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Tab Completion'});
+
+const PRIORITIZE_EMOTES_NAME = formatMessage({defaultMessage: 'Prioritize Emotes'});
+const PRIORITIZE_EMOTES_DESCRIPTION = formatMessage({
+  defaultMessage: 'Prefer emotes over usernames when using tab completion.',
+});
 
 function TabCompletion({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.TAB_COMPLETION_EMOTE_PRIORITY);
@@ -14,8 +21,8 @@ function TabCompletion({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Prioritize Emotes'})}
-        description={formatMessage({defaultMessage: 'Prefer emotes over usernames when using tab completion.'})}
+        name={PRIORITIZE_EMOTES_NAME}
+        description={PRIORITIZE_EMOTES_DESCRIPTION}
         value={value}
         onChange={setValue}
       />
@@ -27,7 +34,12 @@ SettingStore.registerSetting(TabCompletion, {
   settingPanelId: SettingPanelIds.TAB_COMPLETION,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['tab', 'completion', 'emote', 'priority'],
+});
+
+searchStore.registerSearchEntry({
+  name: PRIORITIZE_EMOTES_NAME,
+  description: PRIORITIZE_EMOTES_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.TAB_COMPLETION),
 });
 
 export default TabCompletion;

--- a/src/modules/settings/settings/twitch/Theme.jsx
+++ b/src/modules/settings/settings/twitch/Theme.jsx
@@ -6,9 +6,20 @@ import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingPrimaryColorRadio from '@/modules/settings/components/SettingPrimaryColorRadio';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Theme'});
+
+const DARK_THEME_NAME = formatMessage({defaultMessage: 'Dark theme'});
+const DARK_THEME_DESCRIPTION = formatMessage({defaultMessage: 'Use a dark color scheme.'});
+const AUTO_THEME_NAME = formatMessage({defaultMessage: 'Auto theme'});
+const AUTO_THEME_DESCRIPTION = formatMessage({
+  defaultMessage: "Automatically set dark theme from your system's theme.",
+});
+const ACCENT_COLOR_NAME = formatMessage({defaultMessage: 'Accent Color'});
+const ACCENT_COLOR_DESCRIPTION = formatMessage({defaultMessage: 'The primary accent color of the theme.'});
 
 function Theme({ref, ...props}) {
   const [darkThemeValue, setDarkThemeValue] = useStorageState(SettingIds.DARKENED_MODE);
@@ -24,17 +35,15 @@ function Theme({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Dark theme'})}
-        description={formatMessage({defaultMessage: 'Use a dark color scheme.'})}
+        name={DARK_THEME_NAME}
+        description={DARK_THEME_DESCRIPTION}
         value={darkThemeValue}
         onChange={setDarkThemeValue}
         disabled={autoThemeValue}
       />
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Auto theme'})}
-        description={formatMessage({
-          defaultMessage: "Automatically set dark theme from your system's theme.",
-        })}
+        name={AUTO_THEME_NAME}
+        description={AUTO_THEME_DESCRIPTION}
         value={autoThemeValue}
         onChange={setAutoThemeValue}
       />
@@ -42,8 +51,8 @@ function Theme({ref, ...props}) {
         showProBadge
         value={normalizedThemeColorValue}
         onChange={setNormalizedThemeColorValue}
-        name={formatMessage({defaultMessage: 'Accent Color'})}
-        description={formatMessage({defaultMessage: 'The primary accent color of the theme.'})}
+        name={ACCENT_COLOR_NAME}
+        description={ACCENT_COLOR_DESCRIPTION}
       />
     </SettingGroup>
   );
@@ -53,7 +62,14 @@ SettingStore.registerSetting(Theme, {
   settingPanelId: SettingPanelIds.THEME,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['dark', 'mode', 'light', 'theme', 'white', 'black'],
 });
+
+for (const entry of [
+  {name: DARK_THEME_NAME, description: DARK_THEME_DESCRIPTION},
+  {name: AUTO_THEME_NAME, description: AUTO_THEME_DESCRIPTION},
+  {name: ACCENT_COLOR_NAME, description: ACCENT_COLOR_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.THEME)});
+}
 
 export default Theme;

--- a/src/modules/settings/settings/twitch/Usernames.jsx
+++ b/src/modules/settings/settings/twitch/Usernames.jsx
@@ -4,9 +4,22 @@ import {SettingIds, UsernameFlags} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingCheckbox from '@/modules/settings/components/SettingCheckbox';
 import SettingCheckboxGroup from '@/modules/settings/components/SettingCheckboxGroup';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Usernames'});
+
+const LOCALIZED_NAME = formatMessage({defaultMessage: 'Localized Usernames'});
+const LOCALIZED_DESCRIPTION = formatMessage({defaultMessage: 'Show localized display names in the chat window.'});
+const COLORS_NAME = formatMessage({defaultMessage: 'Username Colors'});
+const COLORS_DESCRIPTION = formatMessage({defaultMessage: 'Show username colors in the chat window.'});
+const READABLE_NAME = formatMessage({defaultMessage: 'Readable Colors'});
+const READABLE_DESCRIPTION = formatMessage({
+  defaultMessage: 'Show username colors with higher contrast (prevents hard to read names).',
+});
+const BADGES_NAME = formatMessage({defaultMessage: 'Badges'});
+const BADGES_DESCRIPTION = formatMessage({defaultMessage: 'Show chat badges next to usernames.'});
 
 function UsernamesModule({ref, ...props}) {
   const [usernames, setUsernames] = useStorageState(SettingIds.USERNAMES);
@@ -19,30 +32,10 @@ function UsernamesModule({ref, ...props}) {
       value={usernames}
       onChange={setUsernames}
       flags={Object.values(UsernameFlags)}>
-      <SettingCheckbox
-        value={UsernameFlags.LOCALIZED}
-        name={formatMessage({defaultMessage: 'Localized Usernames'})}
-        description={formatMessage({
-          defaultMessage: 'Show localized display names in the chat window.',
-        })}
-      />
-      <SettingCheckbox
-        value={UsernameFlags.COLORS}
-        name={formatMessage({defaultMessage: 'Username Colors'})}
-        description={formatMessage({defaultMessage: 'Show username colors in the chat window.'})}
-      />
-      <SettingCheckbox
-        value={UsernameFlags.READABLE}
-        name={formatMessage({defaultMessage: 'Readable Colors'})}
-        description={formatMessage({
-          defaultMessage: 'Show username colors with higher contrast (prevents hard to read names).',
-        })}
-      />
-      <SettingCheckbox
-        value={UsernameFlags.BADGES}
-        name={formatMessage({defaultMessage: 'Badges'})}
-        description={formatMessage({defaultMessage: 'Show chat badges next to usernames.'})}
-      />
+      <SettingCheckbox value={UsernameFlags.LOCALIZED} name={LOCALIZED_NAME} description={LOCALIZED_DESCRIPTION} />
+      <SettingCheckbox value={UsernameFlags.COLORS} name={COLORS_NAME} description={COLORS_DESCRIPTION} />
+      <SettingCheckbox value={UsernameFlags.READABLE} name={READABLE_NAME} description={READABLE_DESCRIPTION} />
+      <SettingCheckbox value={UsernameFlags.BADGES} name={BADGES_NAME} description={BADGES_DESCRIPTION} />
     </SettingCheckboxGroup>
   );
 }
@@ -51,7 +44,15 @@ SettingStore.registerSetting(UsernamesModule, {
   settingPanelId: SettingPanelIds.USERNAMES,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['color', 'username', 'accessibility', 'readability'],
 });
+
+for (const entry of [
+  {name: LOCALIZED_NAME, description: LOCALIZED_DESCRIPTION},
+  {name: COLORS_NAME, description: COLORS_DESCRIPTION},
+  {name: READABLE_NAME, description: READABLE_DESCRIPTION},
+  {name: BADGES_NAME, description: BADGES_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.USERNAMES)});
+}
 
 export default UsernamesModule;

--- a/src/modules/settings/settings/twitch/Whispers.jsx
+++ b/src/modules/settings/settings/twitch/Whispers.jsx
@@ -4,21 +4,20 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
+import {isStandaloneWindow} from '@/utils/window';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Whispers'});
+const SETTING_DESCRIPTION = formatMessage({defaultMessage: 'Enable and recieve Twitch whispers.'});
 
 function DisableWhispers({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.WHISPERS);
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
-      <SettingSwitch
-        name={SETTING_NAME}
-        description={formatMessage({defaultMessage: 'Enable and recieve Twitch whispers.'})}
-        value={value}
-        onChange={setValue}
-      />
+      <SettingSwitch name={SETTING_NAME} description={SETTING_DESCRIPTION} value={value} onChange={setValue} />
     </SettingGroup>
   );
 }
@@ -26,7 +25,13 @@ function DisableWhispers({ref, ...props}) {
 SettingStore.registerSetting(DisableWhispers, {
   settingPanelId: SettingPanelIds.WHISPERS,
   name: SETTING_NAME,
-  keywords: ['whispers', 'direct', 'messages'],
+});
+
+searchStore.registerSearchEntry({
+  name: SETTING_NAME,
+  description: SETTING_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.WHISPERS),
+  predicate: () => !isStandaloneWindow(),
 });
 
 export default DisableWhispers;

--- a/src/modules/settings/settings/twitch/YouTube.jsx
+++ b/src/modules/settings/settings/twitch/YouTube.jsx
@@ -2,10 +2,13 @@ import React, {useEffect} from 'react';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 import extension from '@/utils/extension';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'YouTube (beta)'});
+const SETTING_DESCRIPTION = formatMessage({defaultMessage: 'Show BetterTTV emotes on YouTube Live Chat.'});
 const browser = window.chrome || window.browser;
 
 function sendExtensionCommand(commandData, callback = undefined) {
@@ -97,7 +100,7 @@ function YouTube({ref, ...props}) {
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
         name={SETTING_NAME}
-        description={formatMessage({defaultMessage: 'Show BetterTTV emotes on YouTube Live Chat.'})}
+        description={SETTING_DESCRIPTION}
         value={value}
         onChange={() => requestPermission()}
         disabled={loading || value}
@@ -115,7 +118,12 @@ function maybeRegisterComponent() {
     settingPanelId: SettingPanelIds.YOUTUBE,
     name: SETTING_NAME,
     supportsStandaloneWindow: true,
-    keywords: ['youtube'],
+  });
+
+  searchStore.registerSearchEntry({
+    name: SETTING_NAME,
+    description: SETTING_DESCRIPTION,
+    goto: () => gotoSettingPanel(SettingPanelIds.YOUTUBE),
   });
 
   return YouTube;

--- a/src/modules/settings/settings/youtube/AutoLiveChatView.jsx
+++ b/src/modules/settings/settings/youtube/AutoLiveChatView.jsx
@@ -4,23 +4,19 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Auto Live Chat View'});
+const SETTING_DESCRIPTION = formatMessage({defaultMessage: 'Switch to the Live Chat view when chat loads.'});
 
 function EmoteAutoLiveChatView({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.AUTO_LIVE_CHAT_VIEW);
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
-      <SettingSwitch
-        name={formatMessage({defaultMessage: 'Auto Live Chat View'})}
-        description={formatMessage({
-          defaultMessage: 'Switch to the Live Chat view when chat loads.',
-        })}
-        value={value}
-        onChange={setValue}
-      />
+      <SettingSwitch name={SETTING_NAME} description={SETTING_DESCRIPTION} value={value} onChange={setValue} />
     </SettingGroup>
   );
 }
@@ -29,7 +25,12 @@ SettingStore.registerSetting(EmoteAutoLiveChatView, {
   settingPanelId: SettingPanelIds.AUTO_LIVE_CHAT_VIEW,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['auto', 'live', 'chat', 'view'],
+});
+
+searchStore.registerSearchEntry({
+  name: SETTING_NAME,
+  description: SETTING_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.AUTO_LIVE_CHAT_VIEW),
 });
 
 export default EmoteAutoLiveChatView;

--- a/src/modules/settings/settings/youtube/EmoteAutocomplete.jsx
+++ b/src/modules/settings/settings/youtube/EmoteAutocomplete.jsx
@@ -4,23 +4,21 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Emote Autocomplete'});
+const SETTING_DESCRIPTION = formatMessage({
+  defaultMessage: 'Typing : before text will attempt to autocomplete your emote.',
+});
 
 function EmoteAutocomplete({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.EMOTE_AUTOCOMPLETE);
 
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
-      <SettingSwitch
-        name={SETTING_NAME}
-        description={formatMessage({
-          defaultMessage: 'Typing : before text will attempt to autocomplete your emote.',
-        })}
-        value={value}
-        onChange={setValue}
-      />
+      <SettingSwitch name={SETTING_NAME} description={SETTING_DESCRIPTION} value={value} onChange={setValue} />
     </SettingGroup>
   );
 }
@@ -29,7 +27,12 @@ SettingStore.registerSetting(EmoteAutocomplete, {
   settingPanelId: SettingPanelIds.EMOTE_AUTOCOMPLETE,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['auto', 'autocomplete', 'emote', ':'],
+});
+
+searchStore.registerSearchEntry({
+  name: SETTING_NAME,
+  description: SETTING_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.EMOTE_AUTOCOMPLETE),
 });
 
 export default EmoteAutocomplete;

--- a/src/modules/settings/settings/youtube/EmoteMenu.jsx
+++ b/src/modules/settings/settings/youtube/EmoteMenu.jsx
@@ -6,9 +6,17 @@ import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingNumberInput from '@/modules/settings/components/SettingNumberInput';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Emote Menu'});
+const SETTING_DESCRIPTION = formatMessage({defaultMessage: 'Enables a more advanced emote menu for chat.'});
+
+const MAX_WIDTH_NAME = formatMessage({defaultMessage: 'Max Width'});
+const MAX_WIDTH_DESCRIPTION = formatMessage({
+  defaultMessage: 'Maximum width of the emote menu, measured in pixels.',
+});
 
 function EmoteMenu({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.EMOTE_MENU);
@@ -18,15 +26,15 @@ function EmoteMenu({ref, ...props}) {
   return (
     <SettingGroup ref={ref} {...props} name={SETTING_NAME}>
       <SettingSwitch
-        name={formatMessage({defaultMessage: 'Emote Menu'})}
-        description={formatMessage({defaultMessage: 'Enables a more advanced emote menu for chat.'})}
+        name={SETTING_NAME}
+        description={SETTING_DESCRIPTION}
         value={isEnabled}
         onChange={(state) => setValue(state ? EmoteMenuTypes.ENABLED : EmoteMenuTypes.NONE)}
       />
       <SettingNumberInput
         disabled={!isEnabled}
-        name={formatMessage({defaultMessage: 'Max Width'})}
-        description={formatMessage({defaultMessage: 'Maximum width of the emote menu, measured in pixels.'})}
+        name={MAX_WIDTH_NAME}
+        description={MAX_WIDTH_DESCRIPTION}
         value={width}
         onChange={setWidth}
         placeholder={SettingDefaultValues[SettingIds.EMOTE_MENU_WIDTH]}
@@ -40,7 +48,13 @@ SettingStore.registerSetting(EmoteMenu, {
   settingPanelId: SettingPanelIds.EMOTE_MENU,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['emotes', 'popup'],
 });
+
+for (const entry of [
+  {name: SETTING_NAME, description: SETTING_DESCRIPTION},
+  {name: MAX_WIDTH_NAME, description: MAX_WIDTH_DESCRIPTION},
+]) {
+  searchStore.registerSearchEntry({...entry, goto: () => gotoSettingPanel(SettingPanelIds.EMOTE_MENU)});
+}
 
 export default EmoteMenu;

--- a/src/modules/settings/settings/youtube/Theme.jsx
+++ b/src/modules/settings/settings/youtube/Theme.jsx
@@ -5,9 +5,14 @@ import {SettingDefaultValues, SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingPrimaryColorRadio from '@/modules/settings/components/SettingPrimaryColorRadio';
+import searchStore from '@/modules/settings/stores/search-store';
 import SettingStore, {SettingPanelIds} from '@/modules/settings/stores/setting-store';
+import {gotoSettingPanel} from '@/modules/settings/stores/settings-navigation';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Theme'});
+
+const ACCENT_COLOR_NAME = formatMessage({defaultMessage: 'Accent Color'});
+const ACCENT_COLOR_DESCRIPTION = formatMessage({defaultMessage: 'The primary accent color of the theme.'});
 
 function Theme({ref, ...props}) {
   const [value, setValue] = useStorageState(SettingIds.PRIMARY_COLOR);
@@ -24,8 +29,8 @@ function Theme({ref, ...props}) {
         showProBadge
         value={normalizedValue}
         onChange={setNormalizedValue}
-        name={formatMessage({defaultMessage: 'Accent Color'})}
-        description={formatMessage({defaultMessage: 'The primary accent color of the theme.'})}
+        name={ACCENT_COLOR_NAME}
+        description={ACCENT_COLOR_DESCRIPTION}
       />
     </SettingGroup>
   );
@@ -35,7 +40,12 @@ SettingStore.registerSetting(Theme, {
   settingPanelId: SettingPanelIds.THEME,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
-  keywords: ['primary', 'color', 'theme', 'accent'],
+});
+
+searchStore.registerSearchEntry({
+  name: ACCENT_COLOR_NAME,
+  description: ACCENT_COLOR_DESCRIPTION,
+  goto: () => gotoSettingPanel(SettingPanelIds.THEME),
 });
 
 export default Theme;

--- a/src/modules/settings/stores/search-store.js
+++ b/src/modules/settings/stores/search-store.js
@@ -1,0 +1,57 @@
+// Searchable index of every setting. Settings register one entry per user-facing option (a panel
+// with multiple options, e.g. BetterTTV/FrankerFaceZ/7TV emotes, registers each one) with the
+// name and description the option displays, plus a `goto` handler that navigates to it. Matches
+// rank name prefixes first, then name substrings, then description substrings; an empty query
+// returns every entry in registration order.
+const entries = [];
+
+class SearchStore {
+  registerSearchEntry({name, description = null, goto, predicate = null}) {
+    if (name == null || typeof name !== 'string') {
+      throw new Error('Name is required');
+    }
+
+    if (typeof goto !== 'function') {
+      throw new Error('Goto is required');
+    }
+
+    if (predicate != null && typeof predicate !== 'function') {
+      throw new Error('Predicate must be a function');
+    }
+
+    entries.push({name, description, goto, predicate});
+  }
+
+  search(query) {
+    // Predicates run at query time so results track live state (auth, standalone window, etc.).
+    const isAvailable = (entry) => entry.predicate == null || entry.predicate();
+
+    if (query == null || query.length === 0) {
+      return entries.filter(isAvailable);
+    }
+
+    const normalizedQuery = query.toLowerCase();
+    const nameStartsWith = [];
+    const nameIncludes = [];
+    const descriptionIncludes = [];
+
+    for (const entry of entries) {
+      if (!isAvailable(entry)) {
+        continue;
+      }
+
+      const normalizedName = entry.name.toLowerCase();
+      if (normalizedName.startsWith(normalizedQuery)) {
+        nameStartsWith.push(entry);
+      } else if (normalizedName.includes(normalizedQuery)) {
+        nameIncludes.push(entry);
+      } else if (entry.description != null && entry.description.toLowerCase().includes(normalizedQuery)) {
+        descriptionIncludes.push(entry);
+      }
+    }
+
+    return [...nameStartsWith, ...nameIncludes, ...descriptionIncludes];
+  }
+}
+
+export default new SearchStore();

--- a/src/modules/settings/stores/setting-store.js
+++ b/src/modules/settings/stores/setting-store.js
@@ -37,7 +37,7 @@ class SettingStore {
     this.settings = {};
   }
 
-  registerSetting(Component, {name, settingPanelId, keywords, supportsStandaloneWindow = false}) {
+  registerSetting(Component, {name, settingPanelId, supportsStandaloneWindow = false}) {
     if (name == null || typeof name !== 'string') {
       throw new Error('Name is required');
     }
@@ -46,19 +46,9 @@ class SettingStore {
       throw new Error('Setting panel ID is invalid');
     }
 
-    if (
-      keywords == null ||
-      keywords.length === 0 ||
-      !Array.isArray(keywords) ||
-      !keywords.every((keyword) => typeof keyword === 'string')
-    ) {
-      throw new Error('Keywords is invalid');
-    }
-
     this.settings[settingPanelId] = {
       name,
       settingPanelId,
-      keywords,
       supportsStandaloneWindow,
       render: ({...props}) => React.createElement(Component, {key: settingPanelId, ...props}),
     };

--- a/src/modules/settings/stores/settings-navigation.js
+++ b/src/modules/settings/stores/settings-navigation.js
@@ -1,8 +1,10 @@
 import {create} from 'zustand';
+import {PageTypes} from '@/constants';
 
-// Tracks which setting panel is currently in view on the settings page so the
-// side navigation can highlight the matching entry as the user scrolls.
+// Navigation state for the settings modal. Lives in a store (rather than component state) so
+// module-scope code — e.g. search entries' goto handlers — can navigate the modal.
 const useSettingsNavigationStore = create((set, get) => ({
+  // which setting panel is currently in view on the settings page (scroll spy)
   activePanelId: null,
   setActivePanelId(activePanelId) {
     if (get().activePanelId === activePanelId) {
@@ -10,6 +12,25 @@ const useSettingsNavigationStore = create((set, get) => ({
     }
     set({activePanelId});
   },
+
+  // current settings modal page
+  page: PageTypes.SETTINGS,
+  setPage(page) {
+    set({page});
+  },
+
+  // pending scroll target, consumed by the settings modal once the panel is rendered
+  pendingSettingPanelId: null,
+  gotoSettingPanel(settingPanelId) {
+    set({page: PageTypes.SETTINGS, pendingSettingPanelId: settingPanelId});
+  },
+  clearPendingSettingPanel() {
+    set({pendingSettingPanelId: null});
+  },
 }));
+
+export function gotoSettingPanel(settingPanelId) {
+  useSettingsNavigationStore.getState().gotoSettingPanel(settingPanelId);
+}
 
 export default useSettingsNavigationStore;

--- a/src/modules/shadow_dom/ThemeProvider.jsx
+++ b/src/modules/shadow_dom/ThemeProvider.jsx
@@ -163,6 +163,8 @@ const resolver = (theme) => ({
     '--mantine-color-body': 'var(--mantine-color-dark-8)',
     '--mantine-color-body-inverse': 'var(--mantine-color-dark-0)',
     '--mantine-primary-color-light-active': alpha(theme.colors[theme.primaryColor][theme.primaryShade - 2], 0.3),
+    // dimmed primary-colored text, e.g. the description under a highlighted search result
+    '--mantine-primary-color-text-dimmed': alpha(theme.colors[theme.primaryColor][theme.primaryShade], 0.7),
     // raised surface (e.g. the user-settings card): a step lighter than the body, with a border
     // lighter still so it reads as elevated against the sidebar.
     '--mantine-color-body-raised': 'var(--mantine-color-dark-6)',
@@ -176,6 +178,7 @@ const resolver = (theme) => ({
     '--mantine-color-body-secondary': 'var(--mantine-color-gray-0)',
     '--mantine-color-body-inverse': 'var(--mantine-color-gray-9)',
     '--mantine-primary-color-light-active': alpha(theme.colors[theme.primaryColor][theme.primaryShade], 0.18),
+    '--mantine-primary-color-text-dimmed': alpha(theme.colors[theme.primaryColor][theme.primaryShade], 0.7),
     '--mantine-color-body-raised': 'var(--mantine-color-white)',
     '--mantine-color-body-raised-border': 'var(--mantine-color-gray-3)',
   },


### PR DESCRIPTION
Stacked on #8055 (settings modal side navigation).

Adds a search input to the settings side navigation, backed by a new search store:

- **search-store** — settings register one entry per user-facing option (name + description + a `goto` handler that navigates to it, optional `predicate` evaluated at query time). Matching ranks name prefixes, then name substrings, then description substrings.
- Every settings panel registers its options (names/descriptions hoisted to constants shared with the JSX; the old `keywords` param is removed from `registerSetting`).
- Predicates hide options that don't apply (e.g. non-chat settings in the standalone chat window, mirroring `getSupportedSettings`).
- **SettingsSearch** — combobox popover (top 4 matches): ↑/↓ move the selection, hover follows the mouse, Enter/Tab darken the selected row while held and navigate on release (matching the autocomplete's pending-complete behavior).
- Navigation state (`page`, pending panel) moves from SettingsModal into the settings-navigation store so module-scope `goto` handlers can navigate; the search input autofocuses once the modal's open transition finishes.

The User Settings page's own entries (Cloud Backup, Sign In/Sign Out) land in a follow-up once this and the user settings PR are both in, since they need the tabbed page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)