### PR TITLE
fix: authenticate the socket during the subscription upgrade flow

### DIFF
--- a/src/common/utils/modal.jsx
+++ b/src/common/utils/modal.jsx
@@ -160,7 +160,7 @@ export function openSubscriptionUpgradeModal(props = {}, callback = () => {}) {
 
   let unsubscribeUserUpdated = null;
 
-  socketClient.acquireAuthenticationHold();
+  socketClient.ensureAuthentication();
 
   function onConfirm() {
     return new Promise((resolve, reject) => {
@@ -191,7 +191,6 @@ export function openSubscriptionUpgradeModal(props = {}, callback = () => {}) {
     onClose: () => {
       controller.abort();
       unsubscribeUserUpdated?.();
-      socketClient.releaseAuthenticationHold();
     },
     labels: {
       confirm: formatMessage({defaultMessage: 'Upgrade'}),

--- a/src/common/utils/modal.jsx
+++ b/src/common/utils/modal.jsx
@@ -3,6 +3,7 @@ import {modals} from '@mantine/modals';
 import React from 'react';
 import {ExternalLinks} from '@/constants';
 import formatMessage from '@/i18n/index';
+import socketClient from '@/socket-client';
 import useAuthStore from '@/stores/auth';
 import {executeOAuth2SignInAndSetCredentials} from '@/utils/auth';
 import {isUserPro} from '@/utils/pro';
@@ -159,6 +160,8 @@ export function openSubscriptionUpgradeModal(props = {}, callback = () => {}) {
 
   let unsubscribeUserUpdated = null;
 
+  socketClient.acquireAuthenticationHold();
+
   function onConfirm() {
     return new Promise((resolve, reject) => {
       signal.addEventListener('abort', () => reject(new Error('Aborted')));
@@ -188,6 +191,7 @@ export function openSubscriptionUpgradeModal(props = {}, callback = () => {}) {
     onClose: () => {
       controller.abort();
       unsubscribeUserUpdated?.();
+      socketClient.releaseAuthenticationHold();
     },
     labels: {
       confirm: formatMessage({defaultMessage: 'Upgrade'}),

--- a/src/modules/cloud_backup/index.js
+++ b/src/modules/cloud_backup/index.js
@@ -49,7 +49,6 @@ class CloudBackup extends SafeEventEmitter {
 
     if (newSettings.enabled != null && newSettings.enabled !== previousEnabled) {
       this.load(newSettings);
-      socketClient.handleAuthenticationRequest();
     }
   }
 
@@ -74,6 +73,8 @@ class CloudBackup extends SafeEventEmitter {
     if (!enabled) {
       return;
     }
+
+    socketClient.ensureAuthentication();
 
     if (unlistenSettingsChange == null) {
       unlistenSettingsChange = settings.on('changed', this.handleInternalSettingsChange.bind(this));

--- a/src/modules/self_bot/index.js
+++ b/src/modules/self_bot/index.js
@@ -31,6 +31,7 @@ function isSelfBotActive() {
 // so another session can take over
 function updateSessionLock() {
   if (isSelfBotActive()) {
+    socketClient.ensureAuthentication();
     socketClient.acquireSessionLock(SELF_BOT_SESSION_LOCK);
   } else {
     socketClient.releaseSessionLock(SELF_BOT_SESSION_LOCK);

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -35,6 +35,7 @@ let state = CONNECTION_STATES.DISCONNECTED;
 let attempts = 1;
 let authenticated = false;
 let retryAuthenticationRequest = true;
+let authenticationHolds = 0;
 
 const joinedChannels = [];
 // session locks this client wants to hold, and the subset the server has granted us
@@ -70,6 +71,10 @@ function shouldRequestAuthentication() {
   const {accessToken} = getCredentials();
   if (accessToken == null) {
     return false;
+  }
+
+  if (authenticationHolds > 0) {
+    return true;
   }
 
   if (settings.get(SettingIds.SELF_BOT) === true) {
@@ -119,6 +124,20 @@ class SocketClient extends SafeEventEmitter {
     } else if (!shouldRequest && authenticated) {
       this.send('authentication_logout');
     }
+  }
+
+  acquireAuthenticationHold() {
+    authenticationHolds++;
+    this.handleAuthenticationRequest();
+  }
+
+  releaseAuthenticationHold() {
+    if (authenticationHolds === 0) {
+      return;
+    }
+
+    authenticationHolds--;
+    this.handleAuthenticationRequest();
   }
 
   async handleAuthenticationUpdate(data) {

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -2,12 +2,9 @@ import throttle from 'lodash.throttle';
 import useAuthStore, {getCredentials, setCredentials} from '@/stores/auth';
 import {refreshAndSetCredentials} from '@/utils/auth';
 import debug from '@/utils/debug';
-import {isUserPro} from '@/utils/pro';
 import SafeEventEmitter from '@/utils/safe-event-emitter';
 import {getCurrentUser} from '@/utils/user';
-import {CLOUD_BACKUP_SETTINGS_STORAGE_KEY, SettingIds, SOCKET_ENDPOINT} from './constants';
-import settings from './settings';
-import storage from './storage';
+import {SOCKET_ENDPOINT} from './constants';
 
 const CONNECTION_STATES = {
   DISCONNECTED: 0,
@@ -35,7 +32,7 @@ let state = CONNECTION_STATES.DISCONNECTED;
 let attempts = 1;
 let authenticated = false;
 let retryAuthenticationRequest = true;
-let authenticationHolds = 0;
+let authenticationDesired = false;
 
 const joinedChannels = [];
 // session locks this client wants to hold, and the subset the server has granted us
@@ -60,34 +57,11 @@ export function deserializeSocketChannel(channel) {
 function handleUserUpdateEvent(newUser) {
   const {user} = useAuthStore.getState();
 
-  if (user.id !== newUser.id) {
+  if (user == null || user.id !== newUser.id) {
     return;
   }
 
   useAuthStore.setState({user: newUser});
-}
-
-function shouldRequestAuthentication() {
-  const {accessToken} = getCredentials();
-  if (accessToken == null) {
-    return false;
-  }
-
-  if (authenticationHolds > 0) {
-    return true;
-  }
-
-  if (settings.get(SettingIds.SELF_BOT) === true) {
-    return true;
-  }
-
-  const {user} = useAuthStore.getState();
-  if (!isUserPro(user)) {
-    return false;
-  }
-
-  const cloudBackupSettings = storage.get(CLOUD_BACKUP_SETTINGS_STORAGE_KEY);
-  return cloudBackupSettings != null && cloudBackupSettings.enabled === true;
 }
 
 class SocketClient extends SafeEventEmitter {
@@ -101,13 +75,6 @@ class SocketClient extends SafeEventEmitter {
       () => this.handleAuthenticationRequest()
     );
 
-    useAuthStore.subscribe(
-      (state) => isUserPro(state.user),
-      () => this.handleAuthenticationRequest()
-    );
-
-    settings.on(`changed.${SettingIds.SELF_BOT}`, () => this.handleAuthenticationRequest());
-
     this.broadcastMe = throttle(this.broadcastMe.bind(this), 1000, {leading: false});
   }
 
@@ -116,27 +83,20 @@ class SocketClient extends SafeEventEmitter {
       return;
     }
 
-    const shouldRequest = shouldRequestAuthentication();
-
-    if (shouldRequest && !authenticated) {
-      const {accessToken} = getCredentials();
-      this.send('authentication_request', {token: accessToken});
-    } else if (!shouldRequest && authenticated) {
-      this.send('authentication_logout');
-    }
-  }
-
-  acquireAuthenticationHold() {
-    authenticationHolds++;
-    this.handleAuthenticationRequest();
-  }
-
-  releaseAuthenticationHold() {
-    if (authenticationHolds === 0) {
+    if (!authenticationDesired || authenticated) {
       return;
     }
 
-    authenticationHolds--;
+    const {accessToken} = getCredentials();
+    if (accessToken == null) {
+      return;
+    }
+
+    this.send('authentication_request', {token: accessToken});
+  }
+
+  ensureAuthentication() {
+    authenticationDesired = true;
     this.handleAuthenticationRequest();
   }
 


### PR DESCRIPTION
Since #8129 the socket only authenticates when a feature needs it. The subscription upgrade modal resolves by waiting for a `user_update` broadcast after the user completes checkout, but a non-pro user's socket is never authenticated under the gate — so the event never arrives and the modal never detects the upgrade.

This replaces the reactive gate (`shouldRequestAuthentication` + pro/self-bot/credentials subscriptions) with a push model: features that need the authenticated socket call `socketClient.ensureAuthentication()` — the subscription upgrade modal on open, cloud backup when it loads enabled, and self bot when it activates in the user's own channel. Once authenticated the socket stays authenticated for the connection's lifetime (no more `authentication_logout` churn when gates flip off), and the desired state re-authenticates across reconnects. `user_update` events for a signed-out session are now ignored instead of throwing on the null user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)