### PR TITLE
qol: skip rendering offscreen chat messages

### DIFF
--- a/src/common/styles/UsernameEffects.module.css
+++ b/src/common/styles/UsernameEffects.module.css
@@ -1,3 +1,8 @@
+.contained {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 28px;
+}
+
 .glow {
   text-shadow: 0 0 20px color-mix(in srgb, currentColor 80%, transparent);
 }

--- a/src/common/styles/UsernameEffects.module.css
+++ b/src/common/styles/UsernameEffects.module.css
@@ -1,5 +1,7 @@
 .contained {
   content-visibility: auto;
+  /* approximate single-line message height; only used as the placeholder for lines that have
+     never rendered — once painted, the browser remembers each line's real height instead */
   contain-intrinsic-size: auto 28px;
 }
 

--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -413,7 +413,7 @@ class ChatModule {
     this._messageParser(element, messageObj, fromNode, badgesContainer, messageParts);
   }
 
-  applyUsernameEffect(fromNode, userId) {
+  applyUsernameEffect(element, fromNode, userId) {
     const usernameEffect = subscribers.getUsernameEffect(userId);
     if (usernameEffect == null) {
       return;
@@ -425,6 +425,7 @@ class ChatModule {
     }
 
     fromNode.classList.add(effectClassName);
+    element.classList.add(effects.contained);
   }
 
   _messageParser(element, messageObj, fromNode, badgesContainer, messageParts = []) {
@@ -445,7 +446,7 @@ class ChatModule {
       color = fromNode.style.color;
     }
 
-    this.applyUsernameEffect(fromNode, user.id);
+    this.applyUsernameEffect(element, fromNode, user.id);
 
     if ((globalBots.includes(user.name) || channelBots.includes(user.name)) && user.mod) {
       element

--- a/src/modules/chat/style.css
+++ b/src/modules/chat/style.css
@@ -1,8 +1,3 @@
-.chat-line__message {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 28px;
-}
-
 .bttv-chat-badge {
   width: 18px;
   height: 18px;

--- a/src/modules/chat/style.css
+++ b/src/modules/chat/style.css
@@ -1,3 +1,8 @@
+.chat-line__message {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 28px;
+}
+
 .bttv-chat-badge {
   width: 18px;
   height: 18px;


### PR DESCRIPTION
Adds a `contained` class alongside the effect class in `applyUsernameEffect`, applying `content-visibility: auto` to messages with a username effect so they skip paint entirely while outside the viewport. `contain-intrinsic-size: auto 28px` keeps a placeholder height for never-rendered lines so scrollback geometry stays correct (the `auto` keyword makes the browser reuse each line's real height once it has rendered). Messages without effects are untouched.

Every effect is an infinite `background-position` animation on `background-clip: text`, plus an SVG stroke filter for the textured ones, so each one repaints continuously — including offscreen lines, meaning the cost scales with the entire message buffer rather than the ~20 visible lines. This came out of investigating a user report that effects lag streams as chat builds up.

Full 2×2 matrix measured on a live stream (busy chat, effects spoofed onto ~90% of usernames via a dev shim, identical 645-line buffer for all four runs, 15s rAF sampling per run):

| | fps | p95 frame time |
|---|---|---|
| no rule, no effects | 222 | 4.4 ms |
| no rule, ~450 effects | 97 | 15.9 ms |
| rule, no effects | 188* | 6.9 ms |
| rule, ~450 effects | 215 | 5.9 ms |

Effects alone cost ~56% of frame rate at a saturated buffer; with the rule the same buffer runs within ~3% of a clean chat. Zero dropped video frames in all runs (video decode is unaffected either way — the lag is chat/page rendering).

\* With no effects present the `contained` class is never applied, so this cell exercises identical styles to the top-left cell; the lower reading is wake-up noise from the tab having just been foregrounded (it recorded a 319ms worst frame in its first second), not overhead from the rule.

At realistic effect counts (~130 in a 150-line buffer) the cost is small (~8% fps), so this is headroom for growing Pro adoption rather than a fix for a current regression. Scrollback, scroll anchoring, and the paused-chat flow were checked live and behave normally; visible effects still animate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)