### PR TITLE
qol: remove new badges from settings and retire promotions

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -225,6 +225,13 @@ export const EmoteMenuTips = {
   EMOTE_MENU_CUSTOMIZE_ACCENT_COLOR: 'emoteMenuTipClosedCustomizeAccentColor',
 };
 
+export const SettingsPromotions = {
+  // USERNAME_EFFECT: 'settingsPromotionDismissedUsernameEffect',
+  // CHATBOT_COMMAND_AUTOCOMPLETE: 'settingsPromotionDismissedChatbotCommandAutocomplete',
+  // SELF_BOT: 'settingsPromotionDismissedSelfBot',
+  // SUBSCRIPTION_BADGE: 'settingsPromotionDismissedSubscriptionBadge',
+};
+
 export const SettingsPrompts = {
   SIGN_IN: 'settingsSignInPromptSeen',
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -225,13 +225,6 @@ export const EmoteMenuTips = {
   EMOTE_MENU_CUSTOMIZE_ACCENT_COLOR: 'emoteMenuTipClosedCustomizeAccentColor',
 };
 
-export const SettingsPromotions = {
-  USERNAME_EFFECT: 'settingsPromotionDismissedUsernameEffect',
-  CHATBOT_COMMAND_AUTOCOMPLETE: 'settingsPromotionDismissedChatbotCommandAutocomplete',
-  SELF_BOT: 'settingsPromotionDismissedSelfBot',
-  SUBSCRIPTION_BADGE: 'settingsPromotionDismissedSubscriptionBadge',
-};
-
 export const SettingsPrompts = {
   SIGN_IN: 'settingsSignInPromptSeen',
 };

--- a/src/modules/settings/components/SettingUsernameEffect.jsx
+++ b/src/modules/settings/components/SettingUsernameEffect.jsx
@@ -195,7 +195,6 @@ function SettingUsernameEffect() {
         reverse
         name={formatMessage({defaultMessage: 'Username effect'})}
         description={formatMessage({defaultMessage: 'Choose how your username is styled in chat.'})}
-        showNewBadge
         showProBadge
       />
       <div className={styles.cards}>

--- a/src/modules/settings/components/SubscriptionBadgeSetting.jsx
+++ b/src/modules/settings/components/SubscriptionBadgeSetting.jsx
@@ -181,7 +181,6 @@ function SubscriptionBadgeSetting() {
         <SettingWrapper
           reverse
           showProBadge
-          showNewBadge
           name={formatMessage({defaultMessage: 'Subscriber Badge'})}
           description={formatMessage({
             defaultMessage: 'Show a BetterTTV Pro badge next to your name when you type in chat.',
@@ -190,7 +189,6 @@ function SubscriptionBadgeSetting() {
       ) : (
         <SettingSwitch
           showProBadge
-          showNewBadge
           name={formatMessage({defaultMessage: 'Subscriber Badge'})}
           description={formatMessage({
             defaultMessage: 'Show a BetterTTV Pro badge next to your name when you type in chat.',

--- a/src/modules/settings/pages/UserSettings.jsx
+++ b/src/modules/settings/pages/UserSettings.jsx
@@ -61,7 +61,6 @@ function CloudBackupSetting() {
   return (
     <SettingSwitch
       showProBadge
-      showNewBadge
       name={formatMessage({defaultMessage: 'Cloud Backup'})}
       description={formatMessage({defaultMessage: 'Backup your settings to the cloud.'})}
       value={normalizedCloudBackupSettings.enabled}

--- a/src/modules/settings/settings/global/ChatBots.jsx
+++ b/src/modules/settings/settings/global/ChatBots.jsx
@@ -5,13 +5,11 @@ import {SettingIds} from '@/constants';
 import formatMessage from '@/i18n/index';
 import SettingGroup from '@/modules/settings/components/SettingGroup';
 import SettingSwitch from '@/modules/settings/components/SettingSwitch';
-import {useHasPromotion} from '@/modules/settings/stores/promotion-store';
 import SettingStore, {SettingCategoryIds, SettingPanelIds} from '@/modules/settings/stores/setting-store';
 
 const SETTING_NAME = formatMessage({defaultMessage: 'Chat Bots'});
 
 function ChatBots({ref, ...props}) {
-  const hasPromotion = useHasPromotion(SettingPanelIds.CHATBOTS);
   const [value, setValue] = useStorageState(SettingIds.CHATBOT_COMMAND_AUTOCOMPLETE);
   const [normalizedValue, setNormalizedValue] = useProRequiredState({
     value,
@@ -25,7 +23,6 @@ function ChatBots({ref, ...props}) {
         ref={ref}
         {...props}
         showProBadge
-        showNewBadge={hasPromotion}
         name={formatMessage({defaultMessage: 'Command Autocomplete'})}
         value={normalizedValue}
         onChange={setNormalizedValue}

--- a/src/modules/settings/settings/twitch/SelfBot.jsx
+++ b/src/modules/settings/settings/twitch/SelfBot.jsx
@@ -61,7 +61,6 @@ function SelfBot({ref, ...props}) {
       <SettingSwitch
         name={formatMessage({defaultMessage: 'Self Bot'})}
         description={formatMessage({defaultMessage: 'Automatically send and reply to messages on your own channel.'})}
-        showNewBadge
         value={displayEnabled}
         onChange={handleEnabledChange}
       />

--- a/src/modules/settings/stores/promotion-store.js
+++ b/src/modules/settings/stores/promotion-store.js
@@ -1,29 +1,11 @@
 import {useState} from 'react';
-import {SettingsPromotions} from '@/constants';
-import {SettingPanelIds} from '@/modules/settings/stores/setting-store';
 import storage from '@/storage';
 import SafeEventEmitter from '@/utils/safe-event-emitter';
 
 // A promotion marks its setting panel with a dot in the settings navigation until the user scrolls
-// the panel into view.
-const PROMOTION_SLOTS = [
-  {
-    storageKey: SettingsPromotions.CHATBOT_COMMAND_AUTOCOMPLETE,
-    settingPanelId: SettingPanelIds.CHATBOTS,
-  },
-  {
-    storageKey: SettingsPromotions.SELF_BOT,
-    settingPanelId: SettingPanelIds.SELF_BOT,
-  },
-  {
-    storageKey: SettingsPromotions.USERNAME_EFFECT,
-    settingPanelId: SettingPanelIds.USERNAME_EFFECT,
-  },
-  {
-    storageKey: SettingsPromotions.SUBSCRIPTION_BADGE,
-    settingPanelId: SettingPanelIds.SUBSCRIPTION_BADGE,
-  },
-];
+// the panel into view. Each slot is {storageKey: SettingsPromotions..., settingPanelId: SettingPanelIds...};
+// empty when nothing is currently promoted.
+const PROMOTION_SLOTS = [];
 
 function isPromotionSlotSeen(storageKey) {
   return storage.get(storageKey) === true;


### PR DESCRIPTION
Removes the "New" badge from the five settings still carrying one: Subscriber Badge, Username effect, Command Autocomplete, Cloud Backup, and Self Bot.

The badge came from two places: a hardcoded `showNewBadge` on four of the settings, and the promotion store for Command Autocomplete (`useHasPromotion`). Since every current promotion slot corresponds to a setting losing its badge, this also retires all four `PROMOTION_SLOTS` (the red dots in the settings navigation and on the top-nav button) and their now-unused `SettingsPromotions` storage keys — the same retirement pattern as the theme promotion in #8140. The promotion machinery itself stays for the next launch.

Verified live on Twitch popout chat with the dev build: Subscriber Badge, Username effect, and Self Bot now show only their Pro badges (Timers keeps Coming Soon), and the settings navigation has no promotion dots. An A/B against a pre-change build confirmed the New badges and the Bots nav dot are present there and gone here. Command Autocomplete and Cloud Backup weren't directly screenshotted (their panels are awkward to reach in a small popout window); Command Autocomplete's badge was promotion-driven, so the emptied slots alone remove it, and Cloud Backup is the same one-line prop removal as the verified settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)