### PR TITLE
qol: mention polls and predictions in community highlights description

### DIFF
--- a/src/modules/settings/settings/twitch/ChatFeatures.jsx
+++ b/src/modules/settings/settings/twitch/ChatFeatures.jsx
@@ -50,7 +50,8 @@ function ChatFeatures({ref, ...props}) {
         value={ChatFlags.COMMUNITY_HIGHLIGHTS}
         name={formatMessage({defaultMessage: 'Community Highlights'})}
         description={formatMessage({
-          defaultMessage: 'Show alerts above chat window for hype trains, drops, pinned messages, etc.',
+          defaultMessage:
+            'Show alerts above chat window for hype trains, polls, predictions, drops, pinned messages, etc.',
         })}
       />
       <SettingCheckbox


### PR DESCRIPTION
Ref #8185

Disabling Community Highlights hides Twitch's entire highlight stack above chat — polls and predictions included — but the setting's description only listed hype trains, drops, and pinned messages, so users read hidden polls as a bug.

Copy-only change; the new string picks up translations through the normal sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)