### PR TITLE
fix: swap reversed whitelist/blacklist labels in raid settings

### DIFF
--- a/src/modules/settings/settings/twitch/Raids.jsx
+++ b/src/modules/settings/settings/twitch/Raids.jsx
@@ -26,8 +26,8 @@ function AutoJoinRaids({ref, ...props}) {
       <SettingTagInput
         name={
           value
-            ? formatMessage({defaultMessage: 'Whitelist Channels'})
-            : formatMessage({defaultMessage: 'Blacklist Channels'})
+            ? formatMessage({defaultMessage: 'Blacklist Channels'})
+            : formatMessage({defaultMessage: 'Whitelist Channels'})
         }
         description={
           value


### PR DESCRIPTION
Fixes #8170

The channel list under **Settings > Raids** is an *exclusion* list relative to the Auto Join toggle, so its label was inverted.

In `auto_join_raids`:

```js
const channels = settingEnabled ? WHITELISTED_CHANNELS : BLACKLISTED_CHANNELS;
let autoJoin = channels.map((c) => c.toLowerCase()).includes(currentChannelName);
if (settingEnabled) {
  autoJoin = !autoJoin;
}
```

- **Auto Join on** — being in the list flips `autoJoin` to `false`, i.e. it *disables* auto joining. That is a blacklist, but it was labeled "Whitelist Channels".
- **Auto Join off** — being in the list sets `autoJoin` to `true`, i.e. it *enables* auto joining. That is a whitelist, but it was labeled "Blacklist Channels".

The accompanying descriptions ("List of channels that disable/enable auto joining raids.") already described the behavior correctly, so only the two names are swapped.

No functional or storage changes — the underlying `autoJoinRaidsWhitelistedChannels` / `autoJoinRaidsBlacklistedChannels` keys are untouched, so existing user lists keep working exactly as before. Both message strings already exist, so no new translations are needed.