### PR TITLE
fix: preserve flag defaults when syncing settings from cloud backup

### DIFF
--- a/src/modules/cloud_backup/index.js
+++ b/src/modules/cloud_backup/index.js
@@ -2,7 +2,7 @@ import debounce from 'lodash.debounce';
 import isEqual from 'lodash.isequal';
 import {getExtensionSettings, updateExtensionSettings} from '@/actions/extension';
 import {openConfirmModal} from '@/common/utils/modal';
-import {CLOUD_BACKUP_SETTINGS_STORAGE_KEY, FlagSettings} from '@/constants';
+import {CLOUD_BACKUP_SETTINGS_STORAGE_KEY} from '@/constants';
 import formatMessage from '@/i18n/index';
 import settings from '@/settings';
 import socketClient, {EventNames} from '@/socket-client';
@@ -126,20 +126,12 @@ class CloudBackup extends SafeEventEmitter {
 
       ignoringInternalSettingChanges = true;
 
-      for (let [key, value] of Object.entries(serverSettings)) {
+      for (const [key, value] of Object.entries(serverSettings)) {
         if (key === 'version') {
           continue;
         }
 
-        if (FlagSettings.includes(key)) {
-          [value] = value;
-        }
-
-        let currentValue = currentSettings[key];
-        if (FlagSettings.includes(key)) {
-          [currentValue] = currentValue;
-        }
-
+        const currentValue = currentSettings[key];
         if (isEqual(currentValue, value)) {
           continue;
         }
@@ -151,6 +143,8 @@ class CloudBackup extends SafeEventEmitter {
     } finally {
       ignoringInternalSettingChanges = false;
     }
+
+    settings.applyFlagDefaults();
   }
 
   handleInternalSettingsChange(_updatedSettings, temporary) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -127,6 +127,10 @@ class Settings extends SafeEventEmitter {
       }
     }
 
+    this.applyFlagDefaults();
+  }
+
+  applyFlagDefaults() {
     for (const flagSettingId of FlagSettings) {
       const defaultValue = SettingDefaultValues[flagSettingId];
       const defaultFlags = defaultValue[0];
@@ -151,8 +155,9 @@ class Settings extends SafeEventEmitter {
       // upgrade flags where default bits changed
       const [oldFlags, oldChangedBits] = settings[flagSettingId];
       const flagsToAdd = setFlag(defaultFlags, oldChangedBits, false);
-      if (flagsToAdd > 0) {
-        this.set(flagSettingId, setFlag(oldFlags, flagsToAdd, true));
+      const newFlags = setFlag(oldFlags, flagsToAdd, true);
+      if (newFlags !== oldFlags) {
+        this.set(flagSettingId, newFlags);
       }
     }
   }

--- a/src/settings.js
+++ b/src/settings.js
@@ -82,6 +82,10 @@ class Settings extends SafeEventEmitter {
       storageValue = [storageValue, oldChangedBits | getChangedFlags(oldFlags, storageValue)];
     }
 
+    if (FlagSettings.includes(id)) {
+      [value] = storageValue;
+    }
+
     // temp values return the new value during page sessions and persist the prior stored value
     if (temporary === true) {
       storageValue = new TempValue(storageValue, settings[id]);


### PR DESCRIPTION
## Problem

Cloud backup pulls strip flag settings down to the flags number (`[value] = value`) and re-apply them through `settings.set()`, which recomputes `changedBits` from the diff against the local value. When a new default-on flag ships, the sequence on a cloud-backup user's device is:

1. `upgrade()` adds the new bit locally (it's not in `changedBits`)
2. the pull applies the server copy — written by a pre-update client, so the bit is off
3. `settings.set()` records that diff into `changedBits`, permanently marking the new flag as a deliberate user change

The upgrade pass then never re-adds it, so every Pro user with cloud backup enabled silently gets the old default forever. This currently affects any newly added default-on flag (e.g. #8091's watch streaks flag, which is how this was found — the reverted value also gets pushed back to the server, poisoning other devices).

## Fix

- Sync the full `[flags, changedBits]` tuple on pull instead of flags-only. The push side already uploads tuples wholesale, so the server has always stored `changedBits` — the pull just discarded them. Deliberate opt-outs now transfer across devices without being misattributed.
- Re-run the flag defaults pass (extracted from `upgrade()` into `settings.applyFlagDefaults()`) after applying server settings, so default-on bits the user never touched are inferred over a stale server copy and pushed back once.
- The defaults pass now only writes when the flags actually change. It previously called `settings.set()` on every run even with no change; harmless in `upgrade()` (before listeners attach), but after a pull it would fire a settings push containing no changes, and two online devices would ping-pong version bumps indefinitely.

## Verification

Tested in-browser against a stubbed settings endpoint:

- Stale server copy `chat: [61, 2]` (Bits off, predates the Message History bit): local converges to `[125, 66]` — the Bits opt-out syncs, Message History is inferred on, and the merged tuple is pushed back once.
- Deliberate opt-out from an up-to-date device `chat: [63, 64]`: survives the pull untouched, is not re-added by the defaults pass, and triggers no push.

Ideally this lands before #8091 so no production profiles get poisoned `changedBits` (which is indistinguishable from a real opt-out after the fact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)