### PR TITLE
fix: highlight and pin messages when 7tv renders chat

### DIFF
--- a/src/modules/chat_highlight_blacklist_keywords/index.js
+++ b/src/modules/chat_highlight_blacklist_keywords/index.js
@@ -241,6 +241,7 @@ class ChatHighlightBlacklistKeywordsModule {
     watcher.on('load.chat', () => this.loadChat());
     watcher.on('load.vod', () => this.loadChat());
     watcher.on('chat.message', (message, messageObj) => this.onMessage(message, messageObj, false));
+    watcher.on('chat.seventv_message', (message, messageObj) => this.onMessage(message, messageObj, false));
     watcher.on('chat.notice_message', (message, messageObj) => this.onMessage(message, messageObj, true));
     watcher.on('vod.message', (message) => this.onVODMessage(message));
     settings.on(`changed.${SettingIds.BLACKLIST_KEYWORDS}`, computeBlacklistKeywords);


### PR DESCRIPTION
When 7TV takes over chat rendering, Twitch''s own `.chat-line__message` nodes never appear, so the highlight/blacklist keywords module (which only listened to `chat.message`) went completely dead — no keyword highlights, no pinned highlights, no highlight sounds, no blacklist hiding. The watcher already observes 7TV chat lines and emits `chat.seventv_message` with a message object of the same shape (`user.userLogin` / `timestamp` / `messageParts`), so this subscribes the module to that event too.

Verified live on a popout chat with a simulated 7TV message flowing through the DOM observer: the 7TV line gets highlighted and pinned, and native Twitch messages continue to pin alongside.

Known limitation: badge keywords still won''t match on 7TV lines, since badge matching queries Twitch''s `.chat-badge` DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)