### PR TITLE
fix: stop the autoplay settings leaving stale state on other players

### DIFF
--- a/src/modules/disable_homepage_autoplay/index.js
+++ b/src/modules/disable_homepage_autoplay/index.js
@@ -32,11 +32,12 @@ class DisableHomepageAutoplayModule {
 
     const stopAutoplay = () => {
       setTimeout(() => {
-        if (document.querySelector(FEATURED_VIDEO_SELECTOR) == null) {
-          return;
+        // this listener only removes itself once it fires, so it can outlive the featured video
+        // and end up pausing the player of whatever page was navigated to afterwards
+        if (document.querySelector(FEATURED_VIDEO_SELECTOR) != null) {
+          currentPlayer.pause();
         }
 
-        currentPlayer.pause();
         currentPlayer.setMuted(prevMuted);
       }, 0);
       if (currentPlayer.emitter) {

--- a/src/modules/disable_homepage_autoplay/index.js
+++ b/src/modules/disable_homepage_autoplay/index.js
@@ -32,12 +32,11 @@ class DisableHomepageAutoplayModule {
 
     const stopAutoplay = () => {
       setTimeout(() => {
-        // this listener only removes itself once it fires, so it can outlive the featured video
-        // and end up pausing the player of whatever page was navigated to afterwards
-        if (document.querySelector(FEATURED_VIDEO_SELECTOR) != null) {
-          currentPlayer.pause();
+        if (document.querySelector(FEATURED_VIDEO_SELECTOR) == null) {
+          return;
         }
 
+        currentPlayer.pause();
         currentPlayer.setMuted(prevMuted);
       }, 0);
       if (currentPlayer.emitter) {

--- a/src/modules/disable_offline_channel_autoplay/index.js
+++ b/src/modules/disable_offline_channel_autoplay/index.js
@@ -26,11 +26,12 @@ class DisableOfflineChannelAutoplayModule {
     const stopAutoplay = () => {
       setTimeout(() => {
         // this listener only removes itself once it fires, so it can outlive the offline carousel
-        // and end up pausing the player of a live channel navigated to afterwards
-        if (document.querySelector(CAROUSEL_PLAYER_SELECTOR) != null) {
-          currentPlayer.pause();
+        // and pause the player of a live channel navigated to afterwards
+        if (document.querySelector(CAROUSEL_PLAYER_SELECTOR) == null) {
+          return;
         }
 
+        currentPlayer.pause();
         currentPlayer.setMuted(prevMuted);
       }, 0);
       if (currentPlayer.emitter) {

--- a/src/modules/disable_offline_channel_autoplay/index.js
+++ b/src/modules/disable_offline_channel_autoplay/index.js
@@ -5,6 +5,8 @@ import {loadModuleForPlatforms} from '@/utils/modules';
 import twitch from '@/utils/twitch';
 import watcher from '@/watcher';
 
+const CAROUSEL_PLAYER_SELECTOR = '.video-player[data-a-player-type="channel_home_carousel"]';
+
 class DisableOfflineChannelAutoplayModule {
   constructor() {
     watcher.on('load.player', () => this.load());
@@ -13,7 +15,7 @@ class DisableOfflineChannelAutoplayModule {
   load() {
     if (hasFlag(settings.get(SettingIds.AUTO_PLAY), AutoPlayFlags.OFFLINE_CHANNEL_VIDEO)) return;
     const currentPlayer = twitch.getCurrentPlayer();
-    if (!currentPlayer || document.querySelector('.video-player[data-a-player-type="channel_home_carousel"]') == null) {
+    if (!currentPlayer || document.querySelector(CAROUSEL_PLAYER_SELECTOR) == null) {
       return;
     }
 
@@ -23,7 +25,12 @@ class DisableOfflineChannelAutoplayModule {
 
     const stopAutoplay = () => {
       setTimeout(() => {
-        currentPlayer.pause();
+        // this listener only removes itself once it fires, so it can outlive the offline carousel
+        // and end up pausing the player of a live channel navigated to afterwards
+        if (document.querySelector(CAROUSEL_PLAYER_SELECTOR) != null) {
+          currentPlayer.pause();
+        }
+
         currentPlayer.setMuted(prevMuted);
       }, 0);
       if (currentPlayer.emitter) {

--- a/src/modules/video_player/index.js
+++ b/src/modules/video_player/index.js
@@ -56,14 +56,16 @@ function createPictureInPictureButton(toggled) {
 let removeRecommendationWatcher;
 
 function watchPlayerRecommendationVodsAutoplay() {
-  // this runs on every player load, so drop the previous watcher before arming another one.
-  // otherwise they stack up and re-enabling the setting only removes the most recent one.
-  if (removeRecommendationWatcher != null) {
-    removeRecommendationWatcher();
-    removeRecommendationWatcher = null;
+  if (hasFlag(settings.get(SettingIds.AUTO_PLAY), AutoPlayFlags.VOD_RECOMMENDATION_AUTOPLAY)) {
+    if (removeRecommendationWatcher != null) {
+      removeRecommendationWatcher();
+      removeRecommendationWatcher = null;
+    }
+    return;
   }
 
-  if (hasFlag(settings.get(SettingIds.AUTO_PLAY), AutoPlayFlags.VOD_RECOMMENDATION_AUTOPLAY)) {
+  // this runs on every player load, so only arm the watcher if one isn't registered already
+  if (removeRecommendationWatcher != null) {
     return;
   }
 

--- a/src/modules/video_player/index.js
+++ b/src/modules/video_player/index.js
@@ -56,8 +56,14 @@ function createPictureInPictureButton(toggled) {
 let removeRecommendationWatcher;
 
 function watchPlayerRecommendationVodsAutoplay() {
+  // this runs on every player load, so drop the previous watcher before arming another one.
+  // otherwise they stack up and re-enabling the setting only removes the most recent one.
+  if (removeRecommendationWatcher != null) {
+    removeRecommendationWatcher();
+    removeRecommendationWatcher = null;
+  }
+
   if (hasFlag(settings.get(SettingIds.AUTO_PLAY), AutoPlayFlags.VOD_RECOMMENDATION_AUTOPLAY)) {
-    if (removeRecommendationWatcher) removeRecommendationWatcher();
     return;
   }
 


### PR DESCRIPTION
Fixes #8192

`disable_offline_channel_autoplay` arms a one-shot `Playing` listener that only unregisters itself when it fires, so on an offline page, where the carousel gets paused before it ever plays, the listener often stays attached. Twitch reuses the player instance across the SPA navigation to a live channel, so it fires there instead and pauses the live stream, which is why the report saw it intermittently and why one reload cleared it. It now re-checks the carousel and returns early, the same guard `disable_homepage_autoplay` got in 4d8d01b for #6575. Auditing the other autoplay toggles turned up one more: `watchPlayerRecommendationVodsAutoplay` registers a fresh dom watcher on every `load.player` while the setting is off and keeps only the newest remover, so the callbacks pile up for the life of the tab and re-enabling the setting leaves the older ones clicking cancel until you reload. It now arms one and leaves it alone. Lint, prettier and build are clean, but video would not decode in my test browser, so `Playing` never fired and neither fix is verified end to end. Both toggles want a manual pass before merge.