### PR TITLE
fix: hide the bits button wrapper so its notification dot goes too

### DIFF
--- a/src/modules/hide_bits/style.css
+++ b/src/modules/hide_bits/style.css
@@ -2,6 +2,8 @@
   .pinned-cheer,
   .pinned-cheer-v2,
   button[data-a-target='bits-button'],
+  /* the button's wrapper goes too, otherwise Twitch's notification dot is left floating */
+  div:has(> div > button[data-a-target='bits-button']),
   div:has(> div > button.tw-interactable > div.channel-leaderboard-header-rotating__users),
   div:has(> div > div > div.channel-leaderboard-header-rotating__users),
   div[data-test-selector='last-x-events'],


### PR DESCRIPTION
The Bits chat feature only hid `button[data-a-target='bits-button']`. Twitch anchors its unseen-bits notification dot to that button's wrapper (`InjectLayout > Layout[position: relative] > button`) as an absolutely positioned element, so hiding the button alone left the dot painted on the chat input's bottom border, floating where the icon used to be.

Hiding the wrapper takes the button and anything anchored to it. `div:has(> div > button[data-a-target='bits-button'])` resolves to exactly one element on both the channel page and popout chat — the bits-only `InjectLayout` wrapper, which contains no other chat-input control. One level higher would swallow the emote picker, so the child combinators are load-bearing. The plain button selector stays as a fallback in case Twitch flattens those wrappers.

### Verification

Live on Twitch (logged in, BTTV loaded), on both popout chat and a channel page:

- The new selector matches exactly one element in each case, and it contains no other chat-input control.
- I could not get Twitch to serve a real unseen-bits dot on my account, so I stood one in: a 6px `#ff75e6` circle absolutely positioned inside the wrapper, sized/coloured/offset from pixel measurements of the reporter's screenshot (6px across, `rgb(255,117,230)`, centred ~3px left of the emote picker's left edge and ~6px below the button row). With master's rule the button disappears and the stand-in dot stays put, exactly reproducing the screenshot; with this rule both disappear, and re-enabling the setting brings both back. The dot itself is therefore simulated, not a live Twitch repro.
- Emote picker, send button, chat settings gear and the input box keep their exact position and size before and after.
- `npm run build` and `prettier --check` are clean.

Fixes #8193