### PR TITLE
fix(7tv): update for v3 api changes

### DIFF
--- a/src/modules/seventv/channel-emotes.js
+++ b/src/modules/seventv/channel-emotes.js
@@ -43,10 +43,20 @@ class SevenTVChannelEmotes extends AbstractEmotes {
     if (!currentChannel) return;
 
     fetch(
-      `https://7tv.io/v3/users/${encodeURIComponent(currentChannel.provider)}/${encodeURIComponent(currentChannel.id)}`
+      `https://7tv.io/v3/users/${encodeURIComponent(currentChannel.provider)}/${encodeURIComponent(currentChannel.id)}`,
+      {headers: {'X-7tv-Missing-EmoteSet-Aware': '1'}}
     )
       .then((response) => response.json())
-      .then(({emote_set: emoteSet}) => {
+      .then(({emote_set_id: emoteSetId}) => {
+        if (emoteSetId == null) {
+          return null;
+        }
+
+        return fetch(`https://7tv.io/v3/emote-sets/${encodeURIComponent(emoteSetId)}`).then((response) =>
+          response.json()
+        );
+      })
+      .then((emoteSet) => {
         const {emotes} = emoteSet ?? {};
         if (emotes == null) {
           return;


### PR DESCRIPTION
Updates 7TV channel emotes logic to accommodate an upcoming 7TV v3 API change where the `/v3/users/:platform/:platform_id` endpoint will no longer return every emote from the active emote set under `emote_set`.