### PR TITLE
qol: keep subscription badge cards a fixed width

### DIFF
--- a/src/modules/settings/components/SettingRadioCardGroup.jsx
+++ b/src/modules/settings/components/SettingRadioCardGroup.jsx
@@ -3,10 +3,16 @@ import classNames from 'classnames';
 import React from 'react';
 import styles from './SettingRadioCardGroup.module.css';
 
-function SettingRadioCardGroup({value, onChange, capAtFourPerRow = false, children}) {
+function SettingRadioCardGroup({value, onChange, capAtFourPerRow = false, fixedCardWidth = false, children}) {
   return (
     <RadioGroup className={styles.radioGroup} value={value} onChange={onChange}>
-      <div className={classNames(styles.radioCards, {[styles.radioCardsCapped]: capAtFourPerRow})}>{children}</div>
+      <div
+        className={classNames(styles.radioCards, {
+          [styles.radioCardsCapped]: capAtFourPerRow,
+          [styles.radioCardsFixedWidth]: fixedCardWidth,
+        })}>
+        {children}
+      </div>
     </RadioGroup>
   );
 }

--- a/src/modules/settings/components/SettingRadioCardGroup.module.css
+++ b/src/modules/settings/components/SettingRadioCardGroup.module.css
@@ -12,3 +12,8 @@
 .radioCardsCapped {
   grid-template-columns: repeat(auto-fit, minmax(max(80px, (100% - 30px) / 4), 1fr));
 }
+
+/* Fixed width: auto-fill keeps empty tracks, so a handful of cards stay the width they'd have in a full grid instead of stretching to fill the row. */
+.radioCardsFixedWidth {
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+}

--- a/src/modules/settings/components/SubscriptionBadgeSetting.jsx
+++ b/src/modules/settings/components/SubscriptionBadgeSetting.jsx
@@ -198,7 +198,10 @@ function SubscriptionBadgeSetting() {
         />
       )}
       {isPro && eligibleBadges != null && eligibleBadges.length > 0 ? (
-        <SettingRadioCardGroup value={!badgeEnabled ? DISABLED : selectedBadgeId} onChange={handleBadgeChange}>
+        <SettingRadioCardGroup
+          value={!badgeEnabled ? DISABLED : selectedBadgeId}
+          onChange={handleBadgeChange}
+          fixedCardWidth>
           <SettingRadioCard
             value={DISABLED}
             className={styles.badgeCard}


### PR DESCRIPTION
The subscription badge grid used `repeat(auto-fit, minmax(80px, 1fr))`. With `auto-fit`, empty tracks collapse, so when only a few badges are unlocked the disable / reset / badge cards stretch to fill the whole row. Once enough badges are unlocked to fill the grid, the cards sit at their natural width.

This switches the badge grid to `auto-fill` via a new `fixedCardWidth` prop on `SettingRadioCardGroup`. `auto-fill` keeps the empty tracks, so a handful of cards stay the same width they'd have in a full grid instead of stretching.

Scoped to a prop rather than flipping the shared grid, because the same group also backs the primary-color radio, whose fixed 6-swatch palette is meant to fill the row.

**Verification:** eslint / prettier / build all clean. Confirmed the grid behavior with an isolated `auto-fit` vs `auto-fill` demo. Not reproduced live, since the sparse-badge state can't be forced from outside the settings shadow root.