### PR TITLE
qol: add user level badges and whole-argument highlighting to command autocomplete

### DIFF
--- a/src/common/components/AutocompleteRow.jsx
+++ b/src/common/components/AutocompleteRow.jsx
@@ -5,6 +5,7 @@ import styles from './AutocompleteRow.module.css';
 
 function AutocompleteRow({
   leading = null,
+  trailing = null,
   title,
   subtitle,
   active,
@@ -34,6 +35,7 @@ function AutocompleteRow({
           </Text>
         ) : null}
       </div>
+      {trailing != null ? <span className={styles.trailing}>{trailing}</span> : null}
     </button>
   );
 }
@@ -43,6 +45,7 @@ export default React.memo(AutocompleteRow, (prev, next) => {
     prev.title === next.title &&
     prev.subtitle === next.subtitle &&
     prev.leading === next.leading &&
+    prev.trailing === next.trailing &&
     prev.selected === next.selected &&
     prev.active === next.active &&
     prev.className === next.className &&

--- a/src/common/components/AutocompleteRow.module.css
+++ b/src/common/components/AutocompleteRow.module.css
@@ -18,6 +18,13 @@
   flex-shrink: 0;
 }
 
+.trailing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
 .textContainer {
   width: 100%;
   min-width: 0;

--- a/src/modules/command_autocomplete/components/CommandRow.jsx
+++ b/src/modules/command_autocomplete/components/CommandRow.jsx
@@ -1,8 +1,11 @@
+import {faCrown, faGem, faShieldHalved, faStar, faUserCheck} from '@fortawesome/free-solid-svg-icons';
 import classNames from 'classnames';
 import React, {useMemo} from 'react';
 import AutocompleteRow from '@/common/components/AutocompleteRow';
+import Icon from '@/common/components/Icon';
 import NightbotLogoIcon from '@/common/components/NightbotLogoIcon';
-import {CommandProviders, CommandAutocompleteArgumentTypes} from '@/constants';
+import {CommandProviders, CommandAutocompleteArgumentTypes, UserLevelHierarchy, UserLevels} from '@/constants';
+import formatMessage from '@/i18n/index';
 import cdn from '@/utils/cdn';
 import styles from './CommandRow.module.css';
 
@@ -11,6 +14,64 @@ const LogoByCommandProvider = {
   [CommandProviders.MOOBOT]: cdn.url('/assets/logos/moobot_logo.png'),
   [CommandProviders.STREAMELEMENTS]: cdn.url('/assets/logos/streamelements_logo.png'),
 };
+
+// UserLevels.EVERYONE is intentionally absent — commands anyone can use don't need a badge.
+const UserLevelBadges = {
+  [UserLevels.SUBSCRIBER]: {
+    icon: faStar,
+    className: styles.subscriberBadge,
+    label: formatMessage({defaultMessage: 'Subscriber'}),
+  },
+  [UserLevels.REGULAR]: {
+    icon: faUserCheck,
+    className: styles.regularBadge,
+    label: formatMessage({defaultMessage: 'Regular'}),
+  },
+  [UserLevels.TWITCH_VIP]: {
+    icon: faGem,
+    className: styles.vipBadge,
+    label: formatMessage({defaultMessage: 'VIP'}),
+  },
+  [UserLevels.MODERATOR]: {
+    icon: faShieldHalved,
+    className: styles.moderatorBadge,
+    label: formatMessage({defaultMessage: 'Moderator'}),
+  },
+  [UserLevels.OWNER]: {
+    icon: faCrown,
+    className: styles.ownerBadge,
+    label: formatMessage({defaultMessage: 'Broadcaster'}),
+  },
+};
+
+// Fossabot emits a separate broadcaster role alongside its owner role.
+const UserLevelAliases = {broadcaster: UserLevels.OWNER};
+
+// A command's userLevel is either a minimum level (string) or a set of levels that may use it
+// (array). Reduce both to the lowest level in the hierarchy so the badge reads as "the lowest
+// level that can use this command"; unknown levels are skipped.
+function getMinimumUserLevel(userLevel) {
+  const levels = Array.isArray(userLevel) ? userLevel : [userLevel];
+
+  let minimumLevel = null;
+  for (const level of levels) {
+    if (typeof level !== 'string') {
+      continue;
+    }
+
+    const normalizedLevel = level.toLowerCase();
+    const resolvedLevel = UserLevelAliases[normalizedLevel] ?? normalizedLevel;
+    if (UserLevelHierarchy[resolvedLevel] == null) {
+      continue;
+    }
+
+    if (minimumLevel == null || UserLevelHierarchy[resolvedLevel] < UserLevelHierarchy[minimumLevel]) {
+      minimumLevel = resolvedLevel;
+    }
+  }
+
+  return minimumLevel;
+}
 
 function CommandRow({item, active, selected, focusedWordIndex, onMouseOver, onClick}) {
   const leadingElement = useMemo(() => {
@@ -26,15 +87,27 @@ function CommandRow({item, active, selected, focusedWordIndex, onMouseOver, onCl
     return null;
   }, [item.provider]);
 
-  // Combine the command name and its argument placeholders into a single string,
-  // then split on whitespace so the word positions line up with the caret's
-  // focusedWordIndex (which is measured against the chat input the same way).
-  // This handles multi-word command names like "!commands add" — each word is
-  // highlighted only while the caret sits on it.
+  const trailingElement = useMemo(() => {
+    const badge = UserLevelBadges[getMinimumUserLevel(item.userLevel)];
+    if (badge == null) {
+      return null;
+    }
+
+    return (
+      <span title={badge.label} aria-label={badge.label} className={styles.userLevelBadge}>
+        <Icon icon={badge.icon} size={14} className={badge.className} />
+      </span>
+    );
+  }, [item.userLevel]);
+
+  // Combine the command name and its argument placeholders into a word list where the positions
+  // line up with the caret's focusedWordIndex (which is measured against whitespace-delimited
+  // words in the chat input). The name splits into one word per typed word (multi-word names like
+  // "!commands add" occupy one slot each), but each argument placeholder stays a single unit even
+  // when its display name contains spaces ("[game name]") — the user fills it at one word position.
   const titleWords = useMemo(() => {
-    const argumentText = item.arguments.map((argument) => `[${argument.name.toLowerCase()}]`).join(' ');
-    const fullText = argumentText.length > 0 ? `${item.name} ${argumentText}` : item.name;
-    return fullText.split(/\s+/);
+    const argumentWords = item.arguments.map((argument) => `[${argument.name.toLowerCase()}]`);
+    return [...item.name.split(/\s+/), ...argumentWords];
   }, [item.name, item.arguments]);
 
   // A phrase argument soaks up the rest of the message, so it's always the last
@@ -68,6 +141,7 @@ function CommandRow({item, active, selected, focusedWordIndex, onMouseOver, onCl
   return (
     <AutocompleteRow
       leading={leadingElement}
+      trailing={trailingElement}
       title={title}
       active={active}
       selected={selected}

--- a/src/modules/command_autocomplete/components/CommandRow.jsx
+++ b/src/modules/command_autocomplete/components/CommandRow.jsx
@@ -1,11 +1,12 @@
-import {faCrown, faGem, faShieldHalved, faStar, faUserCheck} from '@fortawesome/free-solid-svg-icons';
+import {faGem, faShieldHalved, faStar, faUserCheck, faVideo} from '@fortawesome/free-solid-svg-icons';
 import classNames from 'classnames';
 import React, {useMemo} from 'react';
 import AutocompleteRow from '@/common/components/AutocompleteRow';
 import Icon from '@/common/components/Icon';
 import NightbotLogoIcon from '@/common/components/NightbotLogoIcon';
-import {CommandProviders, CommandAutocompleteArgumentTypes, UserLevelHierarchy, UserLevels} from '@/constants';
+import {CommandProviders, CommandAutocompleteArgumentTypes, UserLevels} from '@/constants';
 import formatMessage from '@/i18n/index';
+import {getMinimumUserLevel} from '@/modules/command_autocomplete/utils';
 import cdn from '@/utils/cdn';
 import styles from './CommandRow.module.css';
 
@@ -38,40 +39,11 @@ const UserLevelBadges = {
     label: formatMessage({defaultMessage: 'Moderator'}),
   },
   [UserLevels.OWNER]: {
-    icon: faCrown,
+    icon: faVideo,
     className: styles.ownerBadge,
     label: formatMessage({defaultMessage: 'Broadcaster'}),
   },
 };
-
-// Fossabot emits a separate broadcaster role alongside its owner role.
-const UserLevelAliases = {broadcaster: UserLevels.OWNER};
-
-// A command's userLevel is either a minimum level (string) or a set of levels that may use it
-// (array). Reduce both to the lowest level in the hierarchy so the badge reads as "the lowest
-// level that can use this command"; unknown levels are skipped.
-function getMinimumUserLevel(userLevel) {
-  const levels = Array.isArray(userLevel) ? userLevel : [userLevel];
-
-  let minimumLevel = null;
-  for (const level of levels) {
-    if (typeof level !== 'string') {
-      continue;
-    }
-
-    const normalizedLevel = level.toLowerCase();
-    const resolvedLevel = UserLevelAliases[normalizedLevel] ?? normalizedLevel;
-    if (UserLevelHierarchy[resolvedLevel] == null) {
-      continue;
-    }
-
-    if (minimumLevel == null || UserLevelHierarchy[resolvedLevel] < UserLevelHierarchy[minimumLevel]) {
-      minimumLevel = resolvedLevel;
-    }
-  }
-
-  return minimumLevel;
-}
 
 function CommandRow({item, active, selected, focusedWordIndex, onMouseOver, onClick}) {
   const leadingElement = useMemo(() => {
@@ -94,8 +66,8 @@ function CommandRow({item, active, selected, focusedWordIndex, onMouseOver, onCl
     }
 
     return (
-      <span title={badge.label} aria-label={badge.label} className={styles.userLevelBadge}>
-        <Icon icon={badge.icon} size={14} className={badge.className} />
+      <span title={badge.label} aria-label={badge.label} className={classNames(styles.userLevelBadge, badge.className)}>
+        <Icon icon={badge.icon} size={12} />
       </span>
     );
   }, [item.userLevel]);

--- a/src/modules/command_autocomplete/components/CommandRow.module.css
+++ b/src/modules/command_autocomplete/components/CommandRow.module.css
@@ -21,27 +21,38 @@
 .userLevelBadge {
   display: flex;
   align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--mantine-radius-md);
 }
 
-/* Badge colors follow Twitch's chat badges for the closest equivalent role. */
+/* Badge colors follow Twitch's chat badges for the closest equivalent role, in the same
+ * dark-container/light-icon treatment as the Nightbot logo above. */
 .subscriberBadge {
-  color: var(--mantine-color-violet-5);
+  background-color: var(--mantine-color-violet-7);
+  color: var(--mantine-color-violet-1);
 }
 
 .regularBadge {
-  color: var(--mantine-color-blue-5);
+  background-color: var(--mantine-color-blue-7);
+  color: var(--mantine-color-blue-1);
 }
 
 .vipBadge {
-  color: var(--mantine-color-pink-5);
+  background-color: var(--mantine-color-pink-7);
+  color: var(--mantine-color-pink-1);
 }
 
 .moderatorBadge {
-  color: var(--mantine-color-green-5);
+  background-color: var(--mantine-color-green-7);
+  color: var(--mantine-color-green-1);
 }
 
 .ownerBadge {
-  color: var(--mantine-color-red-5);
+  background-color: var(--mantine-color-red-7);
+  color: var(--mantine-color-red-1);
 }
 
 /* Every word is dimmed except the one the caret is currently on. The dimmed

--- a/src/modules/command_autocomplete/components/CommandRow.module.css
+++ b/src/modules/command_autocomplete/components/CommandRow.module.css
@@ -18,6 +18,32 @@
   object-fit: cover;
 }
 
+.userLevelBadge {
+  display: flex;
+  align-items: center;
+}
+
+/* Badge colors follow Twitch's chat badges for the closest equivalent role. */
+.subscriberBadge {
+  color: var(--mantine-color-violet-5);
+}
+
+.regularBadge {
+  color: var(--mantine-color-blue-5);
+}
+
+.vipBadge {
+  color: var(--mantine-color-pink-5);
+}
+
+.moderatorBadge {
+  color: var(--mantine-color-green-5);
+}
+
+.ownerBadge {
+  color: var(--mantine-color-red-5);
+}
+
 /* Every word is dimmed except the one the caret is currently on. The dimmed
  * (normal-weight) words carry a touch of letter-spacing so they take up roughly
  * the same width as their bold form; the focused word drops the spacing back to

--- a/src/modules/command_autocomplete/twitch/Autocomplete.jsx
+++ b/src/modules/command_autocomplete/twitch/Autocomplete.jsx
@@ -12,6 +12,7 @@ import {
   CommandAutocompleteArgumentTypes,
 } from '@/constants';
 import CommandRow from '@/modules/command_autocomplete/components/CommandRow';
+import {getMinimumUserLevel} from '@/modules/command_autocomplete/utils';
 import shadowDom from '@/modules/shadow_dom/index';
 import domObserver from '@/observers/dom';
 import settings from '@/settings';
@@ -314,18 +315,16 @@ class CommandAutocomplete {
         return false;
       }
 
-      let isEligible = false;
-
-      const currentUserLevelValue = UserLevelHierarchy[currentUserLevel];
-
-      if (Array.isArray(command.userLevel)) {
-        isEligible = command.userLevel.includes(currentUserLevel);
-      } else {
-        const commandUserLevelValue = UserLevelHierarchy[command.userLevel.toLowerCase()];
-        isEligible = commandUserLevelValue <= currentUserLevelValue;
+      // A command's user level is a floor: everyone at or above the lowest granted level can
+      // use it. Array user levels (Fossabot) previously required exact membership, which hid
+      // commands from higher levels — most visibly broadcaster-only commands, since Fossabot's
+      // 'broadcaster' isn't a UserLevels value and so never matched the owner.
+      const minimumUserLevel = getMinimumUserLevel(command.userLevel);
+      if (minimumUserLevel == null) {
+        return false;
       }
 
-      return isEligible;
+      return UserLevelHierarchy[minimumUserLevel] <= UserLevelHierarchy[currentUserLevel];
     });
 
     sortedCommandIndex = filteredSuggestions.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/modules/command_autocomplete/utils.js
+++ b/src/modules/command_autocomplete/utils.js
@@ -1,0 +1,30 @@
+import {UserLevelHierarchy, UserLevels} from '@/constants';
+
+// Fossabot emits a separate broadcaster role alongside its owner role.
+const UserLevelAliases = {broadcaster: UserLevels.OWNER};
+
+// A command's userLevel is either a minimum level (string) or the set of levels its bot grants
+// it to (array). Reduce both to the lowest level in the hierarchy — "the lowest level that can
+// use this command" — skipping unknown levels. Returns null when no known level remains.
+export function getMinimumUserLevel(userLevel) {
+  const levels = Array.isArray(userLevel) ? userLevel : [userLevel];
+
+  let minimumLevel = null;
+  for (const level of levels) {
+    if (typeof level !== 'string') {
+      continue;
+    }
+
+    const normalizedLevel = level.toLowerCase();
+    const resolvedLevel = UserLevelAliases[normalizedLevel] ?? normalizedLevel;
+    if (UserLevelHierarchy[resolvedLevel] == null) {
+      continue;
+    }
+
+    if (minimumLevel == null || UserLevelHierarchy[resolvedLevel] < UserLevelHierarchy[minimumLevel]) {
+      minimumLevel = resolvedLevel;
+    }
+  }
+
+  return minimumLevel;
+}

--- a/src/modules/command_autocomplete/youtube/Autocomplete.jsx
+++ b/src/modules/command_autocomplete/youtube/Autocomplete.jsx
@@ -9,6 +9,7 @@ import {
   CommandAutocompleteArgumentTypes,
 } from '@/constants';
 import CommandRow from '@/modules/command_autocomplete/components/CommandRow';
+import {getMinimumUserLevel} from '@/modules/command_autocomplete/utils';
 import shadowDom from '@/modules/shadow_dom/index';
 import domObserver from '@/observers/dom';
 import settings from '@/settings';
@@ -231,11 +232,7 @@ class CommandAutocomplete {
 
       // TODO: determine youtube current user level
 
-      if (Array.isArray(command.userLevel)) {
-        return command.userLevel.includes(UserLevels.EVERYONE);
-      }
-
-      return command.userLevel === UserLevels.EVERYONE;
+      return getMinimumUserLevel(command.userLevel) === UserLevels.EVERYONE;
     });
 
     sortedCommandIndex = filteredSuggestions.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
**Whole-argument highlighting.** `getFocusedWordIndex` counts whitespace-delimited words in the chat input, where each argument occupies one word slot. `CommandRow` however built its display string by joining the command name and bracketed placeholders and splitting the whole thing on whitespace, so a placeholder with a space in its name (`[game name]`, `[duration (seconds)]`) became several display "words". The caret's word index then only ever lined up with the placeholder's first chunk — typing `!game ` highlighted `[game` and left `name]` dimmed. The word list is now built as name words + one entry per argument, so each placeholder highlights as a single unit and stays aligned with the caret across multiple arguments.

**User level badges.** Each row now shows a FontAwesome icon on the right for the command's user level (everyone is implied and shows nothing): star (subscriber), user-check (regular), gem (VIP), shield (moderator), crown (broadcaster), colored with the matching mantine `*-5` color following Twitch's chat badge colors. Array user levels (Fossabot) reduce to the lowest level in the hierarchy — "the lowest level that can use this" — and Fossabot's separate `broadcaster` role maps onto owner. `AutocompleteRow` gains an optional `trailing` slot mirroring `leading`.

**Verified live** (dev build in LIRIK's chat, user level patched locally to moderator so elevated commands surface): `!commercial [duration (seconds)] [silent (true|false)]` highlights each placeholder whole as the caret moves through the arguments; shield renders for string `moderator` and `['moderator','broadcaster']` commands, gem for `['twitch_vip','moderator']`, and everyone-level rows show no badge. Crown/star/user-check tiers had no live data in reachable channels — they share the same data-driven path as the verified badges.

Noticed while testing, out of scope here: the eligibility filter checks array user levels with `includes(currentUserLevel)` exactly, so Fossabot commands granting only `broadcaster` never surface for the actual broadcaster (`owner` != `broadcaster`), and `['twitch_vip','moderator']` commands don't surface for the owner either.