### PR TITLE
fix: reparent shadow DOM host back to documentElement on fullscreen exit

### DIFF
--- a/src/modules/shadow_dom/index.jsx
+++ b/src/modules/shadow_dom/index.jsx
@@ -48,7 +48,7 @@ function reparentHost(parent) {
 function syncHostToFullscreen() {
   const fullscreenElement = document.fullscreenElement ?? document.webkitFullscreenElement ?? null;
   if (fullscreenElement == null) {
-    if (!document.documentElement.contains(host)) {
+    if (host.parentElement !== document.documentElement) {
       reparentHost(document.documentElement);
     }
     return;


### PR DESCRIPTION
## Summary

Fixes #8121

The emote menu (and any other BTTV popover) rendered inside the stream window after entering and exiting fullscreen. Repro: open any stream (e.g. an offline channel with a VOD autoplay player), fullscreen the player, exit fullscreen, then open the emote menu — it appears inside the player, clipped behind chat.

## Root cause

On `fullscreenchange`, the shadow DOM host is reparented into the fullscreen element so BTTV UI stays visible in fullscreen. On exit, the restore check used:

```js
if (!document.documentElement.contains(host)) { ... }
```

`contains()` is transitive — the host stranded inside the old fullscreen element (the video player container) is still contained by `documentElement`, so the check always passed and the host never moved back. Since the player container creates a fixed-position containing block, every popover then positioned itself relative to the player instead of the viewport.

## Fix

Check that the host is a direct child of `documentElement` instead:

```js
if (host.parentElement !== document.documentElement) { ... }
```

## Testing

Verified live on twitch.tv with the dev build: entering fullscreen reparents the host into `video-player__container` (unchanged), exiting fullscreen now returns it to `<html>`, and the emote menu opened after a fullscreen round-trip renders correctly anchored above the chat input instead of inside the video player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)