### PR TITLE
refactor: move Accessibility settings to the Interface category

### DIFF
--- a/src/modules/settings/settings/global/Accessibility.jsx
+++ b/src/modules/settings/settings/global/Accessibility.jsx
@@ -28,7 +28,7 @@ function Accessibility({ref, ...props}) {
 
 SettingStore.registerSetting(Accessibility, {
   settingPanelId: SettingPanelIds.ACCESSIBILITY,
-  settingCategoryId: SettingCategoryIds.APPEARANCE,
+  settingCategoryId: SettingCategoryIds.INTERFACE,
   name: SETTING_NAME,
   supportsStandaloneWindow: true,
 });


### PR DESCRIPTION
Moves the **Accessibility** panel from the **Appearance** category to **Interface**.

Appearance currently holds Theme, Subscription Badge, and Username Effects — all of which change how BetterTTV *looks*. Reduce Motion is a behavioral preference about how the interface *acts*, so it sits more naturally alongside the other experience-level panels in Interface (Player, Sidebar, Directory, Auto Play, Whispers, YouTube).

Single-line change to the `registerSetting` call — the panel id, storage key (`reducedMotion`), and the panel's own contents are all untouched, so nothing moves for users except which sidebar group the panel appears under.

`SettingCategoryIds.INTERFACE` already exists and has both a label and an icon wired up in `setting-categories.js`, so no new strings or translations are needed.