### PR TITLE
qol: only authenticate the socket when a feature needs it

### DIFF
--- a/src/modules/cloud_backup/index.js
+++ b/src/modules/cloud_backup/index.js
@@ -41,13 +41,16 @@ class CloudBackup extends SafeEventEmitter {
   updateBackupSettings(newSettings) {
     newSettings = {...this.settings, ...newSettings};
 
-    if (newSettings.enabled != null && newSettings.enabled !== this.settings.enabled) {
-      this.load(newSettings);
-    }
+    const enabledChanged = newSettings.enabled != null && newSettings.enabled !== this.settings.enabled;
 
     this.settings = newSettings;
     this.emit('changed', this.settings);
     storage.set(CLOUD_BACKUP_SETTINGS_STORAGE_KEY, this.settings);
+
+    if (enabledChanged) {
+      this.load(newSettings);
+      socketClient.handleAuthenticationRequest();
+    }
   }
 
   async load(newSettings) {

--- a/src/modules/cloud_backup/index.js
+++ b/src/modules/cloud_backup/index.js
@@ -41,13 +41,13 @@ class CloudBackup extends SafeEventEmitter {
   updateBackupSettings(newSettings) {
     newSettings = {...this.settings, ...newSettings};
 
-    const enabledChanged = newSettings.enabled != null && newSettings.enabled !== this.settings.enabled;
+    const previousEnabled = this.settings.enabled;
 
     this.settings = newSettings;
     this.emit('changed', this.settings);
     storage.set(CLOUD_BACKUP_SETTINGS_STORAGE_KEY, this.settings);
 
-    if (enabledChanged) {
+    if (newSettings.enabled != null && newSettings.enabled !== previousEnabled) {
       this.load(newSettings);
       socketClient.handleAuthenticationRequest();
     }

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -67,13 +67,13 @@ function handleUserUpdateEvent(newUser) {
 }
 
 function shouldRequestAuthentication() {
+  if (settings.get(SettingIds.SELF_BOT) === true) {
+    return true;
+  }
+
   const {user} = useAuthStore.getState();
   if (!isUserPro(user)) {
     return false;
-  }
-
-  if (settings.get(SettingIds.SELF_BOT) === true) {
-    return true;
   }
 
   const cloudBackupSettings = storage.get(CLOUD_BACKUP_SETTINGS_STORAGE_KEY);

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -67,6 +67,11 @@ function handleUserUpdateEvent(newUser) {
 }
 
 function shouldRequestAuthentication() {
+  const {accessToken} = getCredentials();
+  if (accessToken == null) {
+    return false;
+  }
+
   if (settings.get(SettingIds.SELF_BOT) === true) {
     return true;
   }
@@ -106,17 +111,24 @@ class SocketClient extends SafeEventEmitter {
       return;
     }
 
-    const {accessToken} = getCredentials();
-
-    if (accessToken == null || !shouldRequestAuthentication()) {
-      this.send('authentication_logout');
-    } else {
+    if (shouldRequestAuthentication()) {
+      const {accessToken} = getCredentials();
       this.send('authentication_request', {token: accessToken});
+      return;
+    }
+
+    if (authenticated) {
+      this.send('authentication_logout');
     }
   }
 
   async handleAuthenticationUpdate(data) {
     authenticated = data.authenticated === true;
+
+    if (authenticated && !shouldRequestAuthentication()) {
+      this.send('authentication_logout');
+      return;
+    }
 
     if (authenticated) {
       retryAuthenticationRequest = true;

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -124,11 +124,6 @@ class SocketClient extends SafeEventEmitter {
   async handleAuthenticationUpdate(data) {
     authenticated = data.authenticated === true;
 
-    if (authenticated && !shouldRequestAuthentication()) {
-      this.send('authentication_logout');
-      return;
-    }
-
     if (authenticated) {
       retryAuthenticationRequest = true;
       // session locks live on the (possibly new) authenticated connection, so (re)claim any we want
@@ -150,10 +145,6 @@ class SocketClient extends SafeEventEmitter {
 
       retryAuthenticationRequest = false;
       await refreshAndSetCredentials();
-    }
-
-    if (data.reason === 'logged_out') {
-      this.handleAuthenticationRequest();
     }
   }
 

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -111,13 +111,12 @@ class SocketClient extends SafeEventEmitter {
       return;
     }
 
-    if (shouldRequestAuthentication()) {
+    const shouldRequest = shouldRequestAuthentication();
+
+    if (shouldRequest && !authenticated) {
       const {accessToken} = getCredentials();
       this.send('authentication_request', {token: accessToken});
-      return;
-    }
-
-    if (authenticated) {
+    } else if (!shouldRequest && authenticated) {
       this.send('authentication_logout');
     }
   }
@@ -151,6 +150,10 @@ class SocketClient extends SafeEventEmitter {
 
       retryAuthenticationRequest = false;
       await refreshAndSetCredentials();
+    }
+
+    if (data.reason === 'logged_out') {
+      this.handleAuthenticationRequest();
     }
   }
 
@@ -280,6 +283,8 @@ class SocketClient extends SafeEventEmitter {
   reconnect() {
     if (state === CONNECTION_STATES.CONNECTING) return;
     state = CONNECTION_STATES.DISCONNECTED;
+
+    authenticated = false;
 
     // locks do not survive a dropped connection; we re-acquire after re-authenticating
     resetSessionLockConnectionState();

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -2,9 +2,12 @@ import throttle from 'lodash.throttle';
 import useAuthStore, {getCredentials, setCredentials} from '@/stores/auth';
 import {refreshAndSetCredentials} from '@/utils/auth';
 import debug from '@/utils/debug';
+import {isUserPro} from '@/utils/pro';
 import SafeEventEmitter from '@/utils/safe-event-emitter';
 import {getCurrentUser} from '@/utils/user';
-import {SOCKET_ENDPOINT} from './constants';
+import {CLOUD_BACKUP_SETTINGS_STORAGE_KEY, SettingIds, SOCKET_ENDPOINT} from './constants';
+import settings from './settings';
+import storage from './storage';
 
 const CONNECTION_STATES = {
   DISCONNECTED: 0,
@@ -63,6 +66,20 @@ function handleUserUpdateEvent(newUser) {
   useAuthStore.setState({user: newUser});
 }
 
+function shouldRequestAuthentication() {
+  const {user} = useAuthStore.getState();
+  if (!isUserPro(user)) {
+    return false;
+  }
+
+  if (settings.get(SettingIds.SELF_BOT) === true) {
+    return true;
+  }
+
+  const cloudBackupSettings = storage.get(CLOUD_BACKUP_SETTINGS_STORAGE_KEY);
+  return cloudBackupSettings != null && cloudBackupSettings.enabled === true;
+}
+
 class SocketClient extends SafeEventEmitter {
   constructor() {
     super();
@@ -74,6 +91,25 @@ class SocketClient extends SafeEventEmitter {
       () => this.handleAuthenticationRequest()
     );
 
+    useAuthStore.subscribe(
+      (state) => isUserPro(state.user),
+      () => this.handleAuthenticationRequest()
+    );
+
+    settings.on(`changed.${SettingIds.SELF_BOT}`, () => this.handleAuthenticationRequest());
+
+    import('@/modules/cloud_backup').then(({default: cloudBackup}) => {
+      let cloudBackupEnabled = cloudBackup.settings.enabled === true;
+      cloudBackup.on('changed', (newSettings) => {
+        const enabled = newSettings.enabled === true;
+        if (enabled === cloudBackupEnabled) {
+          return;
+        }
+        cloudBackupEnabled = enabled;
+        this.handleAuthenticationRequest();
+      });
+    });
+
     this.broadcastMe = throttle(this.broadcastMe.bind(this), 1000, {leading: false});
   }
 
@@ -84,7 +120,7 @@ class SocketClient extends SafeEventEmitter {
 
     const {accessToken} = getCredentials();
 
-    if (accessToken == null) {
+    if (accessToken == null || !shouldRequestAuthentication()) {
       this.send('authentication_logout');
     } else {
       this.send('authentication_request', {token: accessToken});

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -98,18 +98,6 @@ class SocketClient extends SafeEventEmitter {
 
     settings.on(`changed.${SettingIds.SELF_BOT}`, () => this.handleAuthenticationRequest());
 
-    import('@/modules/cloud_backup').then(({default: cloudBackup}) => {
-      let cloudBackupEnabled = cloudBackup.settings.enabled === true;
-      cloudBackup.on('changed', (newSettings) => {
-        const enabled = newSettings.enabled === true;
-        if (enabled === cloudBackupEnabled) {
-          return;
-        }
-        cloudBackupEnabled = enabled;
-        this.handleAuthenticationRequest();
-      });
-    });
-
     this.broadcastMe = throttle(this.broadcastMe.bind(this), 1000, {leading: false});
   }
 


### PR DESCRIPTION
## Why

Socket authentication is only needed for features that require an authenticated connection server-side — self botting (session locks) and cloud backups (settings pushes). Everyone else was authenticating (or sending a pointless `authentication_logout` on every connect) for nothing, so this makes the client send auth messages only when a feature that needs them is enabled: self botting, or cloud backups (Pro-only).

## Changes

**`src/socket-client.js`**
- New `shouldRequestAuthentication()` gate: has an access token, then `self bot setting enabled || (isUserPro(user) && cloud backup enabled)` — self bot is not Pro-gated, cloud backups are. Cloud backup state is read from storage (`cloudBackupSettings`) since `cloud_backup` imports `socket-client` and importing it back would be a cycle.
- `handleAuthenticationRequest()` reconciles desired vs actual state: `authentication_request` only when the gate is open and the connection isn't authenticated, `authentication_logout` only when the gate is closed and it is, nothing otherwise (previously every logged-out user sent a logout on each connect). The `authenticated` flag stays server-driven — the server replies to every request/logout with an `authentication_update` — and resets on reconnect since it's per-connection state.
- Re-evaluates on the existing credentials trigger plus two new ones: the user's pro status (auth store subscription) and the self bot setting (`changed.selfBot`).

**`src/modules/cloud_backup/index.js`**
- `updateBackupSettings` calls `socketClient.handleAuthenticationRequest()` when `enabled` flips, after the new value is persisted (the gate reads storage). This also covers cloud backup's automatic self-disable on a 403. The flip is detected by capturing the previous `enabled` before `this.settings` is reassigned; `load()` moves after the persist alongside it — safe since `load` receives `newSettings` as an argument and its async continuations run after `this.settings` is assigned either way.

## Notes

- Same change as the extension-private PR #84.

- Ordering with session locks is safe in both directions: `handleAuthenticationUpdate` already re-claims all desired locks after any successful authentication, and the server ignores acquire/release from unauthenticated connections.
- On login, the pro-dependent path correctly waits for the user object: credentials land first (gate closed — user not yet loaded), then `syncCurrentUserFromCredentials` populates the user and the pro subscription fires the request.
- Token refreshes while authenticated no longer re-send a request — the server session is per-connection and validates the token once, and the next reconnect authenticates with the current token. The `invalid_token` refresh-and-retry flow is unchanged (the refreshed credentials fire the trigger while unauthenticated).
- A gate flip racing an in-flight auth round-trip can briefly leave the connection on the wrong side of the gate; accepted — it self-corrects on the next trigger or reconnect.
- Trade-off: users outside the gate no longer receive `USER_UPDATE` pushes, so pro status changes propagate on reload/token-refresh instead of live.

## Testing

- `eslint`, `prettier --check`, and `vite build` pass.
- Verified by trace-through only — not exercised against the live socket server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
