### PR TITLE
feat: refresh channel emotes on emotes_refresh socket event

### DIFF
--- a/src/modules/emotes/channel-emotes.js
+++ b/src/modules/emotes/channel-emotes.js
@@ -1,3 +1,4 @@
+import {getCachedUser} from '@/actions/users';
 import {EmoteCategories, EmoteProviders} from '@/constants';
 import formatMessage from '@/i18n/index';
 import socketClient, {deserializeSocketChannel, EventNames} from '@/socket-client';
@@ -80,6 +81,26 @@ class ChannelEmotes extends AbstractEmotes {
       );
 
       watcher.emit('emotes.updated');
+    });
+
+    socketClient.on(EventNames.EMOTES_REFRESH, async ({channel}) => {
+      if (!validChannelDestination(channel)) {
+        return;
+      }
+
+      const currentChannel = getCurrentChannel();
+      let data;
+      try {
+        data = await getCachedUser(currentChannel.provider, currentChannel.id);
+      } catch (_) {
+        return;
+      }
+
+      this.updateChannelEmotes(data);
+      watcher.emit(
+        'chat.send_admin_message',
+        formatMessage({defaultMessage: 'BetterTTV Emotes: The channel emotes have been updated'})
+      );
     });
 
     socketClient.on(EventNames.EMOTE_DELETE, ({channel, emoteId}) => {

--- a/src/socket-client.js
+++ b/src/socket-client.js
@@ -18,6 +18,7 @@ export const EventNames = {
   EMOTE_CREATE: 'emote_create',
   EMOTE_DELETE: 'emote_delete',
   EMOTE_UPDATE: 'emote_update',
+  EMOTES_REFRESH: 'emotes_refresh',
   SETTINGS_UPDATE: 'settings_update',
   AUTHENTICATION_UPDATE: 'authentication_update',
   USER_UPDATE: 'user_update',


### PR DESCRIPTION
Adds a `emotes_refresh` socket event handler: on receipt, refetch the channel's cached user data, rebuild the BetterTTV channel emote store, and post one admin chat message ("The channel emotes have been updated").

🤖 Generated with [Claude Code](https://claude.com/claude-code)