### PR TITLE
qol: mark settings promotions as seen when viewed

### DIFF
--- a/src/modules/settings/components/Promotion.jsx
+++ b/src/modules/settings/components/Promotion.jsx
@@ -1,6 +1,7 @@
 import {faClose, faPaintBrush, faRobot} from '@fortawesome/free-solid-svg-icons';
 import {ActionIcon, Button, Image, Title} from '@mantine/core';
 import classNames from 'classnames';
+import {useInView} from 'framer-motion';
 import React, {use, useEffect, useRef, useState} from 'react';
 import AnimatedCanvas from '@/common/components/AnimatedCanvas';
 import Icon from '@/common/components/Icon';
@@ -58,27 +59,15 @@ function Promotion() {
   const [activePromotion, setActivePromotion] = useState(getPromotionToDisplay);
   const panelRef = useRef(null);
   const storageKey = activePromotion?.storageKey;
+  const isInView = useInView(panelRef, {once: true, amount: 0.5});
 
   useEffect(() => {
-    const panel = panelRef.current;
-    if (storageKey == null || panel == null) {
-      return undefined;
+    if (storageKey == null || !isInView) {
+      return;
     }
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry.isIntersecting) {
-          return;
-        }
-        promotionStore.markPromotionSeen(storageKey);
-        observer.disconnect();
-      },
-      {threshold: 0.5}
-    );
-    observer.observe(panel);
-
-    return () => observer.disconnect();
-  }, [storageKey]);
+    promotionStore.markPromotionSeen(storageKey);
+  }, [isInView, storageKey]);
 
   if (activePromotion == null) {
     return null;

--- a/src/modules/settings/components/Promotion.jsx
+++ b/src/modules/settings/components/Promotion.jsx
@@ -1,7 +1,7 @@
 import {faClose, faPaintBrush, faRobot} from '@fortawesome/free-solid-svg-icons';
 import {ActionIcon, Button, Image, Title} from '@mantine/core';
 import classNames from 'classnames';
-import React, {use, useState} from 'react';
+import React, {use, useEffect, useRef, useState} from 'react';
 import AnimatedCanvas from '@/common/components/AnimatedCanvas';
 import Icon from '@/common/components/Icon';
 import NightbotLogoIcon from '@/common/components/NightbotLogoIcon';
@@ -56,12 +56,35 @@ function getPromotionToDisplay() {
 function Promotion() {
   const {handleGotoSettingPanel} = use(PageContext);
   const [activePromotion, setActivePromotion] = useState(getPromotionToDisplay);
+  const panelRef = useRef(null);
+  const storageKey = activePromotion?.storageKey;
+
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (storageKey == null || panel == null) {
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+        promotionStore.markPromotionSeen(storageKey);
+        observer.disconnect();
+      },
+      {threshold: 0.5}
+    );
+    observer.observe(panel);
+
+    return () => observer.disconnect();
+  }, [storageKey]);
 
   if (activePromotion == null) {
     return null;
   }
 
-  const {storageKey, settingPanelId, icon, title} = activePromotion;
+  const {settingPanelId, icon, title} = activePromotion;
 
   const advance = () => {
     setActivePromotion(getPromotionToDisplay());
@@ -79,7 +102,7 @@ function Promotion() {
   };
 
   return (
-    <Panel className={styles.promotion} containerClassName={styles.panelContainer}>
+    <Panel ref={panelRef} className={styles.promotion} containerClassName={styles.panelContainer}>
       <AnimatedCanvas className={styles.canvas} />
       <div className={styles.content}>
         {icon}


### PR DESCRIPTION
Settings promotions were only marked seen when the user explicitly interacted (dismiss or "Take me there"). A promotion the user scrolled past — or had on screen and ignored — kept coming back and kept the top-nav indicator dot lit indefinitely.

This marks the promotion seen via framer-motion's `useInView` (`once: true`) on the promotion panel, calling `promotionStore.markPromotionSeen()` once at least half of the panel is visible in the viewport.

Behavior notes:
- The panel stays visible for the rest of the session; only the stored seen state changes.
- Marking seen on view starts the existing 2-day global promotion cooldown, same as a dismissal.
- The top-nav indicator dot clears as soon as the promotion is actually seen, via the store's existing `changed` event.
- The 0.5 amount means a promotion below the fold in the settings modal is not marked until scrolled into view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)