### PR TITLE
fix: close a stuck tooltip when the pointer moves off its element

### DIFF
--- a/src/modules/tooltip/TooltipController.jsx
+++ b/src/modules/tooltip/TooltipController.jsx
@@ -1,6 +1,6 @@
 import {arrow, autoUpdate, flip, FloatingArrow, offset, shift, useFloating} from '@floating-ui/react';
 import classNames from 'classnames';
-import React, {useLayoutEffect, useRef} from 'react';
+import React, {useEffect, useLayoutEffect, useRef} from 'react';
 import useTooltipStore, {closeTooltip, resetTooltip} from './store';
 import styles from './Tooltip.module.css';
 
@@ -26,6 +26,29 @@ export default function TooltipController() {
   useLayoutEffect(() => {
     resetTooltip();
   }, []);
+
+  // A bound element replaced under a stationary pointer fires no mouseleave, and an identical
+  // replacement shifts no layout, so autoUpdate never ticks and the isConnected check above never
+  // gets to run either. Watch where the pointer actually goes instead.
+  useEffect(() => {
+    if (!open || referenceElement == null) {
+      return undefined;
+    }
+
+    // mouseout is no good here: it fires on the element being left, and a detached one no longer
+    // propagates to document. mouseover fires on the element being entered, which always does.
+    function handleMouseOver(event) {
+      if (referenceElement.contains(event.target)) {
+        return;
+      }
+
+      closeTooltip(referenceElement);
+    }
+
+    document.addEventListener('mouseover', handleMouseOver, true);
+
+    return () => document.removeEventListener('mouseover', handleMouseOver, true);
+  }, [open, referenceElement]);
 
   const {refs, floatingStyles, context} = useFloating({
     open,


### PR DESCRIPTION
A tooltip had only two ways to close: the bound element's own `mouseleave`, and the `reference.isConnected` check inside floating-ui's `autoUpdate`. Neither runs when a bound element is replaced under a stationary pointer, since no `mouseleave` fires for a node the pointer never left and an identical replacement occupies the same box, so nothing scrolls or resizes and `autoUpdate` never ticks — `loadPictureInPicture` does exactly this, `replaceWith`-ing a freshly built button on `enterpictureinpicture`/`leavepictureinpicture` while the pointer still sits on the button that was just clicked, and neither the top nav nor the player controls have a scrollable ancestor to tick it afterwards, so the tooltip stays anchored to a detached node until the page reloads. This adds one listener, bound only while a tooltip is open, that closes it as soon as the pointer is over something outside the reference element (`mouseover` rather than `mouseout`, because `mouseout` fires on the element being left and a detached one no longer propagates to `document`, so the first move away is missed). Verified live on Twitch with a dev build: reproduced the stuck tooltip on the top nav settings button, on a chat emote, and on the PiP button via BTTV's own `enterpictureinpicture` handler — tooltip node still painted at its last rect with a detached reference, surviving both a pointer move and a client-side channel navigation — and confirmed all three clear on the first pointer move with this change, that node removal while hovered is still caught by the existing `isConnected` guard (#8098), and that handing off directly between two bound elements still shows the second tooltip in both directions. Known residue: if the pointer leaves the browser window entirely the tooltip stays until it comes back over the page, which I left alone rather than layering a second listener.

Fixes #8199