### PR TITLE
fix: tolerate invalid stored primaryColor values

### DIFF
--- a/src/modules/accent_color/index.js
+++ b/src/modules/accent_color/index.js
@@ -36,6 +36,16 @@ class AccentColor {
     const themeColor = parseThemeColor({color: value, theme});
     const baseColors = theme.colors[themeColor.color];
 
+    // Legacy Pro accent colors were stored as arbitrary hex values, which have no palette in
+    // theme.colors — treat them like an unset accent rather than crashing.
+    if (baseColors == null) {
+      if (cssVariablesStyle != null) {
+        cssVariablesStyle.remove();
+      }
+
+      return;
+    }
+
     const twitchPurpleColors = {
       '--color-twitch-purple-1': darken(baseColors[9], 0.4),
       '--color-twitch-purple-2': darken(baseColors[9], 0.3),

--- a/src/modules/shadow_dom/ThemeProvider.jsx
+++ b/src/modules/shadow_dom/ThemeProvider.jsx
@@ -220,10 +220,21 @@ const resolver = (theme) => ({
   },
 });
 
-export const mantineVariablesResolver = (theme, primaryColor) => {
-  if (primaryColor != null) {
-    theme.primaryColor = primaryColor;
+// Legacy Pro accent colors were stored as arbitrary hex values (and can still arrive via cloud
+// backup sync), but Mantine only accepts keys of theme.colors as primaryColor — fall back to the
+// default for anything else so an invalid stored value can't crash the UI.
+export function normalizeThemePrimaryColor(primaryColor) {
+  if (primaryColor == null || theme.colors[primaryColor] == null) {
+    return DEFAULT_PRIMARY_COLOR;
   }
+
+  return primaryColor;
+}
+
+export const mantineVariablesResolver = (baseTheme, primaryColor) => {
+  // Copy rather than mutate: baseTheme is the shared module-level theme, and writing an
+  // unvalidated primaryColor to it would poison every other consumer.
+  const theme = {...baseTheme, primaryColor: normalizeThemePrimaryColor(primaryColor ?? baseTheme.primaryColor)};
 
   const {variables: defaultVariables, dark: defaultDark, light: defaultLight} = v8CssVariablesResolver(theme);
   const {variables, dark, light} = resolver(theme);
@@ -248,13 +259,10 @@ function ThemeProvider({children, ...props}) {
     defaultValue: DEFAULT_PRIMARY_COLOR,
   });
 
-  const modifiedTheme = useMemo(() => {
-    if (normalizedPrimaryColor == null) {
-      return {...theme, primaryColor: DEFAULT_PRIMARY_COLOR};
-    }
-
-    return {...theme, primaryColor: normalizedPrimaryColor};
-  }, [normalizedPrimaryColor]);
+  const modifiedTheme = useMemo(
+    () => ({...theme, primaryColor: normalizeThemePrimaryColor(normalizedPrimaryColor)}),
+    [normalizedPrimaryColor]
+  );
 
   return (
     <PortalContext value={portalRef}>


### PR DESCRIPTION
Legacy Pro accent colors were stored as arbitrary hex values (e.g. `#70cfce`), and cloud backup sync can still restore them into settings. Mantine only accepts keys of `theme.colors` as `theme.primaryColor`, so an invalid stored value crashed the UI in two places once auth resolved the user as Pro:

- `MantineProvider` threw `Invalid theme.primaryColor, it accepts only key of theme.colors` when rendering the settings UI
- the accent color module threw `Cannot read properties of undefined (reading '9')` reading `theme.colors[value][9]` on page load

### Fix

- Normalize the stored value against `theme.colors` before it reaches `MantineProvider` or the CSS variables resolver, falling back to `DEFAULT_PRIMARY_COLOR` (whose doc comment already promised a fallback for "unset or invalid" values).
- Treat palette-less colors as an unset accent in the accent color module instead of crashing.
- `mantineVariablesResolver` no longer mutates the shared module-level theme, which would have poisoned every other consumer with the unvalidated value.

### Testing

- Reproduced both crashes on a profile with `primaryColor: "#70cfce"` in `bttv_settings` (restored by cloud backup sync).
- With the fix: no console errors on load, the settings modal renders and navigates normally, and the accent falls back to the default red. Selecting palette colors still works.